### PR TITLE
Enhance EntrySelector popup styling with glassmorphism effects

### DIFF
--- a/libs/frontend/packages/sdk/src/Component/Layout/EntrySelector.tsx
+++ b/libs/frontend/packages/sdk/src/Component/Layout/EntrySelector.tsx
@@ -403,7 +403,22 @@ export const EntrySelector = ({
             onClose={handleClose}
             anchorOrigin={{vertical: 'bottom', horizontal: 'left'}}
             transformOrigin={{vertical: 'top', horizontal: 'left'}}
-            slotProps={{paper: {sx: {width: 520, maxHeight: 440, mt: 0.5, borderRadius: 1.5}}}}
+            slotProps={{
+                paper: {
+                    sx: {
+                        width: 520,
+                        maxHeight: 440,
+                        mt: 0.5,
+                        borderRadius: 1.5,
+                        border: 1,
+                        borderColor: 'divider',
+                        boxShadow: '0 8px 32px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.08)',
+                        backdropFilter: 'blur(12px)',
+                        backgroundColor: (t) =>
+                            t.palette.mode === 'dark' ? 'rgba(30, 41, 59, 0.92)' : 'rgba(255, 255, 255, 0.92)',
+                    },
+                },
+            }}
         >
             <FilterRow>
                 <FilterInput


### PR DESCRIPTION
## Summary
Enhanced the visual appearance of the EntrySelector popup menu by adding modern glassmorphism styling effects, including a border, refined shadow, and a frosted glass background with backdrop blur.

## Key Changes
- Added a subtle border with the theme's divider color to define the popup edges
- Implemented layered box shadows for improved depth perception (8px blur for ambient shadow, 2px blur for direct shadow)
- Applied a 12px backdrop blur filter to create a frosted glass effect
- Added semi-transparent background color that adapts to the theme mode:
  - Dark mode: `rgba(30, 41, 59, 0.92)` (slate-900 with 92% opacity)
  - Light mode: `rgba(255, 255, 255, 0.92)` (white with 92% opacity)

## Implementation Details
- Refactored the inline `slotProps` object for better readability by expanding it across multiple lines
- Maintained all existing styling properties (width: 520px, maxHeight: 440px, borderRadius: 1.5)
- Used theme-aware styling with a callback function to ensure the background color respects the current theme mode

https://claude.ai/code/session_01D8ZqcCjyZfrBy6ktqiePpq