### PR TITLE
Improve Yii2 adapter test coverage from 57% to 91%

### DIFF
--- a/libs/Adapter/Yii2/tests/Unit/Controller/DebugQueryControllerTest.php
+++ b/libs/Adapter/Yii2/tests/Unit/Controller/DebugQueryControllerTest.php
@@ -140,6 +140,102 @@ final class DebugQueryControllerTest extends TestCase
         $this->assertSame('list', $controller->defaultAction);
     }
 
+    public function testListWithJsonOutput(): void
+    {
+        $repository = $this->createMock(CollectorRepositoryInterface::class);
+        $repository
+            ->method('getSummary')
+            ->willReturn([
+                ['id' => 'abc-123', 'request' => ['method' => 'GET', 'url' => '/test', 'responseStatusCode' => '200']],
+            ]);
+
+        $controller = $this->createController($repository);
+        $result = $controller->actionList(json: true);
+
+        $this->assertSame(ExitCode::OK, $result);
+    }
+
+    public function testViewWithJsonOutput(): void
+    {
+        $data = [
+            'AppDevPanel\\Kernel\\Collector\\LogCollector' => ['entries' => ['log1']],
+        ];
+        $repository = $this->createMock(CollectorRepositoryInterface::class);
+        $repository->method('getDetail')->with('abc-123')->willReturn($data);
+
+        $controller = $this->createController($repository);
+        $result = $controller->actionView('abc-123', json: true);
+
+        $this->assertSame(ExitCode::OK, $result);
+    }
+
+    public function testViewCollectorWithJsonOutput(): void
+    {
+        $collectorClass = 'AppDevPanel\\Kernel\\Collector\\LogCollector';
+        $data = [
+            $collectorClass => ['entries' => ['log1']],
+        ];
+        $repository = $this->createMock(CollectorRepositoryInterface::class);
+        $repository->method('getDetail')->willReturn($data);
+
+        $controller = $this->createController($repository);
+        $result = $controller->actionView('abc-123', collector: $collectorClass, json: true);
+
+        $this->assertSame(ExitCode::OK, $result);
+    }
+
+    public function testViewFullEntryWithMultipleCollectors(): void
+    {
+        $data = [
+            'AppDevPanel\\Kernel\\Collector\\LogCollector' => ['entries' => ['log1']],
+            'AppDevPanel\\Kernel\\Collector\\ExceptionCollector' => [],
+        ];
+        $repository = $this->createMock(CollectorRepositoryInterface::class);
+        $repository->method('getDetail')->willReturn($data);
+
+        $controller = $this->createController($repository);
+        $result = $controller->actionView('abc-123');
+
+        $this->assertSame(ExitCode::OK, $result);
+    }
+
+    public function testListWithEntriesContainingCollectorInfo(): void
+    {
+        $repository = $this->createMock(CollectorRepositoryInterface::class);
+        $repository
+            ->method('getSummary')
+            ->willReturn([
+                [
+                    'id' => 'entry-1',
+                    'request' => ['method' => 'POST', 'url' => '/api/data', 'responseStatusCode' => '201'],
+                    'logger' => ['total' => 5],
+                    'event' => ['total' => 12],
+                    'exception' => ['class' => 'RuntimeException'],
+                ],
+            ]);
+
+        $controller = $this->createController($repository);
+        $result = $controller->actionList();
+
+        $this->assertSame(ExitCode::OK, $result);
+    }
+
+    public function testListWithNonArrayEntries(): void
+    {
+        $repository = $this->createMock(CollectorRepositoryInterface::class);
+        $repository
+            ->method('getSummary')
+            ->willReturn([
+                'not-an-array',
+                ['id' => 'valid'],
+            ]);
+
+        $controller = $this->createController($repository);
+        $result = $controller->actionList();
+
+        $this->assertSame(ExitCode::OK, $result);
+    }
+
     private function createController(CollectorRepositoryInterface $repository): DebugQueryController
     {
         return new DebugQueryController('debug-query', \Yii::$app, $repository);

--- a/libs/Adapter/Yii2/tests/Unit/Inspector/NullSchemaProviderTest.php
+++ b/libs/Adapter/Yii2/tests/Unit/Inspector/NullSchemaProviderTest.php
@@ -36,4 +36,32 @@ final class NullSchemaProviderTest extends TestCase
 
         $this->assertSame('orders', $result['name']);
     }
+
+    public function testExecuteQueryReturnsEmptyArray(): void
+    {
+        $provider = new NullSchemaProvider();
+
+        $this->assertSame([], $provider->executeQuery('SELECT * FROM users'));
+    }
+
+    public function testExecuteQueryWithParamsReturnsEmptyArray(): void
+    {
+        $provider = new NullSchemaProvider();
+
+        $this->assertSame([], $provider->executeQuery('SELECT * FROM users WHERE id = ?', [1]));
+    }
+
+    public function testExplainQueryReturnsEmptyArray(): void
+    {
+        $provider = new NullSchemaProvider();
+
+        $this->assertSame([], $provider->explainQuery('SELECT * FROM users'));
+    }
+
+    public function testExplainQueryWithAnalyzeReturnsEmptyArray(): void
+    {
+        $provider = new NullSchemaProvider();
+
+        $this->assertSame([], $provider->explainQuery('SELECT * FROM users', [], true));
+    }
 }

--- a/libs/Adapter/Yii2/tests/Unit/Inspector/Yii2ConfigProviderTest.php
+++ b/libs/Adapter/Yii2/tests/Unit/Inspector/Yii2ConfigProviderTest.php
@@ -140,4 +140,111 @@ final class Yii2ConfigProviderTest extends TestCase
 
         $this->assertSame(\stdClass::class, $result['custom']);
     }
+
+    public function testComponentWithNonClassDefinition(): void
+    {
+        $components = [
+            'custom' => 42,
+        ];
+
+        $app = $this->createMock(Application::class);
+        $app->method('getComponents')->willReturn($components);
+
+        $provider = new Yii2ConfigProvider($app);
+        $result = $provider->get('services');
+
+        $this->assertSame('int', $result['custom']);
+    }
+
+    public function testGetEventsWebGroupIsAlias(): void
+    {
+        $app = $this->createMock(Application::class);
+        $app->method('getBehaviors')->willReturn([]);
+
+        $provider = new Yii2ConfigProvider($app);
+
+        $this->assertSame($provider->get('events'), $provider->get('events-web'));
+    }
+
+    public function testGetEventsWithBehaviors(): void
+    {
+        $behavior = new \yii\base\Behavior();
+
+        $app = $this->createMock(Application::class);
+        $app->method('getBehaviors')->willReturn(['myBehavior' => $behavior]);
+
+        $provider = new Yii2ConfigProvider($app);
+        $result = $provider->get('events');
+
+        $this->assertArrayHasKey('behavior:myBehavior', $result);
+        $this->assertSame([\yii\base\Behavior::class], $result['behavior:myBehavior']);
+    }
+
+    public function testGetEventsWithClassLevelHandlers(): void
+    {
+        // Register a class-level event handler
+        \yii\base\Event::on(\yii\web\Application::class, 'testEvent', static function (): void {});
+
+        $app = $this->createMock(Application::class);
+        $app->method('getBehaviors')->willReturn([]);
+
+        $provider = new Yii2ConfigProvider($app);
+        $result = $provider->get('events');
+
+        $this->assertNotEmpty($result);
+
+        // Clean up
+        \yii\base\Event::offAll();
+    }
+
+    public function testDescribeHandlerWithStringHandler(): void
+    {
+        $method = new \ReflectionMethod(Yii2ConfigProvider::class, 'describeHandler');
+
+        $this->assertSame('myFunction', $method->invoke(null, 'myFunction'));
+    }
+
+    public function testDescribeHandlerWithArrayHandler(): void
+    {
+        $method = new \ReflectionMethod(Yii2ConfigProvider::class, 'describeHandler');
+
+        $result = $method->invoke(null, [new \stdClass(), 'doSomething']);
+        $this->assertSame('stdClass::doSomething', $result);
+    }
+
+    public function testDescribeHandlerWithClassStringArrayHandler(): void
+    {
+        $method = new \ReflectionMethod(Yii2ConfigProvider::class, 'describeHandler');
+
+        $result = $method->invoke(null, ['SomeClass', 'staticMethod']);
+        $this->assertSame('SomeClass::staticMethod', $result);
+    }
+
+    public function testDescribeHandlerWithClosure(): void
+    {
+        $method = new \ReflectionMethod(Yii2ConfigProvider::class, 'describeHandler');
+
+        $result = $method->invoke(null, static function (): void {});
+        $this->assertSame('Closure', $result);
+    }
+
+    public function testDescribeHandlerWithInvokableObject(): void
+    {
+        $method = new \ReflectionMethod(Yii2ConfigProvider::class, 'describeHandler');
+
+        $invokable = new class {
+            public function __invoke(): void {}
+        };
+
+        $result = $method->invoke(null, $invokable);
+        $this->assertStringEndsWith('::__invoke', $result);
+    }
+
+    public function testDescribeHandlerWithOtherType(): void
+    {
+        $method = new \ReflectionMethod(Yii2ConfigProvider::class, 'describeHandler');
+
+        $result = $method->invoke(null, 42);
+        $this->assertSame('int', $result);
+    }
 }

--- a/libs/Adapter/Yii2/tests/Unit/Inspector/Yii2DbSchemaProviderTest.php
+++ b/libs/Adapter/Yii2/tests/Unit/Inspector/Yii2DbSchemaProviderTest.php
@@ -149,4 +149,158 @@ final class Yii2DbSchemaProviderTest extends TestCase
         $this->assertCount(1, $tables);
         $this->assertSame(0, $tables[0]['records']);
     }
+
+    public function testGetTablesSkipsNullTableSchema(): void
+    {
+        $schema = $this->createMock(Schema::class);
+        $schema->method('getTableNames')->willReturn(['valid_table', 'null_table']);
+        $schema
+            ->method('getTableSchema')
+            ->willReturnCallback(static function (string $name) {
+                if ($name === 'null_table') {
+                    return null;
+                }
+                $tableSchema = new TableSchema();
+                $tableSchema->name = $name;
+                $tableSchema->primaryKey = [];
+                $tableSchema->columns = [];
+                return $tableSchema;
+            });
+
+        $countCommand = $this->createMock(Command::class);
+        $countCommand->method('queryScalar')->willReturn('0');
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getSchema')->willReturn($schema);
+        $connection->method('quoteTableName')->willReturnArgument(0);
+        $connection->method('createCommand')->willReturn($countCommand);
+
+        $provider = new Yii2DbSchemaProvider($connection);
+        $tables = $provider->getTables();
+
+        $this->assertCount(1, $tables);
+        $this->assertSame('valid_table', $tables[0]['table']);
+    }
+
+    public function testExecuteQueryWithoutParams(): void
+    {
+        $command = $this->createMock(Command::class);
+        $command->method('queryAll')->willReturn([['id' => 1, 'name' => 'Alice']]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('createCommand')->with('SELECT * FROM users')->willReturn($command);
+
+        $provider = new Yii2DbSchemaProvider($connection);
+        $result = $provider->executeQuery('SELECT * FROM users');
+
+        $this->assertSame([['id' => 1, 'name' => 'Alice']], $result);
+    }
+
+    public function testExecuteQueryWithNamedParams(): void
+    {
+        $command = $this->createMock(Command::class);
+        $command->expects($this->once())->method('bindValues')->with([':id' => 1])->willReturnSelf();
+        $command->method('queryAll')->willReturn([['id' => 1]]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('createCommand')->willReturn($command);
+
+        $provider = new Yii2DbSchemaProvider($connection);
+        $result = $provider->executeQuery('SELECT * FROM users WHERE id = :id', ['id' => 1]);
+
+        $this->assertSame([['id' => 1]], $result);
+    }
+
+    public function testExecuteQueryWithNamedParamsAlreadyPrefixed(): void
+    {
+        $command = $this->createMock(Command::class);
+        $command->expects($this->once())->method('bindValues')->with([':name' => 'Alice'])->willReturnSelf();
+        $command->method('queryAll')->willReturn([]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('createCommand')->willReturn($command);
+
+        $provider = new Yii2DbSchemaProvider($connection);
+        $provider->executeQuery('SELECT * FROM users WHERE name = :name', [':name' => 'Alice']);
+    }
+
+    public function testExecuteQueryWithPositionalParams(): void
+    {
+        $command = $this->createMock(Command::class);
+        $command->expects($this->once())->method('bindValues')->with([1 => 'Alice', 2 => 30])->willReturnSelf();
+        $command->method('queryAll')->willReturn([]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('createCommand')->willReturn($command);
+
+        $provider = new Yii2DbSchemaProvider($connection);
+        $provider->executeQuery('SELECT * FROM users WHERE name = ? AND age = ?', ['Alice', 30]);
+    }
+
+    public function testExplainQueryDefault(): void
+    {
+        $command = $this->createMock(Command::class);
+        $command->method('queryAll')->willReturn([['EXPLAIN' => 'Seq Scan on users']]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDriverName')->willReturn('pgsql');
+        $connection
+            ->expects($this->once())
+            ->method('createCommand')
+            ->with('EXPLAIN SELECT * FROM users')
+            ->willReturn($command);
+
+        $provider = new Yii2DbSchemaProvider($connection);
+        $result = $provider->explainQuery('SELECT * FROM users');
+
+        $this->assertSame([['EXPLAIN' => 'Seq Scan on users']], $result);
+    }
+
+    public function testExplainQueryWithAnalyze(): void
+    {
+        $command = $this->createMock(Command::class);
+        $command->method('queryAll')->willReturn([['EXPLAIN' => 'Seq Scan']]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDriverName')->willReturn('mysql');
+        $connection
+            ->expects($this->once())
+            ->method('createCommand')
+            ->with('EXPLAIN ANALYZE SELECT * FROM users')
+            ->willReturn($command);
+
+        $provider = new Yii2DbSchemaProvider($connection);
+        $provider->explainQuery('SELECT * FROM users', [], true);
+    }
+
+    public function testExplainQuerySqlite(): void
+    {
+        $command = $this->createMock(Command::class);
+        $command->method('queryAll')->willReturn([['detail' => 'SCAN TABLE users']]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDriverName')->willReturn('sqlite');
+        $connection
+            ->expects($this->once())
+            ->method('createCommand')
+            ->with('EXPLAIN QUERY PLAN SELECT * FROM users')
+            ->willReturn($command);
+
+        $provider = new Yii2DbSchemaProvider($connection);
+        $provider->explainQuery('SELECT * FROM users');
+    }
+
+    public function testExplainQueryWithParams(): void
+    {
+        $command = $this->createMock(Command::class);
+        $command->expects($this->once())->method('bindValues')->with([':id' => 5])->willReturnSelf();
+        $command->method('queryAll')->willReturn([]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDriverName')->willReturn('pgsql');
+        $connection->method('createCommand')->willReturn($command);
+
+        $provider = new Yii2DbSchemaProvider($connection);
+        $provider->explainQuery('SELECT * FROM users WHERE id = :id', ['id' => 5]);
+    }
 }

--- a/libs/Adapter/Yii2/tests/Unit/Inspector/Yii2RouteCollectionTest.php
+++ b/libs/Adapter/Yii2/tests/Unit/Inspector/Yii2RouteCollectionTest.php
@@ -8,8 +8,10 @@ use AppDevPanel\Adapter\Yii2\Inspector\Yii2RouteAdapter;
 use AppDevPanel\Adapter\Yii2\Inspector\Yii2RouteCollection;
 use AppDevPanel\Adapter\Yii2\Proxy\UrlRuleProxy;
 use PHPUnit\Framework\TestCase;
+use yii\web\CompositeUrlRule;
 use yii\web\UrlManager;
 use yii\web\UrlRule;
+use yii\web\UrlRuleInterface;
 
 final class Yii2RouteCollectionTest extends TestCase
 {
@@ -81,5 +83,66 @@ final class Yii2RouteCollectionTest extends TestCase
         $this->assertCount(1, $routes);
         $info = $routes[0]->__debugInfo();
         $this->assertSame([], $info['hosts']);
+    }
+
+    public function testGetRoutesWithCompositeUrlRuleExtractsSubRules(): void
+    {
+        $subRule = $this->createMock(UrlRule::class);
+        $subRule->name = 'api/users/<id>';
+
+        $compositeRule = $this->getMockBuilder(CompositeUrlRule::class)->disableOriginalConstructor()->getMock();
+
+        $reflection = new \ReflectionProperty(CompositeUrlRule::class, 'rules');
+        $reflection->setValue($compositeRule, [$subRule]);
+
+        $urlManager = $this->createMock(UrlManager::class);
+        $urlManager->rules = [$compositeRule];
+
+        $collection = new Yii2RouteCollection($urlManager);
+        $routes = $collection->getRoutes();
+
+        $this->assertCount(1, $routes);
+        $info = $routes[0]->__debugInfo();
+        $this->assertSame('api/users/<id>', $info['name']);
+    }
+
+    public function testGetRoutesWithCompositeUrlRuleNullSubRules(): void
+    {
+        $compositeRule = $this->getMockBuilder(CompositeUrlRule::class)->disableOriginalConstructor()->getMock();
+
+        $reflection = new \ReflectionProperty(CompositeUrlRule::class, 'rules');
+        $reflection->setValue($compositeRule, null);
+
+        $compositeRule->method('createRules')->willReturn([]);
+
+        $urlManager = $this->createMock(UrlManager::class);
+        $urlManager->rules = [$compositeRule];
+
+        $collection = new Yii2RouteCollection($urlManager);
+        $routes = $collection->getRoutes();
+
+        $this->assertCount(1, $routes);
+        $info = $routes[0]->__debugInfo();
+        $this->assertSame($compositeRule::class, $info['name']);
+    }
+
+    public function testCompositeUrlRuleWithUrlRuleInterfaceSubRules(): void
+    {
+        $subRule = $this->createMock(UrlRuleInterface::class);
+
+        $compositeRule = $this->getMockBuilder(CompositeUrlRule::class)->disableOriginalConstructor()->getMock();
+
+        $reflection = new \ReflectionProperty(CompositeUrlRule::class, 'rules');
+        $reflection->setValue($compositeRule, [$subRule]);
+
+        $urlManager = $this->createMock(UrlManager::class);
+        $urlManager->rules = [$compositeRule];
+
+        $collection = new Yii2RouteCollection($urlManager);
+        $routes = $collection->getRoutes();
+
+        $this->assertCount(1, $routes);
+        $info = $routes[0]->__debugInfo();
+        $this->assertSame($subRule::class, $info['name']);
     }
 }

--- a/libs/Adapter/Yii2/tests/Unit/ModuleBootstrapTest.php
+++ b/libs/Adapter/Yii2/tests/Unit/ModuleBootstrapTest.php
@@ -1,0 +1,484 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppDevPanel\Adapter\Yii2\Tests\Unit;
+
+use AppDevPanel\Adapter\Yii2\Collector\DbProfilingTarget;
+use AppDevPanel\Adapter\Yii2\Collector\DebugLogTarget;
+use AppDevPanel\Adapter\Yii2\Module;
+use AppDevPanel\Adapter\Yii2\Proxy\UrlRuleProxy;
+use AppDevPanel\Api\ApiApplication;
+use AppDevPanel\Api\Inspector\Database\SchemaProviderInterface;
+use AppDevPanel\Kernel\Collector\AssetBundleCollector;
+use AppDevPanel\Kernel\Collector\CollectorInterface;
+use AppDevPanel\Kernel\Collector\DatabaseCollector;
+use AppDevPanel\Kernel\Collector\EventCollector;
+use AppDevPanel\Kernel\Collector\ExceptionCollector;
+use AppDevPanel\Kernel\Collector\HttpClientCollector;
+use AppDevPanel\Kernel\Collector\LogCollector;
+use AppDevPanel\Kernel\Collector\MailerCollector;
+use AppDevPanel\Kernel\Collector\RouterCollector;
+use AppDevPanel\Kernel\Collector\ServiceCollector;
+use AppDevPanel\Kernel\Collector\TimelineCollector;
+use AppDevPanel\Kernel\Collector\VarDumperCollector;
+use AppDevPanel\Kernel\Collector\Web\RequestCollector;
+use AppDevPanel\Kernel\Collector\Web\WebAppInfoCollector;
+use AppDevPanel\Kernel\Debugger;
+use AppDevPanel\Kernel\DebuggerIdGenerator;
+use AppDevPanel\Kernel\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+use yii\base\Event;
+use yii\log\Dispatcher;
+use yii\web\Application;
+use yii\web\UrlManager;
+use yii\web\UrlRule;
+
+final class ModuleBootstrapTest extends TestCase
+{
+    private string $storagePath;
+    private mixed $previousExceptionHandler = null;
+
+    protected function setUp(): void
+    {
+        $this->storagePath = sys_get_temp_dir() . '/adp_bootstrap_test_' . bin2hex(random_bytes(8));
+        mkdir($this->storagePath, 0o777, true);
+        mkdir($this->storagePath . '/runtime', 0o777, true);
+
+        \Yii::$container = new \yii\di\Container();
+        \Yii::setAlias('@app', $this->storagePath);
+        \Yii::setAlias('@runtime', $this->storagePath . '/runtime');
+
+        // Save current exception handler to restore later
+        $this->previousExceptionHandler = set_exception_handler(null);
+        restore_exception_handler();
+
+        // Clear class-level event handlers from previous tests
+        Event::offAll();
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore the exception handler (Module::hookErrorHandler sets one)
+        set_exception_handler($this->previousExceptionHandler);
+
+        \Yii::$container = new \yii\di\Container();
+        \Yii::$app = null;
+        \Yii::setAlias('@AppDevPanel', null);
+        Event::offAll();
+
+        $this->removeDirectory($this->storagePath);
+    }
+
+    public function testBootstrapRegistersDebuggerInContainer(): void
+    {
+        $module = $this->createModuleAndBootstrap();
+
+        $this->assertTrue(\Yii::$container->has(Debugger::class));
+        $this->assertInstanceOf(Debugger::class, $module->getDebugger());
+    }
+
+    public function testBootstrapRegistersStorageInContainer(): void
+    {
+        $this->createModuleAndBootstrap();
+
+        $this->assertTrue(\Yii::$container->has(StorageInterface::class));
+        $this->assertInstanceOf(StorageInterface::class, \Yii::$container->get(StorageInterface::class));
+    }
+
+    public function testBootstrapRegistersIdGeneratorInContainer(): void
+    {
+        $this->createModuleAndBootstrap();
+
+        $this->assertTrue(\Yii::$container->has(DebuggerIdGenerator::class));
+    }
+
+    public function testBootstrapRegistersApiApplicationInContainer(): void
+    {
+        $this->createModuleAndBootstrap();
+
+        $this->assertTrue(\Yii::$container->has(ApiApplication::class));
+    }
+
+    public function testBootstrapRegistersAllDefaultCollectors(): void
+    {
+        $module = $this->createModuleAndBootstrap();
+        $collectors = $module->getCollectorInstances();
+
+        $expectedTypes = [
+            TimelineCollector::class,
+            RequestCollector::class,
+            WebAppInfoCollector::class,
+            ExceptionCollector::class,
+            LogCollector::class,
+            EventCollector::class,
+            ServiceCollector::class,
+            HttpClientCollector::class,
+            VarDumperCollector::class,
+            DatabaseCollector::class,
+            MailerCollector::class,
+            AssetBundleCollector::class,
+            RouterCollector::class,
+        ];
+
+        $collectorClasses = array_map(static fn(CollectorInterface $c) => $c::class, $collectors);
+        foreach ($expectedTypes as $expectedType) {
+            $this->assertContains($expectedType, $collectorClasses, "Missing collector: {$expectedType}");
+        }
+    }
+
+    public function testBootstrapWithDisabledCollectorsExcludesThem(): void
+    {
+        $module = $this->createModuleAndBootstrap([
+            'collectors' => [
+                'log' => false,
+                'event' => false,
+                'db' => false,
+            ],
+        ]);
+        $collectors = $module->getCollectorInstances();
+
+        $collectorClasses = array_map(static fn(CollectorInterface $c) => $c::class, $collectors);
+        $this->assertNotContains(LogCollector::class, $collectorClasses);
+        $this->assertNotContains(EventCollector::class, $collectorClasses);
+        $this->assertNotContains(DatabaseCollector::class, $collectorClasses);
+    }
+
+    public function testGetCollectorReturnsNullForMissingType(): void
+    {
+        $module = $this->createModuleAndBootstrap(['collectors' => ['log' => false]]);
+
+        $this->assertNull($module->getCollector(LogCollector::class));
+    }
+
+    public function testGetCollectorReturnsMatchingInstance(): void
+    {
+        $module = $this->createModuleAndBootstrap();
+
+        $collector = $module->getCollector(TimelineCollector::class);
+        $this->assertInstanceOf(TimelineCollector::class, $collector);
+    }
+
+    public function testGetDebuggerThrowsBeforeBootstrap(): void
+    {
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Debugger is not initialized');
+        $module->getDebugger();
+    }
+
+    public function testGetTimelineCollectorReturnsConsistentInstance(): void
+    {
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+        ]);
+
+        $timeline1 = $module->getTimelineCollector();
+        $timeline2 = $module->getTimelineCollector();
+
+        $this->assertSame($timeline1, $timeline2);
+    }
+
+    public function testBootstrapRegistersUrlRules(): void
+    {
+        // Use reflection to verify registerRoutes was called by checking rules count
+        $urlManager = $this->createMock(UrlManager::class);
+        $urlManager->rules = [];
+        $urlManager->expects($this->once())->method('addRules');
+
+        $logDispatcher = new \stdClass();
+        $logDispatcher->targets = [];
+
+        $app = $this->createMock(Application::class);
+        $app->method('getUrlManager')->willReturn($urlManager);
+        $app->method('has')->willReturnCallback(static fn(string $id) => $id === 'db');
+        $app->params = [];
+        $app->method('__get')->willReturnCallback(static fn(string $name) => match ($name) {
+            'log' => $logDispatcher,
+            'params' => [],
+            default => null,
+        });
+        \Yii::$app = $app;
+
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+        ]);
+        $module->bootstrap($app);
+    }
+
+    public function testBootstrapWrapsUrlRulesWithProxy(): void
+    {
+        $existingRule = $this->createMock(UrlRule::class);
+        $existingRule->name = 'existing/route';
+
+        $app = $this->createWebApp([$existingRule]);
+
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+        ]);
+        $module->bootstrap($app);
+
+        // All rules should be wrapped in UrlRuleProxy
+        foreach ($app->getUrlManager()->rules as $rule) {
+            $this->assertInstanceOf(UrlRuleProxy::class, $rule);
+        }
+    }
+
+    public function testBootstrapDoesNotWrapRulesWhenRouterDisabled(): void
+    {
+        $existingRule = $this->createMock(UrlRule::class);
+        $existingRule->name = 'existing/route';
+
+        $app = $this->createWebApp([$existingRule]);
+
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+            'collectors' => ['router' => false],
+        ]);
+        $module->bootstrap($app);
+
+        // The existing rule should NOT be wrapped
+        $hasUnwrapped = false;
+        foreach ($app->getUrlManager()->rules as $rule) {
+            if (!$rule instanceof UrlRuleProxy) {
+                $hasUnwrapped = true;
+                break;
+            }
+        }
+        $this->assertTrue($hasUnwrapped, 'Rules should not be wrapped when router collector is disabled');
+    }
+
+    public function testBootstrapRegistersWebEventListeners(): void
+    {
+        $app = $this->createWebApp();
+
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+        ]);
+        $module->bootstrap($app);
+
+        // Verify web event listeners were registered by checking Event class
+        $this->assertTrue(Event::hasHandlers(Application::class, Application::EVENT_BEFORE_REQUEST));
+        $this->assertTrue(Event::hasHandlers(Application::class, Application::EVENT_AFTER_REQUEST));
+    }
+
+    public function testBootstrapRegistersConsoleCommands(): void
+    {
+        $storagePath = sys_get_temp_dir() . '/adp_console_test_' . bin2hex(random_bytes(4));
+        mkdir($storagePath, 0o777, true);
+        mkdir($storagePath . '/runtime', 0o777, true);
+
+        $app = new \yii\console\Application([
+            'id' => 'test-console',
+            'basePath' => $storagePath,
+        ]);
+
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $storagePath . '/debug',
+        ]);
+        $module->bootstrap($app);
+
+        $this->assertArrayHasKey('debug-query', $app->controllerMap);
+        $this->assertArrayHasKey('debug-reset', $app->controllerMap);
+
+        \Yii::$app = null;
+        $this->removeDirectory($storagePath);
+    }
+
+    public function testBootstrapRegistersDbProfilingTarget(): void
+    {
+        $logDispatcher = null;
+        $app = $this->createWebApp([], $logDispatcher);
+
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+        ]);
+        $module->bootstrap($app);
+
+        // Check that DbProfilingTarget was added to Yii's log targets
+        $this->assertArrayHasKey('adp-db-profiling', $logDispatcher->targets);
+        $this->assertInstanceOf(DbProfilingTarget::class, $logDispatcher->targets['adp-db-profiling']);
+    }
+
+    public function testBootstrapRegistersDebugLogTarget(): void
+    {
+        $logDispatcher = null;
+        $app = $this->createWebApp([], $logDispatcher);
+
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+        ]);
+        $module->bootstrap($app);
+
+        $this->assertArrayHasKey('adp-debug', $logDispatcher->targets);
+        $this->assertInstanceOf(DebugLogTarget::class, $logDispatcher->targets['adp-debug']);
+    }
+
+    public function testBootstrapDoesNothingWhenDisabled(): void
+    {
+        $app = $this->createWebApp();
+
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+            'enabled' => false,
+        ]);
+        $module->bootstrap($app);
+
+        $this->assertFalse(\Yii::$container->has(Debugger::class));
+    }
+
+    public function testBootstrapRegistersSchemaProviderWithDb(): void
+    {
+        $app = $this->createWebApp();
+
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+        ]);
+        $module->bootstrap($app);
+
+        $this->assertTrue(\Yii::$container->has(SchemaProviderInterface::class));
+    }
+
+    public function testBootstrapRegistersEventProfiling(): void
+    {
+        $app = $this->createWebApp();
+
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+        ]);
+        $module->bootstrap($app);
+
+        // EventCollector should be in the collector list (event profiling wired via Event::on('*', '*', ...))
+        $this->assertNotNull($module->getCollector(EventCollector::class));
+    }
+
+    public function testNormalizeAddressesHandlesVariousFormats(): void
+    {
+        // Test via reflection since it's a private static method
+        $method = new \ReflectionMethod(Module::class, 'normalizeAddresses');
+
+        // Null
+        $this->assertSame([], $method->invoke(null, null));
+
+        // String
+        $this->assertSame(['test@example.com' => ''], $method->invoke(null, 'test@example.com'));
+
+        // Indexed array
+        $this->assertSame(
+            ['a@test.com' => '', 'b@test.com' => ''],
+            $method->invoke(null, ['a@test.com', 'b@test.com']),
+        );
+
+        // Associative array
+        $this->assertSame(['user@test.com' => 'User Name'], $method->invoke(null, ['user@test.com' => 'User Name']));
+
+        // Integer value (other type)
+        $this->assertSame(['42' => ''], $method->invoke(null, 42));
+    }
+
+    public function testGetCollectorInstancesReturnsAllRegistered(): void
+    {
+        $module = $this->createModuleAndBootstrap();
+        $instances = $module->getCollectorInstances();
+
+        $this->assertNotEmpty($instances);
+        foreach ($instances as $collector) {
+            $this->assertInstanceOf(CollectorInterface::class, $collector);
+        }
+    }
+
+    public function testBootstrapWithoutDbComponent(): void
+    {
+        $urlManager = new UrlManager();
+        $urlManager->rules = [];
+
+        $logDispatcher = new \stdClass();
+        $logDispatcher->targets = [];
+
+        $app = $this->createMock(Application::class);
+        $app->method('getUrlManager')->willReturn($urlManager);
+        $app->method('has')->willReturn(false);
+        $app->params = [];
+        $app->method('__get')->willReturnCallback(static fn(string $name) => match ($name) {
+            'log' => $logDispatcher,
+            'params' => [],
+            default => null,
+        });
+
+        \Yii::$app = $app;
+
+        $module = new Module('debug-panel', null, [
+            'storagePath' => $this->storagePath . '/debug',
+        ]);
+        $module->bootstrap($app);
+
+        // NullSchemaProvider should be registered
+        $this->assertTrue(\Yii::$container->has(SchemaProviderInterface::class));
+    }
+
+    private function createModuleAndBootstrap(array $extraConfig = []): Module
+    {
+        $app = $this->createWebApp();
+
+        $config = array_merge([
+            'storagePath' => $this->storagePath . '/debug',
+        ], $extraConfig);
+
+        $module = new Module('debug-panel', null, $config);
+        $module->bootstrap($app);
+
+        return $module;
+    }
+
+    private function createWebApp(array $existingRules = [], ?object &$logDispatcherOut = null): Application
+    {
+        $urlManager = new UrlManager();
+        $urlManager->rules = $existingRules;
+
+        // Use a simple stdClass with targets property — Yii 2's __get() magic
+        // maps $app->log to getLog(), so we must mock that method.
+        $logDispatcher = new \stdClass();
+        $logDispatcher->targets = [];
+
+        $app = $this->createMock(Application::class);
+        $app->method('getUrlManager')->willReturn($urlManager);
+        $app->method('has')->willReturnCallback(static fn(string $id) => $id === 'db');
+        $app->params = [];
+
+        // Yii2 magic __get: $app->log calls getLog(), $app->db calls getDb(), etc.
+        $app->method('__get')->willReturnCallback(static fn(string $name) => match ($name) {
+            'log' => $logDispatcher,
+            'params' => [],
+            default => null,
+        });
+
+        $logDispatcherOut = $logDispatcher;
+
+        // Make \Yii::$app return the mock
+        \Yii::$app = $app;
+
+        return $app;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## Summary

- Add 73 new tests for the Yii2 adapter, increasing coverage from **57.3%** (373/651 lines) to **91.5%** (861/941 lines)
- New test files cover previously untested classes: `DbProfilingTarget`, `DebugResetController`, `Yii2RouteAdapter`, `Yii2RouteCollection`, and `Module::bootstrap()` (which was at 6.87%)
- Extended existing tests for `NullSchemaProvider`, `Yii2ConfigProvider`, `Yii2DbSchemaProvider`, and `DebugQueryController` to cover missing methods

## Test plan

- [x] All 183 Yii2 adapter tests pass (`php vendor/bin/phpunit --testsuite=Adapter-Yii2`)
- [x] Mago format and lint pass
- [ ] CI pipeline passes

https://claude.ai/code/session_011BJQATTKbFbShGMxXyXDQD