### PR TITLE
feat: Duplicate detection (N+1) for views, SQL queries, and jobs

### DIFF
--- a/libs/Kernel/src/Collector/DatabaseCollector.php
+++ b/libs/Kernel/src/Collector/DatabaseCollector.php
@@ -6,6 +6,9 @@ namespace AppDevPanel\Kernel\Collector;
 
 use Throwable;
 
+use function array_values;
+use function count;
+
 /**
  * Captures SQL queries and transactions from the application.
  *
@@ -18,6 +21,7 @@ use Throwable;
 final class DatabaseCollector implements SummaryCollectorInterface
 {
     use CollectorTrait;
+    use DuplicateDetectionTrait;
 
     private array $queries = [];
     private array $transactions = [];
@@ -157,9 +161,14 @@ final class DatabaseCollector implements SummaryCollectorInterface
             return [];
         }
 
+        $queries = array_values($this->queries);
+
         return [
-            'queries' => $this->queries,
+            'queries' => $queries,
             'transactions' => $this->transactions,
+            'duplicates' => $this->detectDuplicates($queries, static fn(array $query) => $query['rawSql'] !== ''
+                ? $query['rawSql']
+                : $query['sql']),
         ];
     }
 
@@ -168,6 +177,11 @@ final class DatabaseCollector implements SummaryCollectorInterface
         if (!$this->isActive()) {
             return [];
         }
+
+        $queries = array_values($this->queries);
+        $duplicates = $this->detectDuplicates($queries, static fn(array $query) => $query['rawSql'] !== ''
+            ? $query['rawSql']
+            : $query['sql']);
 
         return [
             'db' => [
@@ -185,6 +199,8 @@ final class DatabaseCollector implements SummaryCollectorInterface
                     )),
                     'total' => count($this->transactions),
                 ],
+                'duplicateGroups' => count($duplicates['groups']),
+                'totalDuplicatedCount' => $duplicates['totalDuplicatedCount'],
             ],
         ];
     }

--- a/libs/Kernel/src/Collector/DuplicateDetectionTrait.php
+++ b/libs/Kernel/src/Collector/DuplicateDetectionTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppDevPanel\Kernel\Collector;
+
+use function array_keys;
+use function array_values;
+use function count;
+
+/**
+ * Detects duplicate items in collector data by grouping them by a key.
+ *
+ * Used by ViewCollector (file path), DatabaseCollector (SQL), and QueueCollector (message class)
+ * to detect N+1 patterns where the same operation is repeated many times.
+ */
+trait DuplicateDetectionTrait
+{
+    private const int DUPLICATE_THRESHOLD = 2;
+
+    /**
+     * Detect duplicate groups from a list of items.
+     *
+     * @param array<int, array> $items Items to group.
+     * @param callable(array): string $keyExtractor Extracts the grouping key from an item.
+     * @return array{groups: array<int, array{key: string, count: int, indices: int[]}>, totalDuplicatedCount: int}
+     */
+    private function detectDuplicates(array $items, callable $keyExtractor): array
+    {
+        /** @var array<string, int[]> $grouped */
+        $grouped = [];
+
+        foreach ($items as $index => $item) {
+            $key = $keyExtractor($item);
+            $grouped[$key][] = $index;
+        }
+
+        $groups = [];
+        $totalDuplicatedCount = 0;
+
+        foreach ($grouped as $key => $indices) {
+            if (count($indices) > self::DUPLICATE_THRESHOLD) {
+                $groups[] = [
+                    'key' => $key,
+                    'count' => count($indices),
+                    'indices' => array_values($indices),
+                ];
+                $totalDuplicatedCount += count($indices);
+            }
+        }
+
+        return [
+            'groups' => $groups,
+            'totalDuplicatedCount' => $totalDuplicatedCount,
+        ];
+    }
+}

--- a/libs/Kernel/src/Collector/QueueCollector.php
+++ b/libs/Kernel/src/Collector/QueueCollector.php
@@ -18,6 +18,7 @@ use function is_countable;
 final class QueueCollector implements SummaryCollectorInterface
 {
     use CollectorTrait;
+    use DuplicateDetectionTrait;
 
     /** @var array<string, array<int, array{message: mixed, middlewares: array}>> */
     private array $pushes = [];
@@ -98,6 +99,10 @@ final class QueueCollector implements SummaryCollectorInterface
             'messages' => $this->messages,
             'messageCount' => count($this->messages),
             'failedCount' => count(array_filter($this->messages, static fn(array $m) => $m['failed'])),
+            'duplicates' => $this->detectDuplicates(
+                $this->messages,
+                static fn(array $message) => $message['messageClass'],
+            ),
         ];
     }
 
@@ -106,6 +111,8 @@ final class QueueCollector implements SummaryCollectorInterface
         if (!$this->isActive()) {
             return [];
         }
+
+        $duplicates = $this->detectDuplicates($this->messages, static fn(array $message) => $message['messageClass']);
 
         return [
             'queue' => [
@@ -116,6 +123,8 @@ final class QueueCollector implements SummaryCollectorInterface
                     : 0, $this->processingMessages)),
                 'messageCount' => count($this->messages),
                 'failedCount' => count(array_filter($this->messages, static fn(array $m) => $m['failed'])),
+                'duplicateGroups' => count($duplicates['groups']),
+                'totalDuplicatedCount' => $duplicates['totalDuplicatedCount'],
             ],
         ];
     }

--- a/libs/Kernel/src/Collector/ViewCollector.php
+++ b/libs/Kernel/src/Collector/ViewCollector.php
@@ -15,6 +15,7 @@ use function count;
 final class ViewCollector implements SummaryCollectorInterface
 {
     use CollectorTrait;
+    use DuplicateDetectionTrait;
 
     /** @var array<int, array{file: string, output: string, parameters: array}> */
     private array $renders = [];
@@ -43,7 +44,10 @@ final class ViewCollector implements SummaryCollectorInterface
             return [];
         }
 
-        return $this->renders;
+        return [
+            'renders' => $this->renders,
+            'duplicates' => $this->detectDuplicates($this->renders, static fn(array $render) => $render['file']),
+        ];
     }
 
     public function getSummary(): array
@@ -52,9 +56,13 @@ final class ViewCollector implements SummaryCollectorInterface
             return [];
         }
 
+        $duplicates = $this->detectDuplicates($this->renders, static fn(array $render) => $render['file']);
+
         return [
             'view' => [
                 'total' => count($this->renders),
+                'duplicateGroups' => count($duplicates['groups']),
+                'totalDuplicatedCount' => $duplicates['totalDuplicatedCount'],
             ],
         ];
     }

--- a/libs/Kernel/tests/Unit/Collector/DatabaseCollectorTest.php
+++ b/libs/Kernel/tests/Unit/Collector/DatabaseCollectorTest.php
@@ -34,9 +34,10 @@ final class DatabaseCollectorTest extends AbstractCollectorTestCase
     {
         $this->assertArrayHasKey('queries', $data);
         $this->assertArrayHasKey('transactions', $data);
+        $this->assertArrayHasKey('duplicates', $data);
         $this->assertCount(1, $data['queries']);
 
-        $query = $data['queries']['q1'];
+        $query = $data['queries'][0];
         $this->assertSame('SELECT * FROM users WHERE id = ?', $query['sql']);
         $this->assertSame('SELECT * FROM users WHERE id = 1', $query['rawSql']);
         $this->assertSame('success', $query['status']);
@@ -44,6 +45,9 @@ final class DatabaseCollectorTest extends AbstractCollectorTestCase
         $this->assertCount(2, $query['actions']);
         $this->assertSame('query.start', $query['actions'][0]['action']);
         $this->assertSame('query.end', $query['actions'][1]['action']);
+
+        $this->assertSame([], $data['duplicates']['groups']);
+        $this->assertSame(0, $data['duplicates']['totalDuplicatedCount']);
     }
 
     protected function checkSummaryData(array $data): void
@@ -83,8 +87,8 @@ final class DatabaseCollectorTest extends AbstractCollectorTestCase
         $collector->collectQueryError('e1', new \RuntimeException('syntax error'));
 
         $data = $collector->getCollected();
-        $this->assertSame('error', $data['queries']['e1']['status']);
-        $this->assertInstanceOf(\RuntimeException::class, $data['queries']['e1']['exception']);
+        $this->assertSame('error', $data['queries'][0]['status']);
+        $this->assertInstanceOf(\RuntimeException::class, $data['queries'][0]['exception']);
 
         $summary = $collector->getSummary();
         $this->assertSame(1, $summary['db']['queries']['error']);

--- a/libs/Kernel/tests/Unit/Collector/ViewCollectorTest.php
+++ b/libs/Kernel/tests/Unit/Collector/ViewCollectorTest.php
@@ -27,10 +27,15 @@ final class ViewCollectorTest extends AbstractCollectorTestCase
     {
         parent::checkCollectedData($data);
 
-        $this->assertCount(2, $data);
-        $this->assertSame('/views/layout.php', $data[0]['file']);
-        $this->assertSame('<html>...</html>', $data[0]['output']);
-        $this->assertSame(['title' => 'Home'], $data[0]['parameters']);
+        $this->assertArrayHasKey('renders', $data);
+        $this->assertArrayHasKey('duplicates', $data);
+        $this->assertCount(2, $data['renders']);
+        $this->assertSame('/views/layout.php', $data['renders'][0]['file']);
+        $this->assertSame('<html>...</html>', $data['renders'][0]['output']);
+        $this->assertSame(['title' => 'Home'], $data['renders'][0]['parameters']);
+
+        $this->assertSame([], $data['duplicates']['groups']);
+        $this->assertSame(0, $data['duplicates']['totalDuplicatedCount']);
     }
 
     protected function checkSummaryData(array $data): void

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/DatabasePanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/DatabasePanel.tsx
@@ -15,6 +15,8 @@ import {
     Icon,
     IconButton,
     type Theme,
+    ToggleButton,
+    ToggleButtonGroup,
     Tooltip,
     Typography,
 } from '@mui/material';
@@ -32,7 +34,9 @@ type Query = {
     actions: QueryAction[];
     rowsNumber: number;
 };
-type DatabasePanelProps = {data: {queries?: Query[]; transactions?: any[]}};
+type DuplicateGroup = {key: string; count: number; indices: number[]};
+type DuplicatesData = {groups: DuplicateGroup[]; totalDuplicatedCount: number};
+type DatabasePanelProps = {data: {queries?: Query[]; transactions?: any[]; duplicates?: DuplicatesData}};
 
 function getQueryTime(actions: QueryAction[]) {
     const start = actions.find((a) => a.action === 'query.start');
@@ -84,11 +88,26 @@ const DetailBox = styled(Box)(({theme}) => ({
     fontSize: '12px',
 }));
 
-const QueriesView = ({queries}: {queries: Query[]}) => {
+const GroupHeader = styled(Box)(({theme}) => ({
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(1, 1.5),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    cursor: 'pointer',
+    transition: 'background-color 0.1s ease',
+    backgroundColor: theme.palette.action.selected,
+    '&:hover': {backgroundColor: theme.palette.action.hover},
+}));
+
+const QueriesView = ({queries, duplicates}: {queries: Query[]; duplicates: DuplicatesData}) => {
     const theme = useTheme();
     const [filter, setFilter] = useState('');
     const deferredFilter = useDeferredValue(filter);
     const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+    const [viewMode, setViewMode] = useState<'flat' | 'grouped'>('flat');
+
+    const hasDuplicates = duplicates.groups.length > 0;
 
     if (!queries || queries.length === 0) {
         return <EmptyState icon="storage" title="No queries found" />;
@@ -100,29 +119,169 @@ const QueriesView = ({queries}: {queries: Query[]}) => {
 
     const totalTime = queries.reduce((sum, q) => sum + getQueryTime(q.actions), 0);
 
+    const groupedView = useMemo(() => {
+        if (!hasDuplicates || viewMode !== 'grouped') return null;
+        const filterLower = deferredFilter.toLowerCase();
+        return duplicates.groups
+            .filter((group) => !deferredFilter || group.key.toLowerCase().includes(filterLower))
+            .map((group) => ({
+                ...group,
+                items: group.indices.map((i) => queries[i]).filter(Boolean),
+                totalTime: group.indices.reduce((sum, i) => {
+                    const q = queries[i];
+                    return sum + (q ? getQueryTime(q.actions) : 0);
+                }, 0),
+            }));
+    }, [hasDuplicates, viewMode, duplicates.groups, queries, deferredFilter]);
+
     return (
         <Box>
             <SectionTitle
-                action={<FilterInput value={filter} onChange={setFilter} placeholder="Filter SQL..." />}
-            >{`${filtered.length} queries · ${formatMillisecondsAsDuration(totalTime)} total`}</SectionTitle>
-
-            {filtered.map((query, index) => {
-                const expanded = expandedIndex === index;
-                const ms = getQueryTime(query.actions);
-                const color = durationColor(ms, theme);
-
-                return (
-                    <QueryRowWithExplain
-                        key={index}
-                        query={query}
-                        expanded={expanded}
-                        ms={ms}
-                        color={color}
-                        onToggle={() => setExpandedIndex(expanded ? null : index)}
-                        onExpand={() => setExpandedIndex(index)}
+                action={
+                    <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
+                        {hasDuplicates && (
+                            <ToggleButtonGroup
+                                value={viewMode}
+                                exclusive
+                                onChange={(_e, value) => value && setViewMode(value)}
+                                size="small"
+                                sx={{height: 28}}
+                            >
+                                <ToggleButton value="flat" sx={{fontSize: '11px', px: 1.5, textTransform: 'none'}}>
+                                    All
+                                </ToggleButton>
+                                <ToggleButton value="grouped" sx={{fontSize: '11px', px: 1.5, textTransform: 'none'}}>
+                                    <Tooltip title="Show duplicate queries (N+1)" placement="top">
+                                        <Box sx={{display: 'flex', alignItems: 'center', gap: 0.5}}>
+                                            Duplicates
+                                            <Chip
+                                                label={duplicates.groups.length}
+                                                size="small"
+                                                color="warning"
+                                                sx={{fontSize: '10px', height: 18, minWidth: 20, borderRadius: 1}}
+                                            />
+                                        </Box>
+                                    </Tooltip>
+                                </ToggleButton>
+                            </ToggleButtonGroup>
+                        )}
+                        <FilterInput value={filter} onChange={setFilter} placeholder="Filter SQL..." />
+                    </Box>
+                }
+            >
+                {`${filtered.length} queries · ${formatMillisecondsAsDuration(totalTime)} total`}
+                {hasDuplicates && (
+                    <Chip
+                        label={`N+1`}
+                        size="small"
+                        color="warning"
+                        sx={{fontSize: '10px', height: 18, borderRadius: 1, ml: 1}}
                     />
-                );
-            })}
+                )}
+            </SectionTitle>
+
+            {viewMode === 'grouped' && groupedView
+                ? groupedView.map((group) => (
+                      <DuplicateQueryGroup
+                          key={group.key}
+                          group={group}
+                          queries={queries}
+                          expandedIndex={expandedIndex}
+                          onToggleExpand={setExpandedIndex}
+                      />
+                  ))
+                : filtered.map((query, index) => {
+                      const expanded = expandedIndex === index;
+                      const ms = getQueryTime(query.actions);
+                      const color = durationColor(ms, theme);
+
+                      return (
+                          <QueryRowWithExplain
+                              key={index}
+                              query={query}
+                              expanded={expanded}
+                              ms={ms}
+                              color={color}
+                              onToggle={() => setExpandedIndex(expanded ? null : index)}
+                              onExpand={() => setExpandedIndex(index)}
+                          />
+                      );
+                  })}
+        </Box>
+    );
+};
+
+const DuplicateQueryGroup = ({
+    group,
+    queries,
+    expandedIndex,
+    onToggleExpand,
+}: {
+    group: DuplicateGroup & {items: Query[]; totalTime: number};
+    queries: Query[];
+    expandedIndex: number | null;
+    onToggleExpand: (index: number | null) => void;
+}) => {
+    const theme = useTheme();
+    const [expanded, setExpanded] = useState(false);
+
+    const sqlPreview = group.key;
+    const verb = sqlPreview.trim().split(/\s/)[0]?.toUpperCase();
+
+    return (
+        <Box>
+            <GroupHeader onClick={() => setExpanded(!expanded)}>
+                <Chip
+                    label={verb}
+                    size="small"
+                    sx={{
+                        fontWeight: 700,
+                        fontSize: '9px',
+                        height: 18,
+                        minWidth: 50,
+                        backgroundColor: 'primary.main',
+                        color: 'common.white',
+                        borderRadius: 1,
+                        flexShrink: 0,
+                        mt: '2px',
+                    }}
+                />
+                <SqlCell sx={{color: 'text.primary'}}>{sqlPreview}</SqlCell>
+                <Chip
+                    label={`${group.count}x`}
+                    size="small"
+                    color="warning"
+                    sx={{fontWeight: 700, fontSize: '11px', height: 22, borderRadius: 1, flexShrink: 0}}
+                />
+                <DurationCell sx={{color: durationColor(group.totalTime, theme)}}>
+                    {formatMillisecondsAsDuration(group.totalTime)}
+                </DurationCell>
+                <IconButton size="small" sx={{flexShrink: 0}}>
+                    <Icon sx={{fontSize: 16}}>{expanded ? 'expand_less' : 'expand_more'}</Icon>
+                </IconButton>
+            </GroupHeader>
+            <Collapse in={expanded}>
+                <Box sx={{pl: 2}}>
+                    {group.indices.map((originalIndex) => {
+                        const query = queries[originalIndex];
+                        if (!query) return null;
+                        const isExpanded = expandedIndex === originalIndex;
+                        const ms = getQueryTime(query.actions);
+                        const color = durationColor(ms, theme);
+                        return (
+                            <QueryRowWithExplain
+                                key={originalIndex}
+                                query={query}
+                                expanded={isExpanded}
+                                ms={ms}
+                                color={color}
+                                onToggle={() => onToggleExpand(isExpanded ? null : originalIndex)}
+                                onExpand={() => onToggleExpand(originalIndex)}
+                            />
+                        );
+                    })}
+                </Box>
+            </Collapse>
         </Box>
     );
 };
@@ -491,5 +650,7 @@ export const DatabasePanel = ({data}: DatabasePanelProps) => {
         return <EmptyState icon="storage" title="No queries found" />;
     }
 
-    return <QueriesView queries={data.queries} />;
+    const duplicates: DuplicatesData = data.duplicates ?? {groups: [], totalDuplicatedCount: 0};
+
+    return <QueriesView queries={data.queries} duplicates={duplicates} />;
 };

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/QueuePanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/QueuePanel.tsx
@@ -6,9 +6,21 @@ import {primitives} from '@app-dev-panel/sdk/Component/Theme/tokens';
 import {formatMillisecondsAsDuration} from '@app-dev-panel/sdk/Helper/formatDate';
 import {TabContext, TabPanel} from '@mui/lab';
 import TabList from '@mui/lab/TabList';
-import {Box, Chip, Collapse, Icon, IconButton, Tab, type Theme, Typography} from '@mui/material';
+import {
+    Box,
+    Chip,
+    Collapse,
+    Icon,
+    IconButton,
+    Tab,
+    type Theme,
+    ToggleButton,
+    ToggleButtonGroup,
+    Tooltip,
+    Typography,
+} from '@mui/material';
 import {styled, useTheme} from '@mui/material/styles';
-import {SyntheticEvent, useDeferredValue, useState} from 'react';
+import {SyntheticEvent, useDeferredValue, useMemo, useState} from 'react';
 
 type Message = {
     messageClass: string;
@@ -21,6 +33,9 @@ type Message = {
     message?: any;
 };
 
+type DuplicateGroup = {key: string; count: number; indices: number[]};
+type DuplicatesData = {groups: DuplicateGroup[]; totalDuplicatedCount: number};
+
 type QueuePanelProps = {
     data: {
         pushes: Record<string, {message: any; middlewares: any[]}[]>;
@@ -29,6 +44,7 @@ type QueuePanelProps = {
         messages?: Message[];
         messageCount?: number;
         failedCount?: number;
+        duplicates?: DuplicatesData;
     };
 };
 
@@ -109,6 +125,18 @@ function messageDurationColor(ms: number, theme: Theme): string {
     return theme.palette.success.main;
 }
 
+const GroupHeader = styled(Box)(({theme}) => ({
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(1, 1.5),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    cursor: 'pointer',
+    transition: 'background-color 0.1s ease',
+    backgroundColor: theme.palette.action.selected,
+    '&:hover': {backgroundColor: theme.palette.action.hover},
+}));
+
 const MessageClassCell = styled(Typography)({
     fontFamily: primitives.fontFamilyMono,
     fontSize: '12px',
@@ -125,11 +153,178 @@ const MessageDurationCell = styled(Typography)({
     width: 80,
 });
 
-const MessagesView = ({messages}: {messages: Message[]}) => {
+const MessageItem = ({message, expanded, onToggle}: {message: Message; expanded: boolean; onToggle: () => void}) => {
     const theme = useTheme();
+    const color = messageDurationColor(message.duration, theme);
+    return (
+        <Box>
+            <ItemRow expanded={expanded} onClick={onToggle}>
+                <MessageClassCell>{shortClassName(message.messageClass)}</MessageClassCell>
+                <Chip
+                    label={message.bus}
+                    size="small"
+                    variant="outlined"
+                    sx={{
+                        fontFamily: primitives.fontFamilyMono,
+                        fontSize: '10px',
+                        height: 20,
+                        borderRadius: 1,
+                        flexShrink: 0,
+                    }}
+                />
+                {message.transport && (
+                    <Chip
+                        label={message.transport}
+                        size="small"
+                        variant="outlined"
+                        sx={{
+                            fontFamily: primitives.fontFamilyMono,
+                            fontSize: '10px',
+                            height: 20,
+                            borderRadius: 1,
+                            flexShrink: 0,
+                        }}
+                    />
+                )}
+                {message.failed ? (
+                    <Chip
+                        label="FAILED"
+                        size="small"
+                        sx={{
+                            fontWeight: 700,
+                            fontSize: '9px',
+                            height: 18,
+                            minWidth: 50,
+                            borderRadius: 1,
+                            backgroundColor: theme.palette.error.main,
+                            color: 'common.white',
+                            flexShrink: 0,
+                        }}
+                    />
+                ) : message.handled ? (
+                    <Chip
+                        label="HANDLED"
+                        size="small"
+                        sx={{
+                            fontWeight: 700,
+                            fontSize: '9px',
+                            height: 18,
+                            minWidth: 50,
+                            borderRadius: 1,
+                            backgroundColor: theme.palette.success.main,
+                            color: 'common.white',
+                            flexShrink: 0,
+                        }}
+                    />
+                ) : message.dispatched ? (
+                    <Chip
+                        label="DISPATCHED"
+                        size="small"
+                        sx={{
+                            fontWeight: 700,
+                            fontSize: '9px',
+                            height: 18,
+                            minWidth: 50,
+                            borderRadius: 1,
+                            backgroundColor: theme.palette.warning.main,
+                            color: 'common.white',
+                            flexShrink: 0,
+                        }}
+                    />
+                ) : null}
+                <MessageDurationCell sx={{color}}>{formatMillisecondsAsDuration(message.duration)}</MessageDurationCell>
+                <IconButton size="small" sx={{flexShrink: 0}}>
+                    <Icon sx={{fontSize: 16}}>{expanded ? 'expand_less' : 'expand_more'}</Icon>
+                </IconButton>
+            </ItemRow>
+            <Collapse in={expanded}>
+                <DetailBox>
+                    <Typography sx={{fontSize: '11px', fontWeight: 600, color: 'text.disabled', mb: 0.5}}>
+                        Full Class Name
+                    </Typography>
+                    <Typography
+                        sx={{
+                            fontFamily: primitives.fontFamilyMono,
+                            fontSize: '12px',
+                            color: 'text.secondary',
+                            wordBreak: 'break-all',
+                        }}
+                    >
+                        {message.messageClass}
+                    </Typography>
+                    {message.message != null && (
+                        <Box sx={{mt: 1.5}}>
+                            <Typography sx={{fontSize: '11px', fontWeight: 600, color: 'text.disabled', mb: 0.5}}>
+                                Message Data
+                            </Typography>
+                            <JsonRenderer value={message.message} />
+                        </Box>
+                    )}
+                </DetailBox>
+            </Collapse>
+        </Box>
+    );
+};
+
+const DuplicateMessageGroup = ({
+    group,
+    messages,
+    expandedIndex,
+    onToggleExpand,
+}: {
+    group: DuplicateGroup & {items: Message[]};
+    messages: Message[];
+    expandedIndex: number | null;
+    onToggleExpand: (index: number | null) => void;
+}) => {
+    const theme = useTheme();
+    const [expanded, setExpanded] = useState(false);
+    const totalDuration = group.indices.reduce((sum, i) => sum + (messages[i]?.duration ?? 0), 0);
+
+    return (
+        <Box>
+            <GroupHeader onClick={() => setExpanded(!expanded)}>
+                <MessageClassCell>{shortClassName(group.key)}</MessageClassCell>
+                <Chip
+                    label={`${group.count}x`}
+                    size="small"
+                    color="warning"
+                    sx={{fontWeight: 700, fontSize: '11px', height: 22, borderRadius: 1, flexShrink: 0}}
+                />
+                <MessageDurationCell sx={{color: messageDurationColor(totalDuration, theme)}}>
+                    {formatMillisecondsAsDuration(totalDuration)}
+                </MessageDurationCell>
+                <IconButton size="small" sx={{flexShrink: 0}}>
+                    <Icon sx={{fontSize: 16}}>{expanded ? 'expand_less' : 'expand_more'}</Icon>
+                </IconButton>
+            </GroupHeader>
+            <Collapse in={expanded}>
+                <Box sx={{pl: 2}}>
+                    {group.indices.map((originalIndex) => {
+                        const message = messages[originalIndex];
+                        if (!message) return null;
+                        return (
+                            <MessageItem
+                                key={originalIndex}
+                                message={message}
+                                expanded={expandedIndex === originalIndex}
+                                onToggle={() => onToggleExpand(expandedIndex === originalIndex ? null : originalIndex)}
+                            />
+                        );
+                    })}
+                </Box>
+            </Collapse>
+        </Box>
+    );
+};
+
+const MessagesView = ({messages, duplicates}: {messages: Message[]; duplicates: DuplicatesData}) => {
     const [filter, setFilter] = useState('');
     const deferredFilter = useDeferredValue(filter);
     const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+    const [viewMode, setViewMode] = useState<'flat' | 'grouped'>('flat');
+
+    const hasDuplicates = duplicates.groups.length > 0;
 
     if (!messages || messages.length === 0) {
         return <EmptyState icon="send" title="No messages found" />;
@@ -139,127 +334,77 @@ const MessagesView = ({messages}: {messages: Message[]}) => {
         ? messages.filter((m) => m.messageClass.toLowerCase().includes(deferredFilter.toLowerCase()))
         : messages;
 
+    const groupedView = useMemo(() => {
+        if (!hasDuplicates || viewMode !== 'grouped') return null;
+        const filterLower = deferredFilter.toLowerCase();
+        return duplicates.groups
+            .filter((group) => !deferredFilter || group.key.toLowerCase().includes(filterLower))
+            .map((group) => ({...group, items: group.indices.map((i) => messages[i]).filter(Boolean)}));
+    }, [hasDuplicates, viewMode, duplicates.groups, messages, deferredFilter]);
+
     return (
         <Box>
-            <SectionTitle action={<FilterInput value={filter} onChange={setFilter} placeholder="Filter messages..." />}>
-                {`${filtered.length} messages`}
-            </SectionTitle>
-            {filtered.map((message, index) => {
-                const expanded = expandedIndex === index;
-                const color = messageDurationColor(message.duration, theme);
-                return (
-                    <Box key={index}>
-                        <ItemRow expanded={expanded} onClick={() => setExpandedIndex(expanded ? null : index)}>
-                            <MessageClassCell>{shortClassName(message.messageClass)}</MessageClassCell>
-                            <Chip
-                                label={message.bus}
+            <SectionTitle
+                action={
+                    <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
+                        {hasDuplicates && (
+                            <ToggleButtonGroup
+                                value={viewMode}
+                                exclusive
+                                onChange={(_e, value) => value && setViewMode(value)}
                                 size="small"
-                                variant="outlined"
-                                sx={{
-                                    fontFamily: primitives.fontFamilyMono,
-                                    fontSize: '10px',
-                                    height: 20,
-                                    borderRadius: 1,
-                                    flexShrink: 0,
-                                }}
-                            />
-                            {message.transport && (
-                                <Chip
-                                    label={message.transport}
-                                    size="small"
-                                    variant="outlined"
-                                    sx={{
-                                        fontFamily: primitives.fontFamilyMono,
-                                        fontSize: '10px',
-                                        height: 20,
-                                        borderRadius: 1,
-                                        flexShrink: 0,
-                                    }}
-                                />
-                            )}
-                            {message.failed ? (
-                                <Chip
-                                    label="FAILED"
-                                    size="small"
-                                    sx={{
-                                        fontWeight: 700,
-                                        fontSize: '9px',
-                                        height: 18,
-                                        minWidth: 50,
-                                        borderRadius: 1,
-                                        backgroundColor: theme.palette.error.main,
-                                        color: 'common.white',
-                                        flexShrink: 0,
-                                    }}
-                                />
-                            ) : message.handled ? (
-                                <Chip
-                                    label="HANDLED"
-                                    size="small"
-                                    sx={{
-                                        fontWeight: 700,
-                                        fontSize: '9px',
-                                        height: 18,
-                                        minWidth: 50,
-                                        borderRadius: 1,
-                                        backgroundColor: theme.palette.success.main,
-                                        color: 'common.white',
-                                        flexShrink: 0,
-                                    }}
-                                />
-                            ) : message.dispatched ? (
-                                <Chip
-                                    label="DISPATCHED"
-                                    size="small"
-                                    sx={{
-                                        fontWeight: 700,
-                                        fontSize: '9px',
-                                        height: 18,
-                                        minWidth: 50,
-                                        borderRadius: 1,
-                                        backgroundColor: theme.palette.warning.main,
-                                        color: 'common.white',
-                                        flexShrink: 0,
-                                    }}
-                                />
-                            ) : null}
-                            <MessageDurationCell sx={{color}}>
-                                {formatMillisecondsAsDuration(message.duration)}
-                            </MessageDurationCell>
-                            <IconButton size="small" sx={{flexShrink: 0}}>
-                                <Icon sx={{fontSize: 16}}>{expanded ? 'expand_less' : 'expand_more'}</Icon>
-                            </IconButton>
-                        </ItemRow>
-                        <Collapse in={expanded}>
-                            <DetailBox>
-                                <Typography sx={{fontSize: '11px', fontWeight: 600, color: 'text.disabled', mb: 0.5}}>
-                                    Full Class Name
-                                </Typography>
-                                <Typography
-                                    sx={{
-                                        fontFamily: primitives.fontFamilyMono,
-                                        fontSize: '12px',
-                                        color: 'text.secondary',
-                                        wordBreak: 'break-all',
-                                    }}
-                                >
-                                    {message.messageClass}
-                                </Typography>
-                                {message.message != null && (
-                                    <Box sx={{mt: 1.5}}>
-                                        <Typography
-                                            sx={{fontSize: '11px', fontWeight: 600, color: 'text.disabled', mb: 0.5}}
-                                        >
-                                            Message Data
-                                        </Typography>
-                                        <JsonRenderer value={message.message} />
-                                    </Box>
-                                )}
-                            </DetailBox>
-                        </Collapse>
+                                sx={{height: 28}}
+                            >
+                                <ToggleButton value="flat" sx={{fontSize: '11px', px: 1.5, textTransform: 'none'}}>
+                                    All
+                                </ToggleButton>
+                                <ToggleButton value="grouped" sx={{fontSize: '11px', px: 1.5, textTransform: 'none'}}>
+                                    <Tooltip title="Show duplicate messages (N+1)" placement="top">
+                                        <Box sx={{display: 'flex', alignItems: 'center', gap: 0.5}}>
+                                            Duplicates
+                                            <Chip
+                                                label={duplicates.groups.length}
+                                                size="small"
+                                                color="warning"
+                                                sx={{fontSize: '10px', height: 18, minWidth: 20, borderRadius: 1}}
+                                            />
+                                        </Box>
+                                    </Tooltip>
+                                </ToggleButton>
+                            </ToggleButtonGroup>
+                        )}
+                        <FilterInput value={filter} onChange={setFilter} placeholder="Filter messages..." />
                     </Box>
-                );
-            })}
+                }
+            >
+                {`${filtered.length} messages`}
+                {hasDuplicates && (
+                    <Chip
+                        label={`N+1`}
+                        size="small"
+                        color="warning"
+                        sx={{fontSize: '10px', height: 18, borderRadius: 1, ml: 1}}
+                    />
+                )}
+            </SectionTitle>
+            {viewMode === 'grouped' && groupedView
+                ? groupedView.map((group) => (
+                      <DuplicateMessageGroup
+                          key={group.key}
+                          group={group}
+                          messages={messages}
+                          expandedIndex={expandedIndex}
+                          onToggleExpand={setExpandedIndex}
+                      />
+                  ))
+                : filtered.map((message, index) => (
+                      <MessageItem
+                          key={index}
+                          message={message}
+                          expanded={expandedIndex === index}
+                          onToggle={() => setExpandedIndex(expandedIndex === index ? null : index)}
+                      />
+                  ))}
         </Box>
     );
 };
@@ -450,7 +595,12 @@ export const QueuePanel = ({data}: QueuePanelProps) => {
 
     // Only messages — render directly without tabs
     if (hasMessages && !hasQueueOps) {
-        return <MessagesView messages={data.messages ?? []} />;
+        return (
+            <MessagesView
+                messages={data.messages ?? []}
+                duplicates={data.duplicates ?? {groups: [], totalDuplicatedCount: 0}}
+            />
+        );
     }
 
     // Only queue ops — render queue tabs without messages tab
@@ -560,7 +710,10 @@ const QueueTabsView = ({
                 </Box>
                 {showMessages && (
                     <TabPanel value="messages" sx={{padding: 0}}>
-                        <MessagesView messages={data.messages ?? []} />
+                        <MessagesView
+                            messages={data.messages ?? []}
+                            duplicates={data.duplicates ?? {groups: [], totalDuplicatedCount: 0}}
+                        />
                     </TabPanel>
                 )}
                 <TabPanel value="pushes" sx={{padding: 0}}>

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/WebViewPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/WebViewPanel.tsx
@@ -3,12 +3,24 @@ import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
 import {primitives} from '@app-dev-panel/sdk/Component/Theme/tokens';
-import {Box, Chip, Collapse, Icon, IconButton, Typography} from '@mui/material';
+import {
+    Box,
+    Chip,
+    Collapse,
+    Icon,
+    IconButton,
+    ToggleButton,
+    ToggleButtonGroup,
+    Tooltip,
+    Typography,
+} from '@mui/material';
 import {styled} from '@mui/material/styles';
-import {useDeferredValue, useState} from 'react';
+import {useDeferredValue, useMemo, useState} from 'react';
 
 type WebViewEntry = {output: string; file: string; parameters: any[]};
-type WebViewPanelProps = {data: WebViewEntry[]};
+type DuplicateGroup = {key: string; count: number; indices: number[]};
+type DuplicatesData = {groups: DuplicateGroup[]; totalDuplicatedCount: number};
+type WebViewPanelProps = {data: WebViewEntry[] | {renders: WebViewEntry[]; duplicates: DuplicatesData}};
 
 const OUTPUT_PREVIEW_LENGTH = 300;
 
@@ -21,6 +33,13 @@ function dirname(filePath: string): string {
     const parts = filePath.replace(/\\/g, '/').split('/');
     parts.pop();
     return parts.join('/');
+}
+
+function normalizeData(data: WebViewPanelProps['data']): {renders: WebViewEntry[]; duplicates: DuplicatesData} {
+    if (Array.isArray(data)) {
+        return {renders: data, duplicates: {groups: [], totalDuplicatedCount: 0}};
+    }
+    return data;
 }
 
 const ViewRow = styled(Box, {shouldForwardProp: (p) => p !== 'expanded'})<{expanded?: boolean}>(
@@ -52,19 +71,128 @@ const OutputPreview = styled(Typography)({
     lineHeight: 1.5,
 });
 
+const GroupHeader = styled(Box)(({theme}) => ({
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(1, 1.5),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    cursor: 'pointer',
+    transition: 'background-color 0.1s ease',
+    backgroundColor: theme.palette.action.selected,
+    '&:hover': {backgroundColor: theme.palette.action.hover},
+}));
+
+const RenderItem = ({
+    entry,
+    index,
+    expanded,
+    showFullOutput,
+    onToggle,
+    onToggleFullOutput,
+}: {
+    entry: WebViewEntry;
+    index: number;
+    expanded: boolean;
+    showFullOutput: boolean;
+    onToggle: () => void;
+    onToggleFullOutput: (index: number) => void;
+}) => {
+    const isTruncated = entry.output.length > OUTPUT_PREVIEW_LENGTH;
+    return (
+        <Box key={index}>
+            <ViewRow expanded={expanded} onClick={onToggle}>
+                <Box sx={{flex: 1, minWidth: 0}}>
+                    <Typography sx={{fontFamily: primitives.fontFamilyMono, fontSize: '13px', fontWeight: 500}}>
+                        {basename(entry.file)}
+                    </Typography>
+                    <Typography sx={{fontFamily: primitives.fontFamilyMono, fontSize: '10px', color: 'text.disabled'}}>
+                        {dirname(entry.file)}
+                    </Typography>
+                </Box>
+                {entry.parameters.length > 0 && (
+                    <Chip
+                        label={`${entry.parameters.length} param${entry.parameters.length !== 1 ? 's' : ''}`}
+                        size="small"
+                        variant="outlined"
+                        sx={{fontSize: '10px', height: 20, borderRadius: 1, flexShrink: 0}}
+                    />
+                )}
+                <IconButton size="small" sx={{flexShrink: 0}}>
+                    <Icon sx={{fontSize: 16}}>{expanded ? 'expand_less' : 'expand_more'}</Icon>
+                </IconButton>
+            </ViewRow>
+            <Collapse in={expanded}>
+                <DetailBox>
+                    {entry.output && (
+                        <Box sx={{mb: 1.5}}>
+                            <Typography sx={{fontSize: '11px', fontWeight: 600, color: 'text.disabled', mb: 0.5}}>
+                                Output
+                            </Typography>
+                            <OutputPreview sx={{color: 'text.secondary'}}>
+                                {showFullOutput || !isTruncated
+                                    ? entry.output
+                                    : entry.output.substring(0, OUTPUT_PREVIEW_LENGTH) + '...'}
+                            </OutputPreview>
+                            {isTruncated && (
+                                <Typography
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onToggleFullOutput(index);
+                                    }}
+                                    sx={{
+                                        fontSize: '11px',
+                                        color: 'primary.main',
+                                        cursor: 'pointer',
+                                        mt: 0.5,
+                                        '&:hover': {textDecoration: 'underline'},
+                                    }}
+                                >
+                                    {showFullOutput ? 'Show less' : 'Show more'}
+                                </Typography>
+                            )}
+                        </Box>
+                    )}
+                    {entry.parameters.length > 0 && (
+                        <Box>
+                            <Typography sx={{fontSize: '11px', fontWeight: 600, color: 'text.disabled', mb: 0.5}}>
+                                Parameters
+                            </Typography>
+                            <JsonRenderer value={entry.parameters} />
+                        </Box>
+                    )}
+                </DetailBox>
+            </Collapse>
+        </Box>
+    );
+};
+
 export const WebViewPanel = ({data}: WebViewPanelProps) => {
+    const {renders, duplicates} = normalizeData(data);
     const [filter, setFilter] = useState('');
     const deferredFilter = useDeferredValue(filter);
     const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
     const [showFullOutput, setShowFullOutput] = useState<Set<number>>(new Set());
+    const [viewMode, setViewMode] = useState<'flat' | 'grouped'>('flat');
 
-    if (!data || data.length === 0) {
+    const hasDuplicates = duplicates.groups.length > 0;
+
+    const filtered = useMemo(() => {
+        if (!deferredFilter) return renders;
+        return renders.filter((entry) => entry.file.toLowerCase().includes(deferredFilter.toLowerCase()));
+    }, [renders, deferredFilter]);
+
+    const groupedView = useMemo(() => {
+        if (!hasDuplicates || viewMode !== 'grouped') return null;
+        const filterLower = deferredFilter.toLowerCase();
+        return duplicates.groups
+            .filter((group) => !deferredFilter || group.key.toLowerCase().includes(filterLower))
+            .map((group) => ({...group, items: group.indices.map((i) => renders[i]).filter(Boolean)}));
+    }, [hasDuplicates, viewMode, duplicates.groups, renders, deferredFilter]);
+
+    if (!renders || renders.length === 0) {
         return <EmptyState icon="web" title="No WebView renders found" />;
     }
-
-    const filtered = deferredFilter
-        ? data.filter((entry) => entry.file.toLowerCase().includes(deferredFilter.toLowerCase()))
-        : data;
 
     const toggleFullOutput = (index: number) => {
         setShowFullOutput((prev) => {
@@ -81,92 +209,133 @@ export const WebViewPanel = ({data}: WebViewPanelProps) => {
     return (
         <Box>
             <SectionTitle
-                action={<FilterInput value={filter} onChange={setFilter} placeholder="Filter files..." />}
-            >{`${filtered.length} renders`}</SectionTitle>
-
-            {filtered.map((entry, index) => {
-                const expanded = expandedIndex === index;
-                const isTruncated = entry.output.length > OUTPUT_PREVIEW_LENGTH;
-                const showFull = showFullOutput.has(index);
-                return (
-                    <Box key={index}>
-                        <ViewRow expanded={expanded} onClick={() => setExpandedIndex(expanded ? null : index)}>
-                            <Box sx={{flex: 1, minWidth: 0}}>
-                                <Typography
-                                    sx={{fontFamily: primitives.fontFamilyMono, fontSize: '13px', fontWeight: 500}}
-                                >
-                                    {basename(entry.file)}
-                                </Typography>
-                                <Typography
-                                    sx={{
-                                        fontFamily: primitives.fontFamilyMono,
-                                        fontSize: '10px',
-                                        color: 'text.disabled',
-                                    }}
-                                >
-                                    {dirname(entry.file)}
-                                </Typography>
-                            </Box>
-                            {entry.parameters.length > 0 && (
-                                <Chip
-                                    label={`${entry.parameters.length} param${entry.parameters.length !== 1 ? 's' : ''}`}
-                                    size="small"
-                                    variant="outlined"
-                                    sx={{fontSize: '10px', height: 20, borderRadius: 1, flexShrink: 0}}
-                                />
-                            )}
-                            <IconButton size="small" sx={{flexShrink: 0}}>
-                                <Icon sx={{fontSize: 16}}>{expanded ? 'expand_less' : 'expand_more'}</Icon>
-                            </IconButton>
-                        </ViewRow>
-                        <Collapse in={expanded}>
-                            <DetailBox>
-                                {entry.output && (
-                                    <Box sx={{mb: 1.5}}>
-                                        <Typography
-                                            sx={{fontSize: '11px', fontWeight: 600, color: 'text.disabled', mb: 0.5}}
-                                        >
-                                            Output
-                                        </Typography>
-                                        <OutputPreview sx={{color: 'text.secondary'}}>
-                                            {showFull || !isTruncated
-                                                ? entry.output
-                                                : entry.output.substring(0, OUTPUT_PREVIEW_LENGTH) + '...'}
-                                        </OutputPreview>
-                                        {isTruncated && (
-                                            <Typography
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    toggleFullOutput(index);
-                                                }}
-                                                sx={{
-                                                    fontSize: '11px',
-                                                    color: 'primary.main',
-                                                    cursor: 'pointer',
-                                                    mt: 0.5,
-                                                    '&:hover': {textDecoration: 'underline'},
-                                                }}
-                                            >
-                                                {showFull ? 'Show less' : 'Show more'}
-                                            </Typography>
-                                        )}
-                                    </Box>
-                                )}
-                                {entry.parameters.length > 0 && (
-                                    <Box>
-                                        <Typography
-                                            sx={{fontSize: '11px', fontWeight: 600, color: 'text.disabled', mb: 0.5}}
-                                        >
-                                            Parameters
-                                        </Typography>
-                                        <JsonRenderer value={entry.parameters} />
-                                    </Box>
-                                )}
-                            </DetailBox>
-                        </Collapse>
+                action={
+                    <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
+                        {hasDuplicates && (
+                            <ToggleButtonGroup
+                                value={viewMode}
+                                exclusive
+                                onChange={(_e, value) => value && setViewMode(value)}
+                                size="small"
+                                sx={{height: 28}}
+                            >
+                                <ToggleButton value="flat" sx={{fontSize: '11px', px: 1.5, textTransform: 'none'}}>
+                                    All
+                                </ToggleButton>
+                                <ToggleButton value="grouped" sx={{fontSize: '11px', px: 1.5, textTransform: 'none'}}>
+                                    <Tooltip title="Show duplicate renders (N+1)" placement="top">
+                                        <Box sx={{display: 'flex', alignItems: 'center', gap: 0.5}}>
+                                            Duplicates
+                                            <Chip
+                                                label={duplicates.groups.length}
+                                                size="small"
+                                                color="warning"
+                                                sx={{fontSize: '10px', height: 18, minWidth: 20, borderRadius: 1}}
+                                            />
+                                        </Box>
+                                    </Tooltip>
+                                </ToggleButton>
+                            </ToggleButtonGroup>
+                        )}
+                        <FilterInput value={filter} onChange={setFilter} placeholder="Filter files..." />
                     </Box>
-                );
-            })}
+                }
+            >
+                {`${filtered.length} renders`}
+                {hasDuplicates && (
+                    <Chip
+                        label={`N+1`}
+                        size="small"
+                        color="warning"
+                        sx={{fontSize: '10px', height: 18, borderRadius: 1, ml: 1}}
+                    />
+                )}
+            </SectionTitle>
+
+            {viewMode === 'grouped' && groupedView
+                ? groupedView.map((group) => (
+                      <DuplicateGroupView
+                          key={group.key}
+                          group={group}
+                          renders={renders}
+                          expandedIndex={expandedIndex}
+                          showFullOutput={showFullOutput}
+                          onToggleExpand={setExpandedIndex}
+                          onToggleFullOutput={toggleFullOutput}
+                      />
+                  ))
+                : filtered.map((entry, index) => (
+                      <RenderItem
+                          key={index}
+                          entry={entry}
+                          index={index}
+                          expanded={expandedIndex === index}
+                          showFullOutput={showFullOutput.has(index)}
+                          onToggle={() => setExpandedIndex(expandedIndex === index ? null : index)}
+                          onToggleFullOutput={toggleFullOutput}
+                      />
+                  ))}
+        </Box>
+    );
+};
+
+const DuplicateGroupView = ({
+    group,
+    renders,
+    expandedIndex,
+    showFullOutput,
+    onToggleExpand,
+    onToggleFullOutput,
+}: {
+    group: DuplicateGroup & {items: WebViewEntry[]};
+    renders: WebViewEntry[];
+    expandedIndex: number | null;
+    showFullOutput: Set<number>;
+    onToggleExpand: (index: number | null) => void;
+    onToggleFullOutput: (index: number) => void;
+}) => {
+    const [expanded, setExpanded] = useState(false);
+
+    return (
+        <Box>
+            <GroupHeader onClick={() => setExpanded(!expanded)}>
+                <Box sx={{flex: 1, minWidth: 0}}>
+                    <Typography sx={{fontFamily: primitives.fontFamilyMono, fontSize: '13px', fontWeight: 500}}>
+                        {basename(group.key)}
+                    </Typography>
+                    <Typography sx={{fontFamily: primitives.fontFamilyMono, fontSize: '10px', color: 'text.disabled'}}>
+                        {dirname(group.key)}
+                    </Typography>
+                </Box>
+                <Chip
+                    label={`${group.count}x`}
+                    size="small"
+                    color="warning"
+                    sx={{fontWeight: 700, fontSize: '11px', height: 22, borderRadius: 1, flexShrink: 0}}
+                />
+                <IconButton size="small" sx={{flexShrink: 0}}>
+                    <Icon sx={{fontSize: 16}}>{expanded ? 'expand_less' : 'expand_more'}</Icon>
+                </IconButton>
+            </GroupHeader>
+            <Collapse in={expanded}>
+                <Box sx={{pl: 2}}>
+                    {group.indices.map((originalIndex) => {
+                        const entry = renders[originalIndex];
+                        if (!entry) return null;
+                        return (
+                            <RenderItem
+                                key={originalIndex}
+                                entry={entry}
+                                index={originalIndex}
+                                expanded={expandedIndex === originalIndex}
+                                showFullOutput={showFullOutput.has(originalIndex)}
+                                onToggle={() => onToggleExpand(expandedIndex === originalIndex ? null : originalIndex)}
+                                onToggleFullOutput={onToggleFullOutput}
+                            />
+                        );
+                    })}
+                </Box>
+            </Collapse>
         </Box>
     );
 };

--- a/libs/frontend/packages/panel/src/Module/Debug/Pages/ListPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Pages/ListPage.tsx
@@ -72,6 +72,14 @@ const StatLabel = styled(Typography)({fontFamily: primitives.fontFamilyMono, fon
 // Helpers
 // ---------------------------------------------------------------------------
 
+const hasN1Indicator = (entry: DebugEntry): boolean => {
+    return (
+        (entry.db?.duplicateGroups ?? 0) > 0 ||
+        (entry.view?.duplicateGroups ?? 0) > 0 ||
+        (entry.queue?.duplicateGroups ?? 0) > 0
+    );
+};
+
 const methodColor = (method: string, theme: Theme): string => {
     switch (method.toUpperCase()) {
         case 'GET':
@@ -201,6 +209,23 @@ export const ListPage = () => {
                                     </StatLabel>
                                 </StatCell>
                             )}
+                            {hasN1Indicator(entry) && (
+                                <Tooltip title="Duplicate operations detected (N+1)">
+                                    <Chip
+                                        label="N+1"
+                                        size="small"
+                                        color="warning"
+                                        sx={{
+                                            fontWeight: 700,
+                                            fontSize: '9px',
+                                            height: 18,
+                                            minWidth: 32,
+                                            borderRadius: 1,
+                                            flexShrink: 0,
+                                        }}
+                                    />
+                                </Tooltip>
+                            )}
                             {entry.exception && (
                                 <Tooltip title={entry.exception.message}>
                                     <Icon sx={{fontSize: 15, color: 'error.main'}}>error</Icon>
@@ -240,6 +265,23 @@ export const ListPage = () => {
                                     <Icon sx={{fontSize: 13, color: 'text.disabled'}}>description</Icon>
                                     <StatLabel sx={{color: 'text.disabled'}}>{entry.logger.total}</StatLabel>
                                 </StatCell>
+                            )}
+                            {hasN1Indicator(entry) && (
+                                <Tooltip title="Duplicate operations detected (N+1)">
+                                    <Chip
+                                        label="N+1"
+                                        size="small"
+                                        color="warning"
+                                        sx={{
+                                            fontWeight: 700,
+                                            fontSize: '9px',
+                                            height: 18,
+                                            minWidth: 32,
+                                            borderRadius: 1,
+                                            flexShrink: 0,
+                                        }}
+                                    />
+                                </Tooltip>
                             )}
                             <StatusChip
                                 label={exitOk ? 'OK' : `EXIT ${entry.command?.exitCode}`}

--- a/libs/frontend/packages/sdk/src/API/Debug/Debug.ts
+++ b/libs/frontend/packages/sdk/src/API/Debug/Debug.ts
@@ -17,7 +17,13 @@ export type DebugEntry = {
     timeline?: {total: number};
     'var-dumper'?: {total: number};
     validator?: {total: number; valid: number; invalid: number};
-    queue?: {countPushes: number; countStatuses: number; countProcessingMessages: number};
+    queue?: {
+        countPushes: number;
+        countStatuses: number;
+        countProcessingMessages: number;
+        duplicateGroups?: number;
+        totalDuplicatedCount?: number;
+    };
     http?: {count: number; totalTime: number};
     fs_stream?: {read?: number; write?: number; mkdir?: number};
     http_stream?: [];
@@ -40,7 +46,12 @@ export type DebugEntry = {
     middleware?: {total: number};
     asset?: {bundles: {total: number}};
     exception?: {class: string; message: string; line: string; file: string; code: string};
-    db?: {queries: {error: number; total: number}; transactions: {error: number; total: number}};
+    db?: {
+        queries: {error: number; total: number};
+        transactions: {error: number; total: number};
+        duplicateGroups?: number;
+        totalDuplicatedCount?: number;
+    };
     [name: string]: any;
 };
 type SummaryResponseType = {data: DebugEntry[]};


### PR DESCRIPTION
## Summary

- Add `DuplicateDetectionTrait` shared by `ViewCollector`, `DatabaseCollector`, and `QueueCollector` to detect repeated operations (threshold > 2 occurrences)
- Each collector includes duplicate group data in `getCollected()` and summary counts (`duplicateGroups`, `totalDuplicatedCount`) in `getSummary()`
- Frontend panels (`WebViewPanel`, `DatabasePanel`, `QueuePanel`) gain an **All / Duplicates** toggle button that groups identical operations with `Nx` count badges
- `ListPage` shows an **N+1** warning chip on debug entries with detected duplicates
- Grouping keys: views by file path, SQL by `rawSql` (fallback to `sql`), queue messages by `messageClass`

## Test plan

- [x] All 831 PHP tests pass (including updated `ViewCollectorTest` and `DatabaseCollectorTest`)
- [x] All 407 frontend tests pass
- [x] Mago checks pass (format + lint + analyze)
- [x] Prettier + ESLint pass (0 errors)
- [ ] Manual test: verify N+1 badge appears in entry list when duplicate operations exist
- [ ] Manual test: verify Duplicates toggle groups items correctly in each panel
- [ ] Manual test: verify backward compatibility with old data format (ViewCollector flat array)

https://claude.ai/code/session_01AUZJEHZbfnCooZN3LT2aRD