### PR TITLE
Add git branch and commit hash to EnvironmentCollector

### DIFF
--- a/libs/Kernel/src/Collector/EnvironmentCollector.php
+++ b/libs/Kernel/src/Collector/EnvironmentCollector.php
@@ -36,6 +36,7 @@ final class EnvironmentCollector implements SummaryCollectorInterface
         return [
             'php' => $this->collectPhpInfo(),
             'os' => $this->collectOsInfo(),
+            'git' => $this->collectGitInfo(),
             'server' => $this->serverParams,
             'env' => $this->envVars,
         ];
@@ -75,6 +76,8 @@ final class EnvironmentCollector implements SummaryCollectorInterface
             return [];
         }
 
+        $gitInfo = $this->collectGitInfo();
+
         return [
             'environment' => [
                 'php' => [
@@ -82,6 +85,10 @@ final class EnvironmentCollector implements SummaryCollectorInterface
                     'sapi' => PHP_SAPI,
                 ],
                 'os' => PHP_OS_FAMILY,
+                'git' => [
+                    'branch' => $gitInfo['branch'],
+                    'commit' => $gitInfo['commit'],
+                ],
             ],
         ];
     }
@@ -150,6 +157,48 @@ final class EnvironmentCollector implements SummaryCollectorInterface
             'uname' => php_uname(),
             'hostname' => gethostname() ?: null,
         ];
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private function collectGitInfo(): array
+    {
+        $cwd = getcwd() ?: null;
+
+        return [
+            'branch' => $this->runGitCommand('git rev-parse --abbrev-ref HEAD', $cwd),
+            'commit' => $this->runGitCommand('git rev-parse --short HEAD', $cwd),
+            'commitFull' => $this->runGitCommand('git rev-parse HEAD', $cwd),
+        ];
+    }
+
+    private function runGitCommand(string $command, ?string $cwd): ?string
+    {
+        $descriptors = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open($command, $descriptors, $pipes, $cwd);
+
+        if (!is_resource($process)) {
+            return null;
+        }
+
+        $output = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $exitCode = proc_close($process);
+
+        if ($exitCode !== 0 || $output === false) {
+            return null;
+        }
+
+        $result = trim($output);
+
+        return $result !== '' ? $result : null;
     }
 
     /**

--- a/libs/Kernel/tests/Unit/Collector/EnvironmentCollectorTest.php
+++ b/libs/Kernel/tests/Unit/Collector/EnvironmentCollectorTest.php
@@ -38,8 +38,14 @@ final class EnvironmentCollectorTest extends AbstractCollectorTestCase
 
         $this->assertArrayHasKey('php', $data);
         $this->assertArrayHasKey('os', $data);
+        $this->assertArrayHasKey('git', $data);
         $this->assertArrayHasKey('server', $data);
         $this->assertArrayHasKey('env', $data);
+
+        $git = $data['git'];
+        $this->assertArrayHasKey('branch', $git);
+        $this->assertArrayHasKey('commit', $git);
+        $this->assertArrayHasKey('commitFull', $git);
 
         $php = $data['php'];
         $this->assertSame(PHP_VERSION, $php['version']);

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EnvironmentPanel.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EnvironmentPanel.test.tsx
@@ -27,7 +27,15 @@ type PhpInfo = {
 
 type OsInfo = {family: string; name: string; uname: string; hostname: string | null};
 
-type EnvironmentData = {php: PhpInfo; os: OsInfo; server: Record<string, string>; env: Record<string, string>};
+type GitInfo = {branch: string | null; commit: string | null; commitFull: string | null};
+
+type EnvironmentData = {
+    php: PhpInfo;
+    os: OsInfo;
+    git: GitInfo;
+    server: Record<string, string>;
+    env: Record<string, string>;
+};
 
 const makePhpInfo = (overrides: Partial<PhpInfo> = {}): PhpInfo => ({
     version: '8.4.1',
@@ -59,9 +67,17 @@ const makeOsInfo = (overrides: Partial<OsInfo> = {}): OsInfo => ({
     ...overrides,
 });
 
+const makeGitInfo = (overrides: Partial<GitInfo> = {}): GitInfo => ({
+    branch: 'main',
+    commit: 'abc1234',
+    commitFull: 'abc1234567890abcdef1234567890abcdef123456',
+    ...overrides,
+});
+
 const makeEnvironmentData = (overrides: Partial<EnvironmentData> = {}): EnvironmentData => ({
     php: makePhpInfo(),
     os: makeOsInfo(),
+    git: makeGitInfo(),
     server: {SERVER_NAME: 'localhost', SERVER_PORT: '8080'},
     env: {APP_ENV: 'dev', APP_DEBUG: '1'},
     ...overrides,
@@ -153,5 +169,18 @@ describe('EnvironmentPanel', () => {
         renderWithProviders(<EnvironmentPanel data={data} />);
         expect(screen.getByText('Zend Extensions')).toBeInTheDocument();
         expect(screen.getByText('Zend OPcache')).toBeInTheDocument();
+    });
+
+    it('renders git info section with branch and commit', () => {
+        renderWithProviders(<EnvironmentPanel data={makeEnvironmentData()} />);
+        expect(screen.getByText('Git')).toBeInTheDocument();
+        expect(screen.getByText('main')).toBeInTheDocument();
+        expect(screen.getByText('abc1234567890abcdef1234567890abcdef123456')).toBeInTheDocument();
+    });
+
+    it('hides git section when git info is null', () => {
+        const data = makeEnvironmentData({git: makeGitInfo({branch: null, commit: null, commitFull: null})});
+        renderWithProviders(<EnvironmentPanel data={data} />);
+        expect(screen.queryByText('Git')).not.toBeInTheDocument();
     });
 });

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EnvironmentPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EnvironmentPanel.tsx
@@ -28,7 +28,15 @@ type PhpInfo = {
 
 type OsInfo = {family: string; name: string; uname: string; hostname: string | null};
 
-type EnvironmentData = {php: PhpInfo; os: OsInfo; server: Record<string, string>; env: Record<string, string>};
+type GitInfo = {branch: string | null; commit: string | null; commitFull: string | null};
+
+type EnvironmentData = {
+    php: PhpInfo;
+    os: OsInfo;
+    git: GitInfo;
+    server: Record<string, string>;
+    env: Record<string, string>;
+};
 
 type EnvironmentPanelProps = {data: EnvironmentData};
 
@@ -95,7 +103,7 @@ const KeyValueTable = ({entries, filter}: {entries: Array<{key: string; value: s
     );
 };
 
-const PhpTab = ({php, os}: {php: PhpInfo; os: OsInfo}) => {
+const PhpTab = ({php, os, git}: {php: PhpInfo; os: OsInfo; git: GitInfo}) => {
     const highlights: Array<{key: string; value: string}> = [
         {key: 'PHP Version', value: php.version},
         {key: 'SAPI', value: php.sapi},
@@ -111,6 +119,11 @@ const PhpTab = ({php, os}: {php: PhpInfo; os: OsInfo}) => {
         {key: 'Error Reporting', value: String(php.ini?.error_reporting ?? 'N/A')},
     ];
 
+    const gitEntries: Array<{key: string; value: string}> = [
+        {key: 'Branch', value: git?.branch || 'N/A'},
+        {key: 'Commit', value: git?.commitFull || 'N/A'},
+    ];
+
     const debugExtensions = [
         {name: 'Xdebug', version: php.xdebug},
         {name: 'OPcache', version: php.opcache},
@@ -121,6 +134,13 @@ const PhpTab = ({php, os}: {php: PhpInfo; os: OsInfo}) => {
         <TabPanel>
             <SectionTitle>Runtime</SectionTitle>
             <KeyValueTable entries={highlights} />
+
+            {(git?.branch || git?.commitFull) && (
+                <>
+                    <SectionTitle>Git</SectionTitle>
+                    <KeyValueTable entries={gitEntries} />
+                </>
+            )}
 
             <SectionTitle>Debug Extensions</SectionTitle>
             <Box sx={{display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2}}>
@@ -190,7 +210,7 @@ export const EnvironmentPanel = ({data}: EnvironmentPanelProps) => {
                 </Tabs>
             </Box>
 
-            {tab === 0 && <PhpTab php={data.php} os={data.os} />}
+            {tab === 0 && <PhpTab php={data.php} os={data.os} git={data.git} />}
             {tab === 1 && <DictTab title="Server Parameters" data={data.server} />}
             {tab === 2 && <DictTab title="Environment Variables" data={data.env} />}
         </Box>


### PR DESCRIPTION
## Summary\n\n- Add `git` section to `EnvironmentCollector` with branch name, short commit hash, and full commit hash\n- Git info is auto-detected from the app's working directory via `proc_open` — no adapter changes needed\n- Display git branch and commit in the frontend's PHP & OS tab under a new \"Git\" section (hidden when not in a git repo)\n- Include git branch + short commit in the summary data for quick display in entry lists\n\n## Changed files\n\n- `libs/Kernel/src/Collector/EnvironmentCollector.php` — `collectGitInfo()` + `runGitCommand()` methods, `git` key in `getCollected()` and `getSummary()`\n- `libs/Kernel/tests/Unit/Collector/EnvironmentCollectorTest.php` — assert `git` key in collected data\n- `libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EnvironmentPanel.tsx` — `GitInfo` type, Git section in PhpTab\n- `libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EnvironmentPanel.test.tsx` — 2 new tests for git rendering\n\n## Test plan\n\n- [x] PHP unit tests pass (8/8, including git key assertions)\n- [x] Frontend unit tests pass (14/14, including git section rendering + hiding)\n- [x] Mago format/lint/analyze clean\n- [x] Prettier formatting clean\n\nhttps://claude.ai/code/session_01PQYjvL6P2pssMzSdDDxyQg