### PR TITLE
Strengthen shadows and borders for menus/popovers

### DIFF
--- a/libs/frontend/packages/sdk/src/Component/Theme/DefaultTheme.tsx
+++ b/libs/frontend/packages/sdk/src/Component/Theme/DefaultTheme.tsx
@@ -34,10 +34,12 @@ export const createAdpTheme = (mode: PaletteMode, routerOptions: {openLinksInNew
         mode === 'dark' ? {...semanticTokens.palette, ...darkSemanticTokens.palette} : semanticTokens.palette;
 
     // Build MUI shadows array (25 entries required)
-    const shadows: [string, ...string[]] = ['none', ...Array(24).fill(semanticTokens.shadows.sm)] as [
+    // 0=none, 1=sm (cards), 2-3=md (popovers), 4+=lg (menus, dialogs)
+    const shadows: [string, ...string[]] = ['none', ...Array(24).fill(semanticTokens.shadows.lg)] as [
         string,
         ...string[],
     ];
+    shadows[1] = semanticTokens.shadows.sm;
     shadows[2] = semanticTokens.shadows.md;
     shadows[3] = semanticTokens.shadows.md;
 
@@ -68,6 +70,21 @@ export const createAdpTheme = (mode: PaletteMode, routerOptions: {openLinksInNew
             },
             MuiPaper: {
                 styleOverrides: {outlined: {borderColor: palette.divider, boxShadow: semanticTokens.shadows.sm}},
+            },
+            MuiMenu: {
+                styleOverrides: {
+                    paper: {border: `1px solid ${palette.divider}`, backgroundImage: 'none'},
+                },
+            },
+            MuiPopover: {
+                styleOverrides: {
+                    paper: {border: `1px solid ${palette.divider}`, backgroundImage: 'none'},
+                },
+            },
+            MuiAutocomplete: {
+                styleOverrides: {
+                    paper: {border: `1px solid ${palette.divider}`, backgroundImage: 'none'},
+                },
             },
             MuiButton: {styleOverrides: {root: {textTransform: 'none', fontWeight: 500}}},
         },

--- a/libs/frontend/packages/sdk/src/Component/Theme/tokens.ts
+++ b/libs/frontend/packages/sdk/src/Component/Theme/tokens.ts
@@ -74,7 +74,11 @@ export const semanticTokens = {
         },
     },
     shape: {borderRadius: primitives.radiusBase},
-    shadows: {sm: '0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)', md: '0 4px 12px rgba(0,0,0,0.08)'},
+    shadows: {
+        sm: '0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)',
+        md: '0 4px 12px rgba(0,0,0,0.08)',
+        lg: '0 8px 24px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.08)',
+    },
 } as const;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `lg` shadow token (`0 8px 24px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.08)`) for elevated surfaces
- Map MUI shadow levels 4+ to `lg` so Menu/Popover/Dialog get visible depth instead of the barely-visible `sm`
- Add `1px solid divider` border and `backgroundImage: none` to `MuiMenu`, `MuiPopover`, `MuiAutocomplete` globally via theme
- Fixes weak visual separation of dropdown menus (e.g. settings menu in TopBar)

## Test plan

- [x] Theme unit tests pass (`tokens.test.ts`, `DefaultTheme.test.tsx` — 27 tests)
- [ ] Visual check: open settings menu in TopBar — should have clear border and shadow
- [ ] Visual check: autocomplete dropdowns have consistent styling
- [ ] Visual check: dark mode — no `backgroundImage` gradient artifact on popover papers

https://claude.ai/code/session_01MbZP3B6usByYamXbHBPT22