### PR TITLE
Add expert skills and VitePress documentation site

### DIFF
--- a/.claude/skills/laravel-expert/SKILL.md
+++ b/.claude/skills/laravel-expert/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: laravel-expert
+description: Deep expertise in Laravel internals — service container, service providers, middleware, events, Telescope/DebugBar architecture, and all their limitations and hacks. Use when implementing or modifying the Laravel adapter, writing collectors, or debugging integration issues.
+argument-hint: "[task or question about Laravel internals]"
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Agent
+---
+
+# Laravel Expert
+
+Task: $ARGUMENTS
+
+You are a senior PHP backend developer with deep expertise in Laravel internals. You know every container binding, every event, every middleware hook. You understand Telescope and DebugBar inside-out — their architectures, limitations, and hacks. You write modern PHP 8.4+ code that integrates with Laravel cleanly.
+
+## Reference Documentation
+
+Read these before implementing:
+
+- **Laravel internals** (lifecycle, container, events, middleware, routing, DB, config, facades): `docs/internals.md`
+- **Debug tools** (Telescope architecture, DebugBar architecture, limitations, comparison with ADP): `docs/debug-tools.md`
+- **Best practices** (PHP 8.4+, service provider patterns, pitfalls, testing): `docs/best-practices.md`
+- **ADP Laravel adapter code**: `libs/Adapter/Laravel/src/`
+- **ADP Laravel adapter docs**: `libs/Adapter/Laravel/CLAUDE.md`
+- **Kernel collectors**: `libs/Kernel/src/Collector/`

--- a/.claude/skills/laravel-expert/docs/best-practices.md
+++ b/.claude/skills/laravel-expert/docs/best-practices.md
@@ -1,0 +1,165 @@
+# PHP 8.4+ Best Practices for Laravel Integration
+
+## Code Standards
+
+1. **`declare(strict_types=1)`** — always
+2. **`final` classes** — all new classes unless designed for extension
+3. **`readonly` properties** — for immutable state
+4. **Property hooks** (PHP 8.4) — for computed/validated properties
+5. **Named arguments** — for Laravel APIs with many optional params
+6. **Enums** — instead of class constants for finite value sets
+7. **Union/intersection types** — full type declarations, no `mixed` unless truly polymorphic
+8. **`#[Override]`** attribute — on all methods overriding parent/interface
+9. **First-class callables** — `$this->method(...)` over `[$this, 'method']`
+10. **`array_find()`**, **`array_any()`**, **`array_all()`** (PHP 8.4) — over manual loops
+
+## Architecture Patterns
+
+1. **Wrap, don't extend** — composition over inheriting Laravel base classes
+2. **PSR interfaces** — depend on PSR-3/7/11/14/15/17/18, not Illuminate contracts
+3. **Immutable DTOs** — `readonly class` for data between Laravel and Kernel layers
+4. **No Facades in new code** — inject dependencies via constructor
+5. **No `app()` helper** — pass dependencies explicitly
+6. **No `config()` helper in library code** — accept config values via constructor
+7. **Adapter pattern** — wrap Laravel services behind PSR interfaces for Kernel
+8. **No `@` error suppression**
+9. **No `extract()`/`compact()`**
+10. **Fiber-aware** — don't assume single-thread (Octane runs in long-lived process)
+
+## Service Provider Patterns
+
+### Correct Registration
+
+```php
+final class AppDevPanelServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        // ONLY bindings — no resolving
+        $this->mergeConfigFrom(__DIR__ . '/../config/app-dev-panel.php', 'app-dev-panel');
+
+        $this->app->singleton(StorageInterface::class, function ($app) {
+            $config = $app->make('config')->get('app-dev-panel.storage');
+            return new FileStorage($config['path'], $config['history_size']);
+        });
+    }
+
+    public function boot(): void
+    {
+        // Safe to resolve, register events, routes, middleware
+        $this->publishes([...], 'config');
+        $this->loadRoutesFrom(__DIR__ . '/../routes/adp.php');
+
+        // Decorate services
+        $this->app->extend(LoggerInterface::class, function ($logger, $app) {
+            return new LoggerInterfaceProxy($logger, $app->make(LogCollector::class));
+        });
+    }
+}
+```
+
+### Anti-Patterns
+
+```php
+// BAD: resolving in register()
+public function register(): void
+{
+    $debugger = $this->app->make(Debugger::class); // May not be bound yet!
+}
+
+// BAD: using Facade in library code
+use Illuminate\Support\Facades\Config;
+$path = Config::get('app-dev-panel.storage.path'); // Couples to Laravel
+
+// BAD: relying on boot() order
+public function boot(): void
+{
+    // Another provider's boot() may not have run yet
+    $otherService = $this->app->make(OtherPackageService::class); // May be unbooted
+}
+```
+
+## Event Listener Patterns
+
+### Correct
+
+```php
+// In boot()
+$events = $this->app->make(Dispatcher::class);
+$events->listen(QueryExecuted::class, function (QueryExecuted $event) use ($collector) {
+    $collector->logQuery(
+        $event->sql,
+        $event->bindings,
+        $event->time,
+        $event->connectionName,
+    );
+});
+```
+
+### Queued Listeners — When NOT to Use
+
+ADP collectors must capture data synchronously during the request. Never use `ShouldQueue` for debug data collection — data arrives after request is gone.
+
+## Middleware Patterns
+
+### Terminable Middleware for Debugger
+
+```php
+final class DebugMiddleware
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Convert to PSR-7, start debugger
+        $debugger->startup($context);
+        $response = $next($request);
+        // Capture response data
+        return $response;
+    }
+
+    public function terminate(Request $request, Response $response): void
+    {
+        // Flush to storage AFTER response sent
+        $debugger->shutdown();
+    }
+}
+```
+
+**Why terminate():** Flushing to storage is I/O. Doing it in `handle()` delays the response. `terminate()` runs after `$response->send()`.
+
+## Common Pitfalls
+
+| Pitfall | Why | Fix |
+|---------|-----|-----|
+| `extend()` in `register()` | Service may not exist yet | Call `extend()` in `boot()` |
+| `extend()` after resolution | Extender applies immediately, may miss | Ensure `extend()` before first `make()` |
+| Decorating `events` | Must wrap `Illuminate\Contracts\Events\Dispatcher`, not `Illuminate\Events\Dispatcher` | Check contract vs concrete |
+| CSRF on API routes | Laravel validates CSRF on web routes | Exclude debug API routes from `VerifyCsrfToken` |
+| Request body consumed | `php://input` read once | Cache raw body before middleware chain |
+| Octane compatibility | Singletons persist across requests | Use `scoped()` or reset state in `terminate()` |
+| Config caching | `config:cache` flattens all config | Always use `mergeConfigFrom()` in `register()` |
+| Route caching | `route:cache` skips closure routes | Use controller classes, not closures |
+| PSR-7 conversion | Laravel uses Symfony HttpFoundation internally | Use `nyholm/psr7` factories for conversion |
+| Multiple DB connections | `QueryExecuted` fires for all connections | Filter by `$event->connectionName` if needed |
+
+## Testing Laravel Integration
+
+- Use `Orchestra\Testbench` for package testing (but ADP uses inline mocks per project convention)
+- Mock `Application` container via `$this->createMock(Container::class)`
+- Mock `Config` via `$this->createMock(Repository::class)`
+- Test event listeners in isolation — instantiate listener, call method with mock event
+- Test middleware — call `handle()` with mock `Request` and `Closure`
+- Never use `artisan test` in library code — use `vendor/bin/phpunit`
+
+## Before Implementing
+
+1. Read the ADP Laravel adapter — `libs/Adapter/Laravel/src/`
+2. Read the Kernel collector interfaces — `libs/Kernel/src/Collector/`
+3. Read existing tests — `libs/Adapter/Laravel/tests/`
+4. Check Laravel source for the exact event/hook you need
+
+## After Implementing
+
+1. Run `make test-php` — all tests pass
+2. Run `make mago-fix` — formatting and lint clean
+3. Test against Laravel playground: `make fixtures-laravel`
+4. Verify no Laravel classes leak into Kernel or API modules

--- a/.claude/skills/laravel-expert/docs/debug-tools.md
+++ b/.claude/skills/laravel-expert/docs/debug-tools.md
@@ -1,0 +1,284 @@
+# Laravel Debug Tools — Telescope & DebugBar Internals
+
+## Laravel Telescope
+
+### Architecture
+
+```
+Telescope\TelescopeServiceProvider
+  ├── registers watchers (data collectors)
+  ├── registers storage driver (DatabaseEntriesRepository)
+  ├── registers routes (telescope/*)
+  └── registers assets (SPA frontend)
+
+Data flow:
+  Watcher → Telescope::record(IncomingEntry) → EntryRepository::store() → DB table
+```
+
+### Watcher System
+
+Each watcher is a self-contained data collector that listens to Laravel events:
+
+```php
+abstract class Watcher
+{
+    public function register($app): void;  // Subscribe to events
+    public array $options = [];            // From config/telescope.php
+}
+```
+
+**Built-in watchers:**
+
+| Watcher | Events/Hooks | Data |
+|---------|-------------|------|
+| `RequestWatcher` | `RequestHandled` event | URI, method, headers, payload, response, duration |
+| `QueryWatcher` | `QueryExecuted` event | SQL, bindings, time, connection, slow flag |
+| `ModelWatcher` | `ModelEvent` (created/updated/deleted) | Model class, key, changes |
+| `EventWatcher` | `EventDispatcher` proxy | Event name, payload, listeners |
+| `ExceptionWatcher` | `ExceptionHandler` | Exception class, message, trace, context |
+| `LogWatcher` | `MessageLogged` event | Level, message, context |
+| `MailWatcher` | `MessageSent` event | To, subject, body, attachments |
+| `NotificationWatcher` | `NotificationSent` event | Channel, notifiable, notification |
+| `CacheWatcher` | Cache events | Key, value, hit/miss, TTL |
+| `JobWatcher` | Queue events | Job class, connection, queue, status, duration |
+| `ScheduleWatcher` | `ScheduledTaskFinished` | Command, expression, output |
+| `CommandWatcher` | `CommandFinished` | Command name, arguments, exit code, output |
+| `RedisWatcher` | `CommandExecuted` (Redis) | Command, duration |
+| `GateWatcher` | `GateEvaluated` | Ability, result, user, arguments |
+| `ViewWatcher` | `ComposingView` event | View name, path, data |
+| `DumpWatcher` | `VarDumper::setHandler()` | Dump content with source file/line |
+| `ClientRequestWatcher` | HTTP client events | URL, method, headers, response |
+| `BatchWatcher` | Bus batch events | Batch ID, name, jobs count, progress |
+
+### Telescope::record() Pipeline
+
+```php
+Telescope::record(IncomingEntry $entry)
+  → check Telescope::$shouldRecord (master switch)
+  → apply Telescope::$tagUsing callbacks (auto-tagging)
+  → apply Telescope::$filterUsing callbacks (sampling, filtering)
+  → apply Telescope::$afterStoringHooks
+  → buffer entries in Telescope::$entriesQueue
+  → on terminate: Telescope::store($entriesRepository)
+    → EntryRepository::store(Collection $entries)
+    → store tags in telescope_entries_tags table
+```
+
+### Storage
+
+Default: `DatabaseEntriesRepository` with tables:
+- `telescope_entries` — main data (uuid, batch_id, type, content JSON, created_at)
+- `telescope_entries_tags` — many-to-many tags
+- `telescope_monitoring` — monitored tags for filtering
+
+### Limitations
+
+| Limitation | Details |
+|-----------|---------|
+| DB-only storage | No file storage, no Redis storage out of the box |
+| No real-time streaming | Polling only, no SSE/WebSocket |
+| SPA is Inertia/Vue | Tightly coupled to Vue + Tailwind |
+| Single app only | No cross-app debugging |
+| No PSR interfaces | Everything is Laravel-specific |
+| Heavy DB writes | Every request writes N rows (1 per watcher) |
+| No structured query data | SQL stored as string in JSON blob |
+| Authorization coupled | `TelescopeServiceProvider::gate()` + `viewTelescope` gate |
+| Pruning required | `telescope:prune` cron job or DB grows unbounded |
+| No timeline/waterfall | No cross-watcher timing correlation |
+
+### How ADP Differs from Telescope
+
+| Aspect | Telescope | ADP Laravel Adapter |
+|--------|-----------|---------------------|
+| Storage | Database (Eloquent) | JSON files (Kernel FileStorage) |
+| Transport | HTTP polling | SSE real-time + REST |
+| Frontend | Vue SPA (bundled) | React SPA (separate) |
+| Architecture | Monolithic watchers | Kernel collectors + adapter events |
+| Cross-framework | Laravel only | Any PHP framework |
+| Data format | JSON in DB column | Structured JSON files |
+| PSR compliance | None | PSR-3/7/14/18 proxies |
+| Extensibility | Custom Watcher class | CollectorInterface |
+
+## Laravel DebugBar (barryvdh/laravel-debugbar)
+
+### Architecture
+
+```
+DebugbarServiceProvider
+  ├── wraps DebugBar\DebugBar (maximebf/debugbar)
+  ├── registers DataCollectors
+  ├── registers middleware (InjectDebugbar)
+  └── renders HTML/JS toolbar in response
+
+Data flow:
+  DataCollector::collect() → DebugBar → JsonHttpDriver → inject into HTML response
+```
+
+### DataCollector System
+
+```php
+interface DataCollectorInterface
+{
+    public function collect(): array;    // Return collected data
+    public function getName(): string;   // Unique collector name
+}
+
+interface Renderable
+{
+    public function getWidgets(): array;  // Frontend widget definitions
+}
+```
+
+**Built-in collectors:**
+
+| Collector | Source | Data |
+|-----------|-------|------|
+| `PhpInfoCollector` | `phpinfo()` | PHP version |
+| `MessagesCollector` | `Debugbar::info()` etc. | Log messages |
+| `TimeDataCollector` | `Debugbar::startMeasure()` | Timing measurements |
+| `MemoryCollector` | `memory_get_peak_usage()` | Memory usage |
+| `ExceptionsCollector` | Exception handler | Caught exceptions |
+| `QueryCollector` | DB `QueryExecuted` event | SQL queries, bindings, time, backtrace |
+| `RouteCollector` | `Router::current()` | Current route, controller, middleware |
+| `ViewCollector` | `View::composer('*')` | Rendered views, data passed |
+| `EventCollector` | `Event::listen('*')` | Dispatched events |
+| `LaravelCollector` | `App::version()` | Laravel/PHP version |
+| `SymfonyRequestCollector` | Symfony Request/Response | Headers, cookies, session, server vars |
+| `LogsCollector` | Log files | Last N lines from `storage/logs` |
+| `FilesCollector` | `get_included_files()` | All included PHP files |
+| `ConfigCollector` | `Config::all()` | Application config |
+| `CacheCollector` | Cache events | Cache operations |
+| `ModelCollector` | Eloquent model events | Model hydrations, duplicates |
+| `GateCollector` | Gate checks | Authorization checks |
+| `MultiAuthCollector` | Auth guards | Current user per guard |
+| `SessionCollector` | Session data | Session contents |
+
+### Injection Mechanism
+
+```
+InjectDebugbar middleware (runs last)
+  → $debugbar->collect()  // Calls all collectors
+  → $debugbar->modifyResponse($request, $response)
+    → if HTML response:
+      → inject <script>/<link> tags before </head>
+      → inject toolbar HTML before </body>
+    → if AJAX:
+      → add X-DebugBar headers with data URL
+      → store data in OpenHandler for later fetch
+```
+
+### Limitations
+
+| Limitation | Details |
+|-----------|---------|
+| HTML injection only | Modifies response body — breaks non-HTML, streaming, binary |
+| No standalone UI | Toolbar embedded in page, no separate SPA |
+| No persistence | Data per-request only (OpenHandler for AJAX) |
+| No console support | Web requests only |
+| No SSE/streaming | No real-time updates |
+| jQuery dependency | Frontend relies on jQuery |
+| Performance overhead | All collectors run on every request |
+| No structured storage | Data serialized to response, not stored |
+| CORS issues | AJAX data fetch fails cross-origin |
+
+### How ADP Differs from DebugBar
+
+| Aspect | DebugBar | ADP Laravel Adapter |
+|--------|----------|---------------------|
+| UI delivery | Injected HTML toolbar | Separate React SPA |
+| Data transport | Response injection / AJAX headers | REST API + SSE |
+| Persistence | None (per-request) | JSON file storage |
+| Console support | No | Yes (ConsoleListener) |
+| Architecture | maximebf/debugbar DataCollectors | Kernel collectors + PSR proxies |
+| Dependencies | jQuery, PHP Debug Bar lib | None (standalone Kernel) |
+| Cross-framework | Laravel wrapper only | Any PHP framework |
+
+## Database Layer
+
+### Query Events
+
+```php
+// Laravel fires QueryExecuted for every query
+DB::listen(function (QueryExecuted $query) {
+    $query->sql;          // "select * from users where id = ?"
+    $query->bindings;     // [1]
+    $query->time;         // 3.45 (ms)
+    $query->connection;   // Illuminate\Database\Connection instance
+    $query->connectionName; // 'mysql'
+});
+```
+
+**Internals:** `Connection::run()` wraps every query in timing + event dispatch:
+
+```
+Connection::select($query, $bindings)
+  → run($query, $bindings, function () { PDO::execute() })
+    → start timer
+    → PDO::prepare() → execute()
+    → stop timer
+    → event(new QueryExecuted($sql, $bindings, $time, $this))
+    → log to $this->queryLog if enabled
+```
+
+### Schema Inspection
+
+```php
+$schema = Schema::connection('mysql');
+
+$schema->getTables();        // [{name, schema, size, comment, engine, collation}]
+$schema->getColumns('users'); // [{name, type, nullable, default, ...}]
+$schema->getIndexes('users'); // [{name, columns, type, unique, primary}]
+$schema->getForeignKeys('users'); // [{name, columns, foreign_schema, foreign_table, ...}]
+```
+
+**ADP uses:** `Illuminate\Database\Connection` for `LaravelSchemaProvider` — wraps this in `SchemaProviderInterface`.
+
+## Config System
+
+```php
+// Config is a Repository wrapping nested array
+$config = config('app.debug');              // dot-notation access
+$config = Config::get('database.default');  // Facade
+
+// Internals
+Illuminate\Config\Repository
+  $items = [                  // Loaded from config/*.php files
+      'app' => ['name' => 'ADP', 'debug' => true, ...],
+      'database' => ['default' => 'mysql', ...],
+      ...
+  ];
+```
+
+**Config loading:**
+1. `LoadConfiguration` bootstrapper reads all `config/*.php` files
+2. Cached in `bootstrap/cache/config.php` (production)
+3. Package configs published via `ServiceProvider::mergeConfigFrom()`
+
+**ADP config:** `config/app-dev-panel.php` — published via `AppDevPanelServiceProvider`:
+```php
+$this->publishes([
+    __DIR__ . '/../config/app-dev-panel.php' => config_path('app-dev-panel.php'),
+], 'config');
+```
+
+## Facade System
+
+```php
+// Facade is a static proxy to a container binding
+class Cache extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'cache';  // Resolves $app['cache']
+    }
+}
+
+Cache::get('key');
+// Actually: $app->make('cache')->get('key')
+```
+
+**Internals:** `Facade::__callStatic()` → `static::getFacadeRoot()` → `$app->make($accessor)` → forward method call.
+
+**Real-time facades:** `use Facades\App\Services\Foo;` — auto-generates facade for any class.
+
+**Gotcha for ADP:** If you decorate a service via `extend()`, facades automatically use the decorated version (since they resolve from container).

--- a/.claude/skills/laravel-expert/docs/internals.md
+++ b/.claude/skills/laravel-expert/docs/internals.md
@@ -1,0 +1,291 @@
+# Laravel Internals Deep Dive
+
+## Application Lifecycle
+
+```
+public/index.php
+  → require bootstrap/app.php
+    → Application::__construct($basePath)
+      → registerBaseBindings()        # $app, Container::class, PackageManifest
+      → registerBaseServiceProviders() # EventServiceProvider, LogServiceProvider, RoutingServiceProvider
+      → registerCoreContainerAliases() # 100+ aliases (app, auth, cache, config, db, etc.)
+  → $app->handleRequest(Request::capture())
+    → bootstrap()                     # LoadEnvironmentVariables, LoadConfiguration, HandleExceptions,
+                                      # RegisterFacades, RegisterProviders, BootProviders
+    → Pipeline::send($request)->through($middleware)->then(dispatchToRouter)
+      → Global middleware (TrustProxies, CORS, ValidateCsrfToken, etc.)
+      → Router::dispatch($request)
+        → findRoute($request)         # Match URI + method against compiled RouteCollection
+        → runRoute($request, $route)
+          → Route middleware pipeline
+          → Controller::callAction($method, $params)
+      → Response preparation
+    → terminate($request, $response)  # Terminable middleware, service provider terminate()
+```
+
+## Service Container (Illuminate\Container\Container)
+
+Laravel's DI container is the most powerful in PHP ecosystem.
+
+### Binding Types
+
+```php
+// Simple binding — new instance each time
+$app->bind(InterfaceA::class, ConcreteA::class);
+$app->bind('foo', fn ($app) => new Foo($app->make('bar')));
+
+// Singleton — one instance for app lifetime
+$app->singleton(InterfaceB::class, ConcreteB::class);
+$app->singleton('cache', fn ($app) => new CacheManager($app));
+
+// Scoped — singleton within a request, reset between requests (Octane)
+$app->scoped(InterfaceC::class, ConcreteC::class);
+
+// Instance — already-created object
+$app->instance('config', $configInstance);
+
+// Contextual binding — different implementation per consumer
+$app->when(PhotoController::class)
+    ->needs(StorageInterface::class)
+    ->give(S3Storage::class);
+
+// Tagged bindings
+$app->tag([CpuReport::class, MemoryReport::class], 'reports');
+$app->tagged('reports'); // iterable of all tagged services
+```
+
+### Resolution Order
+
+1. Check `$instances` (already resolved singletons/instances)
+2. Check `$bindings` → execute closure or resolve class
+3. If contextual binding exists for current build stack → use it
+4. Check `$aliases` → resolve alias chain
+5. Auto-resolve via reflection (constructor injection)
+6. Apply `$extenders` (decoration callbacks)
+7. Fire `resolving` and `afterResolving` callbacks
+8. Store in `$instances` if singleton/scoped
+
+### Container Internals
+
+```
+$bindings     — array<string, {concrete: Closure, shared: bool}>
+$instances    — array<string, object>  (resolved singletons)
+$aliases      — array<string, string>  (alias → abstract)
+$abstractAliases — array<string, string[]>  (abstract → [aliases])
+$extenders    — array<string, Closure[]>  (decoration stack)
+$tags         — array<string, string[]>  (tag → [abstracts])
+$buildStack   — string[]  (current resolution chain, for contextual)
+$reboundCallbacks — array<string, Closure[]>  (fire when re-bound)
+$scopedInstances  — array<string, object>  (reset per request in Octane)
+```
+
+### extend() — Service Decoration
+
+```php
+$app->extend(EventDispatcher::class, function ($dispatcher, $app) {
+    return new EventDispatcherProxy($dispatcher, $app->make(EventCollector::class));
+});
+```
+
+**How it works internally:**
+1. Stores closure in `$extenders[abstract][]`
+2. On next `make()`: resolves concrete, then pipes through ALL extenders in order
+3. If already resolved (in `$instances`): immediately applies extender, updates `$instances`
+4. Multiple `extend()` calls stack — each wraps the previous result
+
+**Gotcha:** If service already resolved before `extend()`, the extender runs immediately and replaces the cached instance. Order matters — call `extend()` in `boot()`, not `register()`.
+
+### Deferred Providers
+
+```php
+class HeavyServiceProvider extends ServiceProvider
+{
+    public array $defer = true;
+    public function provides(): array { return [HeavyService::class]; }
+}
+```
+
+- Not loaded until `HeavyService::class` is first resolved
+- Manifest cached in `bootstrap/cache/services.php`
+- `PackageManifest` scans `extra.laravel.providers` in `composer.json`
+
+## Service Provider Lifecycle
+
+```
+ServiceProvider::register()     # Bind into container. NO $app->make() here.
+  ↓ (all providers registered)
+ServiceProvider::boot()         # Use container freely. Wire events, routes, middleware.
+  ↓ (all providers booted)
+Application handles request
+  ↓
+ServiceProvider::terminate()    # Cleanup (if method exists, called after response sent)
+```
+
+**Critical rules:**
+- `register()` — ONLY `$app->bind()`, `$app->singleton()`, `$app->extend()`. Never resolve services.
+- `boot()` — safe to resolve services, register event listeners, publish configs, load routes.
+- `terminate()` — runs after response is sent to client (terminable middleware pattern).
+
+### Package Discovery
+
+```json
+// composer.json
+"extra": {
+    "laravel": {
+        "providers": ["AppDevPanel\\Adapter\\Laravel\\AppDevPanelServiceProvider"],
+        "aliases": {}
+    }
+}
+```
+
+Auto-discovered via `PackageManifest`. No manual registration in `config/app.php` needed.
+
+## Event System
+
+### Architecture
+
+```
+Illuminate\Events\Dispatcher
+  ├── $listeners     — array<string, Closure[]>  (event → handlers)
+  ├── $wildcards     — array<string, Closure[]>  (pattern → handlers)
+  ├── $wildcardsCache — array<string, Closure[]>  (resolved wildcard matches)
+  └── $queueResolver — Closure  (for queued listeners)
+```
+
+### Dispatch Flow
+
+```php
+$events->dispatch(new OrderShipped($order));
+// OR
+$events->dispatch('order.shipped', [$order]);
+```
+
+1. Get event name (class name or string)
+2. Collect listeners: exact match + wildcard matches
+3. If event is `ShouldBroadcast` → queue for broadcasting
+4. Call each listener in registration order
+5. If listener returns `false` → stop propagation (only with `dispatch($event, $payload, $halt=true)`)
+6. If listener implements `ShouldQueue` → push to queue instead of calling
+
+### Listener Registration
+
+```php
+// Closure
+Event::listen(OrderShipped::class, function (OrderShipped $event) { ... });
+
+// Class (resolved from container)
+Event::listen(OrderShipped::class, SendShipmentNotification::class);
+
+// Class with method
+Event::listen(OrderShipped::class, [OrderListener::class, 'handleShipped']);
+
+// Wildcard
+Event::listen('order.*', function (string $eventName, array $data) { ... });
+
+// Subscriber (class with subscribe() method)
+Event::subscribe(OrderEventSubscriber::class);
+```
+
+### Built-in Events Used by ADP
+
+| Event Class | When | Data |
+|-------------|------|------|
+| `Illuminate\Database\Events\QueryExecuted` | After each DB query | `$sql`, `$bindings`, `$time`, `$connection` |
+| `Illuminate\Cache\Events\CacheHit` | Cache key found | `$key`, `$value`, `$tags` |
+| `Illuminate\Cache\Events\CacheMissed` | Cache key not found | `$key`, `$tags` |
+| `Illuminate\Cache\Events\KeyWritten` | Cache key set | `$key`, `$value`, `$seconds`, `$tags` |
+| `Illuminate\Cache\Events\KeyForgotten` | Cache key deleted | `$key`, `$tags` |
+| `Illuminate\Mail\Events\MessageSent` | Email sent | `$sent` (SentMessage), `$data` |
+| `Illuminate\Queue\Events\JobProcessing` | Job starting | `$connectionName`, `$job` |
+| `Illuminate\Queue\Events\JobProcessed` | Job finished | `$connectionName`, `$job` |
+| `Illuminate\Queue\Events\JobFailed` | Job failed | `$connectionName`, `$job`, `$exception` |
+| `Illuminate\Http\Client\Events\RequestSending` | HTTP request starting | `$request` |
+| `Illuminate\Http\Client\Events\ResponseReceived` | HTTP response received | `$request`, `$response` |
+| `Illuminate\Http\Client\Events\ConnectionFailed` | HTTP connection failed | `$request`, `$exception` |
+| `Illuminate\Console\Events\CommandStarting` | CLI command start | `$command`, `$input`, `$output` |
+| `Illuminate\Console\Events\CommandFinished` | CLI command end | `$command`, `$exitCode` |
+
+## Middleware Pipeline
+
+```
+Global middleware (Kernel::$middleware)
+  → Route group middleware (Kernel::$middlewareGroups['web'] or ['api'])
+    → Route-specific middleware
+      → Controller constructor
+        → Controller method
+```
+
+### Middleware Internals
+
+```php
+class ExampleMiddleware
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Before request
+        $response = $next($request);
+        // After response
+        return $response;
+    }
+
+    public function terminate(Request $request, Response $response): void
+    {
+        // After response sent to client
+    }
+}
+```
+
+**Pipeline implementation:** `Illuminate\Pipeline\Pipeline` uses `array_reduce()` to build a nested closure chain. Each middleware wraps the next. Execution is outside-in (first registered = first to handle request, last to handle response).
+
+### Registering Middleware
+
+```php
+// In ServiceProvider::boot()
+$this->app->make(HttpKernel::class)->pushMiddleware(DebugMiddleware::class);
+
+// Or prepend (runs before all others)
+$this->app->make(HttpKernel::class)->prependMiddleware(DebugMiddleware::class);
+
+// Route-level
+Route::middleware(['auth', 'throttle:60,1'])->group(function () { ... });
+```
+
+## Routing
+
+### Route Registration
+
+```php
+Route::get('/api/debug/{id}', [DebugController::class, 'show']);
+Route::prefix('debug/api')->group(function () {
+    Route::get('/{path}', [AdpApiController::class, 'handle'])->where('path', '.*');
+});
+```
+
+### Route Resolution
+
+```
+Router::dispatch($request)
+  → RouteCollection::match($request)
+    → getRoutesByMethod($request->getMethod())
+    → foreach: matchAgainstRoutes($routes, $request)
+      → Route::matches($request)  // URI regex + domain + scheme + method check
+    → return first match or throw NotFoundHttpException
+  → Route::bind($request)         // Resolve route parameters, model bindings
+  → runRouteWithinStack($route, $request)
+    → Route middleware pipeline
+    → Route::run()
+      → Controller::callAction() or Closure
+```
+
+### Route Model Binding
+
+```php
+Route::get('/users/{user}', function (User $user) { ... });
+// Resolves: User::findOrFail($routeParam)
+
+// Explicit binding
+Route::model('user', User::class);
+
+// Custom resolution
+Route::bind('user', fn ($value) => User::where('slug', $value)->firstOrFail());
+```

--- a/.claude/skills/symfony-expert/SKILL.md
+++ b/.claude/skills/symfony-expert/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: symfony-expert
+description: Deep expertise in Symfony internals — DI container compilation, bundles, compiler passes, event dispatcher, profiler/toolbar architecture, config tree builder, and how to integrate without breaking user config. Use when implementing or modifying the Symfony adapter.
+argument-hint: "[task or question about Symfony internals]"
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Agent
+---
+
+# Symfony Expert
+
+Task: $ARGUMENTS
+
+You are a senior PHP backend developer with deep expertise in Symfony internals. You know every compiler pass phase, every event priority, every config tree node type. You understand the Profiler and Web Debug Toolbar inside-out — their architectures, limitations, and how ADP improves on them. You write modern PHP 8.4+ code that integrates with Symfony cleanly, without breaking user configurations.
+
+## Reference Documentation
+
+Read these before implementing:
+
+- **Symfony internals** (lifecycle, DI container, bundles, events, routing): `docs/internals.md`
+- **Profiler & toolbar** (DataCollector system, toolbar injection, panel rendering, limitations, comparison with ADP): `docs/profiler.md`
+- **Best practices** (PHP 8.4+, bundle patterns, compiler passes, event subscribers, pitfalls, testing): `docs/best-practices.md`
+- **ADP Symfony adapter code**: `libs/Adapter/Symfony/src/`
+- **ADP Symfony adapter docs**: `libs/Adapter/Symfony/CLAUDE.md`
+- **Kernel collectors**: `libs/Kernel/src/Collector/`

--- a/.claude/skills/symfony-expert/docs/best-practices.md
+++ b/.claude/skills/symfony-expert/docs/best-practices.md
@@ -1,0 +1,228 @@
+# PHP 8.4+ Best Practices for Symfony Integration
+
+## Code Standards
+
+1. **`declare(strict_types=1)`** — always
+2. **`final` classes** — all new classes unless designed for extension
+3. **`readonly` properties** — for immutable state
+4. **Property hooks** (PHP 8.4) — for computed/validated properties
+5. **Named arguments** — for Symfony APIs with many optional params
+6. **Enums** — instead of class constants for finite value sets
+7. **Union/intersection types** — full type declarations, no `mixed`
+8. **`#[Override]`** attribute — on all methods overriding parent/interface
+9. **First-class callables** — `$this->method(...)` over `[$this, 'method']`
+10. **`array_find()`**, **`array_any()`**, **`array_all()`** (PHP 8.4)
+
+## Architecture Patterns
+
+1. **Wrap, don't extend** — composition over extending Symfony base classes
+2. **PSR interfaces** — depend on PSR-3/7/14/18, not Symfony interfaces (except EventDispatcher — see below)
+3. **Immutable DTOs** — `readonly class` for data transfer
+4. **No static service locator** — inject via constructor
+5. **Compiler passes for decoration** — `setDecoratedService()` pattern
+6. **Tagged services** — for collecting multiple implementations
+7. **Configuration tree** — for bundle config with safe defaults
+8. **No `@` error suppression**
+9. **No `extract()`/`compact()`**
+
+## Bundle Development Patterns
+
+### Extension Registration
+
+```php
+final class AppDevPanelExtension extends Extension
+{
+    #[Override]
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        if (!$config['enabled']) {
+            return;  // Bundle disabled — register nothing
+        }
+
+        // Register services based on processed config
+        $this->registerCoreServices($container, $config);
+        $this->registerCollectors($container, $config['collectors']);
+        $this->registerApiServices($container, $config);
+    }
+}
+```
+
+### CompilerPass Pattern
+
+```php
+final class CollectorProxyCompilerPass implements CompilerPassInterface
+{
+    #[Override]
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(Debugger::class)) {
+            return;  // Bundle not loaded
+        }
+
+        // Collect all tagged collectors
+        $collectors = $container->findTaggedServiceIds('app_dev_panel.collector');
+        $debuggerDef = $container->getDefinition(Debugger::class);
+
+        foreach ($collectors as $id => $tags) {
+            $debuggerDef->addMethodCall('addCollector', [new Reference($id)]);
+        }
+
+        // Decorate logger (check existence first!)
+        $this->decorateLogger($container);
+        $this->decorateEventDispatcher($container);
+        $this->decorateHttpClient($container);
+    }
+
+    private function decorateLogger(ContainerBuilder $container): void
+    {
+        // Symfony registers logger as 'logger' service ID
+        // Some apps also register via FQCN
+        $loggerId = $container->hasDefinition('logger')
+            ? 'logger'
+            : (LoggerInterface::class);
+
+        if (!$container->hasDefinition($loggerId) && !$container->hasAlias($loggerId)) {
+            return;  // No logger to decorate
+        }
+
+        $container->register('app_dev_panel.logger_proxy', LoggerInterfaceProxy::class)
+            ->setDecoratedService($loggerId)
+            ->setArguments([
+                new Reference('app_dev_panel.logger_proxy.inner'),
+                new Reference(LogCollector::class),
+            ]);
+    }
+}
+```
+
+### EventSubscriber Pattern
+
+```php
+final class HttpSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly Debugger $debugger,
+        private readonly RequestCollector $requestCollector,
+        private readonly ExceptionCollector $exceptionCollector,
+    ) {}
+
+    #[Override]
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onRequest', 1024],     // First
+            KernelEvents::RESPONSE => ['onResponse', -1024],  // Late
+            KernelEvents::EXCEPTION => ['onException', 0],
+            KernelEvents::TERMINATE => ['onTerminate', -2048], // Last
+        ];
+    }
+
+    public function onRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;  // Skip sub-requests
+        }
+        // Convert HttpFoundation Request → PSR-7
+        // Start debugger
+    }
+}
+```
+
+## Common Pitfalls
+
+| Pitfall | Why | Fix |
+|---------|-----|-----|
+| Decorating non-existent service | `setDecoratedService()` on missing service = silent no-op | Check `hasDefinition()` first |
+| Wrong CompilerPass phase | Service may not exist yet in early phases | Use `TYPE_BEFORE_OPTIMIZATION` (default) |
+| Sub-request events | `kernel.request` fires for ESI/sub-requests too | Check `$event->isMainRequest()` |
+| Event priority collision | Two subscribers at same priority = undefined order | Use explicit priorities, document them |
+| Serialization in collectors | `Data` objects from `VarCloner` are heavy | Use Kernel's Dumper instead |
+| Container not compiled | Calling `get()` on `ContainerBuilder` before compile | Only use `ContainerBuilder` in passes |
+| Private service access | Symfony 6+ makes services private by default | Use aliases or make public explicitly |
+| Config cache | `cache:clear` needed after config changes | In dev, container auto-recompiles |
+| Autowiring conflicts | Multiple implementations of same interface | Use explicit `bind()` or aliases |
+| Logger decoration loop | Logger used in LogCollector → infinite recursion | Proxy must not log its own operations |
+| Event dispatcher decoration | Must implement Symfony interface, not PSR-14 | See "Why ADP uses Symfony interface" in internals |
+
+## Symfony-Specific Event Dispatcher Proxy
+
+The ADP event dispatcher proxy for Symfony MUST implement `Symfony\Component\EventDispatcher\EventDispatcherInterface`, not `Psr\EventDispatcher\EventDispatcherInterface`:
+
+```php
+final class SymfonyEventDispatcherProxy implements EventDispatcherInterface
+{
+    public function __construct(
+        private readonly EventDispatcherInterface $dispatcher,
+        private readonly EventCollector $collector,
+    ) {}
+
+    #[Override]
+    public function dispatch(object $event, ?string $eventName = null): object
+    {
+        $this->collector->collect($event, $eventName);
+        return $this->dispatcher->dispatch($event, $eventName);
+    }
+
+    // Must proxy ALL EventDispatcherInterface methods:
+    // addListener, addSubscriber, removeListener, removeSubscriber,
+    // getListeners, getListenerPriority, hasListeners
+}
+```
+
+**Reasons:**
+1. Symfony's `dispatch()` signature: `dispatch(object $event, ?string $eventName = null)` — PSR-14 has no `$eventName`
+2. `SymfonyConfigProvider` calls `getListeners()` — not in PSR-14
+3. Container passes `[$service, 'method']` arrays to `addListener()` — Symfony-specific
+
+## PSR-7 Bridge
+
+Symfony uses HttpFoundation, not PSR-7. Conversion required for ADP Kernel:
+
+```php
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+
+// HttpFoundation Request → PSR-7
+$psr17Factory = new Psr17Factory();
+$creator = new ServerRequestCreator($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
+$psrRequest = $creator->fromGlobals();
+// OR from existing Symfony Request:
+$psrRequest = $creator->fromSymfonyRequest($symfonyRequest);  // Not standard — use bridge
+
+// HttpFoundation Response → PSR-7
+$psrResponse = $psr17Factory->createResponse($symfonyResponse->getStatusCode());
+foreach ($symfonyResponse->headers->all() as $name => $values) {
+    foreach ($values as $value) {
+        $psrResponse = $psrResponse->withAddedHeader($name, $value);
+    }
+}
+$psrResponse = $psrResponse->withBody(
+    $psr17Factory->createStream($symfonyResponse->getContent())
+);
+```
+
+## Testing Symfony Integration
+
+- Test Extension: create `ContainerBuilder`, call `load()`, assert definitions exist
+- Test CompilerPass: create `ContainerBuilder` with pre-registered services, call `process()`, verify decorations
+- Test EventSubscriber: instantiate with mocks, call event handler methods directly
+- Test Configuration: process config arrays, verify defaults and validation
+- Never use Symfony Kernel in unit tests — mock container and services
+- Use `$this->createMock(ContainerBuilder::class)` for compiler pass tests
+
+## Before Implementing
+
+1. Read the ADP Symfony adapter — `libs/Adapter/Symfony/src/`
+2. Read the Kernel collector interfaces — `libs/Kernel/src/Collector/`
+3. Read existing tests — `libs/Adapter/Symfony/tests/`
+4. Check Symfony source for the exact hook/event you need
+
+## After Implementing
+
+1. Run `make test-php` — all tests pass
+2. Run `make mago-fix` — formatting and lint clean
+3. Test against Symfony playground: `make fixtures-symfony`
+4. Verify no Symfony classes leak into Kernel or API modules

--- a/.claude/skills/symfony-expert/docs/internals.md
+++ b/.claude/skills/symfony-expert/docs/internals.md
@@ -1,0 +1,372 @@
+# Symfony Internals Deep Dive
+
+## Application Lifecycle
+
+```
+public/index.php
+  → Kernel::__construct(environment, debug)
+  → Kernel::handle(Request)
+    → boot()
+      → initializeBundles()           # Load bundles from config/bundles.php
+      → initializeContainer()
+        → buildContainer()            # Compile DI container
+          → Load Extension configs
+          → Run CompilerPasses
+          → Compile + dump to cache
+        → Container::boot()
+    → handleRaw(Request)
+      → fireEvent(kernel.request)     # Routing, security, locale
+      → controller = resolve(route)
+      → fireEvent(kernel.controller)  # Controller arguments resolved
+      → fireEvent(kernel.controller_arguments)
+      → $response = controller()
+      → fireEvent(kernel.response)    # Response processing
+    → return Response
+  → Response::send()
+  → Kernel::terminate(Request, Response)
+    → fireEvent(kernel.terminate)     # Cleanup, profiler data flush
+```
+
+## DI Container (Symfony\Component\DependencyInjection)
+
+### Compilation Phases
+
+```
+ContainerBuilder
+  1. Extension::load()              # Each bundle registers services
+  2. CompilerPass::process()        # Modify/decorate/validate services
+  3. compile()                      # Freeze container, resolve params
+  4. dump()                         # Generate PHP class (cached)
+```
+
+**Key difference from Laravel:** Container is compiled once, dumped to PHP file, never modified at runtime. No `set()`/`bind()` after compilation.
+
+### Service Registration
+
+```php
+// In Extension::load()
+$container->register('app_dev_panel.storage', FileStorage::class)
+    ->setArguments(['%app_dev_panel.storage.path%', '%app_dev_panel.storage.history_size%'])
+    ->setPublic(false);
+
+// Alias for interface
+$container->setAlias(StorageInterface::class, 'app_dev_panel.storage');
+
+// Autowired (default in Symfony 6+)
+$container->register(Debugger::class)
+    ->setAutowired(true)
+    ->setAutoconfigured(true);
+```
+
+### Service Decoration
+
+```php
+// In CompilerPass or Extension
+$container->register('app_dev_panel.logger_proxy', LoggerInterfaceProxy::class)
+    ->setDecoratedService('logger')  // or LoggerInterface::class
+    ->setArguments([
+        new Reference('app_dev_panel.logger_proxy.inner'),  // original service
+        new Reference(LogCollector::class),
+    ]);
+```
+
+**How decoration works internally:**
+1. `setDecoratedService('logger')` marks this service as a decorator
+2. Compiler renames original `logger` → `app_dev_panel.logger_proxy.inner`
+3. New service takes the `logger` ID
+4. `.inner` reference points to original
+5. Priority controls decoration order (higher = outermost wrapper)
+
+**Gotcha:** Decoration happens at compile time. If the decorated service doesn't exist, compilation fails silently (service just won't be decorated). Use `$container->hasDefinition()` check.
+
+### Tagged Services
+
+```php
+// Register with tag
+$container->register(LogCollector::class)
+    ->addTag('app_dev_panel.collector');
+
+// In CompilerPass: collect all tagged services
+$taggedServices = $container->findTaggedServiceIds('app_dev_panel.collector');
+foreach ($taggedServices as $id => $tags) {
+    $debuggerDef->addMethodCall('addCollector', [new Reference($id)]);
+}
+```
+
+### Parameters
+
+```php
+// Set parameter
+$container->setParameter('app_dev_panel.storage.path', '%kernel.project_dir%/var/debug');
+
+// Parameters resolved at compile time
+// %kernel.project_dir% → /var/www/app
+// %env(APP_DEBUG)% → resolved from .env
+```
+
+**Gotcha:** After compilation, parameters are frozen. No runtime parameter changes.
+
+### Container Internals
+
+```
+ContainerBuilder (compile-time only)
+  $definitions    — array<string, Definition>     (service definitions)
+  $aliasDefinitions — array<string, Alias>        (alias → service ID)
+  $parameterBag   — ParameterBag                  (string parameters)
+  $compiler       — Compiler                      (pass scheduler)
+  $extensionConfigs — array<string, array[]>       (bundle configs)
+
+Container (runtime, dumped PHP class)
+  $services       — array<string, object>         (resolved singletons)
+  $privates       — array<string, object>         (private services)
+  $parameters     — array<string, mixed>          (frozen params)
+  $aliases        — array<string, string>         (alias → service ID)
+  $methodMap      — array<string, string>         (service → factory method name)
+```
+
+## Bundle System
+
+### Bundle Lifecycle
+
+```
+Bundle::build(ContainerBuilder $container)     # Register compiler passes
+  → getContainerExtension()                    # Returns Extension instance
+    → Extension::load(array $configs, ContainerBuilder $container)
+      → process config
+      → register services
+  ↓ (all bundles loaded)
+CompilerPass::process(ContainerBuilder $container)
+  ↓ (container compiled)
+Bundle::boot()                                  # Runtime initialization
+  ↓
+Bundle::shutdown()                              # Cleanup
+```
+
+### Extension Configuration
+
+```php
+// Configuration.php — defines the config tree
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('app_dev_panel');
+        $rootNode = $treeBuilder->getRootNode();
+
+        $rootNode
+            ->children()
+                ->booleanNode('enabled')->defaultTrue()->end()
+                ->arrayNode('storage')
+                    ->children()
+                        ->scalarNode('path')->defaultValue('%kernel.project_dir%/var/debug')->end()
+                        ->integerNode('history_size')->defaultValue(50)->end()
+                    ->end()
+                ->end()
+                ->arrayNode('collectors')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('request')->defaultTrue()->end()
+                        ->booleanNode('log')->defaultTrue()->end()
+                        // ...
+                    ->end()
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}
+```
+
+**Config loading:**
+1. User writes `config/packages/app_dev_panel.yaml`
+2. Symfony loads all YAML configs, merges per environment
+3. `Extension::load()` receives merged config array
+4. `Configuration` validates and normalizes it
+5. Extension uses processed config to register services
+
+**How users DON'T override your defaults:**
+- `Configuration` tree defines `defaultValue()` for every node
+- User config MERGES with defaults (not replaces)
+- `addDefaultsIfNotSet()` ensures missing keys get defaults
+- Environment-specific configs override base: `config/packages/dev/app_dev_panel.yaml`
+- `canBeDisabled()` / `canBeEnabled()` — shorthand for enabled/disabled boolean
+
+### Bundle Registration
+
+```php
+// config/bundles.php
+return [
+    AppDevPanel\Adapter\Symfony\AppDevPanelBundle::class => ['dev' => true, 'test' => true],
+];
+```
+
+Environments: `all`, `dev`, `test`, `prod`. Bundle only loads in specified environments.
+
+### CompilerPass Priorities
+
+```php
+class AppDevPanelBundle extends Bundle
+{
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+        $container->addCompilerPass(
+            new CollectorProxyCompilerPass(),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,  // Phase
+            0  // Priority (higher = earlier)
+        );
+    }
+}
+```
+
+**Pass phases (execution order):**
+1. `TYPE_BEFORE_OPTIMIZATION` — most passes run here
+2. `TYPE_OPTIMIZE` — Symfony core optimization
+3. `TYPE_BEFORE_REMOVING` — last chance before unused services removed
+4. `TYPE_REMOVE` — remove unused/private services
+5. `TYPE_AFTER_REMOVING` — post-cleanup
+
+**For ADP:** `TYPE_BEFORE_OPTIMIZATION` — we need to decorate services before Symfony optimizes them.
+
+## Event System (EventDispatcher Component)
+
+### Architecture
+
+```
+EventDispatcher
+  $listeners    — array<string, array<int, array<Closure>>>
+                   eventName → priority → [listeners]
+  $sorted       — array<string, Closure[]>  (cached sorted listeners)
+  $optimized    — ?EventDispatcher  (immutable compiled dispatcher)
+```
+
+### Dispatch Flow
+
+```php
+$dispatcher->dispatch(new RequestEvent($kernel, $request, $type));
+// OR
+$dispatcher->dispatch($event, 'kernel.request');  // second arg = event name
+```
+
+1. Get event name (class name or explicit string)
+2. Call listeners sorted by priority (highest first)
+3. Each listener receives the event object
+4. If `$event->stopPropagation()` called → stop
+5. Return the event object
+
+### Listener Registration
+
+```php
+// Direct
+$dispatcher->addListener('kernel.request', $callable, $priority = 0);
+
+// Via subscriber (recommended)
+class HttpSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onRequest', 1024],
+            KernelEvents::RESPONSE => ['onResponse', -1024],
+            KernelEvents::EXCEPTION => ['onException', 0],
+            KernelEvents::TERMINATE => ['onTerminate', -2048],
+        ];
+    }
+}
+
+// Via service tag (in DI)
+$container->register(HttpSubscriber::class)
+    ->addTag('kernel.event_subscriber');
+```
+
+### Priority Convention
+
+| Priority | Usage |
+|----------|-------|
+| 2048+ | Security (firewall) |
+| 1024 | ADP request capture (must run before controllers) |
+| 256 | Routing |
+| 0 | Default (most subscribers) |
+| -256 | Response modification |
+| -1024 | ADP response capture (must run after controllers) |
+| -2048 | ADP terminate/flush (must run last) |
+
+### Symfony Event Dispatcher vs PSR-14
+
+| Feature | Symfony EventDispatcher | PSR-14 |
+|---------|----------------------|--------|
+| Priority | Yes (int) | No |
+| Stop propagation | `$event->stopPropagation()` | `$event->isPropagationStopped()` |
+| Event naming | Class name or string | Class name only |
+| `dispatch()` signature | `dispatch(object $event, ?string $eventName)` | `dispatch(object $event)` |
+| `getListeners()` | Yes | No (not in interface) |
+| Subscriber interface | Yes (`EventSubscriberInterface`) | No |
+
+**Why ADP uses Symfony interface, not PSR-14:**
+- Symfony's `dispatch()` has `?string $eventName` second param — PSR-14 doesn't
+- `SymfonyConfigProvider` needs `getListeners()` to inspect registered listeners
+- Symfony container passes `[$service, 'method']` arrays as listeners — requires `callable|array` signature
+
+## Kernel Events
+
+| Event | Constant | When | Use |
+|-------|----------|------|-----|
+| `RequestEvent` | `kernel.request` | Request received | Routing, auth, CORS, ADP startup |
+| `ControllerEvent` | `kernel.controller` | Controller resolved | Modify controller |
+| `ControllerArgumentsEvent` | `kernel.controller_arguments` | Args resolved | Modify arguments |
+| `ViewEvent` | `kernel.view` | Controller returned non-Response | Convert to Response |
+| `ResponseEvent` | `kernel.response` | Response ready | Headers, cache, ADP capture |
+| `FinishRequestEvent` | `kernel.finish_request` | Sub-request finished | Stack cleanup |
+| `TerminateEvent` | `kernel.terminate` | After Response::send() | ADP flush, profiler |
+| `ExceptionEvent` | `kernel.exception` | Exception thrown | Error handling, ADP capture |
+
+### Console Events
+
+| Event | Constant | When |
+|-------|----------|------|
+| `ConsoleCommandEvent` | `console.command` | Before command executes |
+| `ConsoleErrorEvent` | `console.error` | Command threw exception |
+| `ConsoleTerminateEvent` | `console.terminate` | After command finishes |
+
+## Routing
+
+### Route Loading
+
+```
+Kernel::boot()
+  → RoutingExtension → load config/routes.yaml
+    → imports config/routes/*.yaml
+  → RouterListener (kernel.request, priority 32)
+    → UrlMatcher::match($pathinfo)
+      → compiled regex match against RouteCollection
+      → return route params + _controller + _route
+    → $request->attributes->set('_controller', ...)
+```
+
+### Route Registration for Bundles
+
+```php
+// In Extension or routes config
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes->add('adp_api', '/debug/api/{path}')
+        ->controller([AdpApiController::class, 'handle'])
+        ->requirements(['path' => '.+'])
+        ->methods(['GET', 'POST', 'PUT', 'DELETE']);
+};
+```
+
+### Route Introspection
+
+```php
+$router = $container->get('router');
+$routeCollection = $router->getRouteCollection();
+
+foreach ($routeCollection->all() as $name => $route) {
+    $route->getPath();       // '/debug/api/{path}'
+    $route->getMethods();    // ['GET', 'POST']
+    $route->getDefaults();   // ['_controller' => '...']
+    $route->getRequirements(); // ['path' => '.+']
+}
+```

--- a/.claude/skills/symfony-expert/docs/profiler.md
+++ b/.claude/skills/symfony-expert/docs/profiler.md
@@ -1,0 +1,332 @@
+# Symfony Profiler & Web Debug Toolbar Internals
+
+## Architecture Overview
+
+```
+symfony/web-profiler-bundle
+  ├── WebProfilerBundle              # Bundle entry point
+  ├── Controller/
+  │   ├── ProfilerController         # Serves profiler UI (/_profiler/{token})
+  │   └── RouterController           # Route debugging page
+  ├── Twig/
+  │   └── WebProfilerExtension       # Twig functions for toolbar rendering
+  ├── EventListener/
+  │   └── WebDebugToolbarListener    # Injects toolbar HTML into responses
+  └── Resources/
+      └── views/                     # Twig templates for profiler panels
+
+symfony/http-kernel (Profiler component)
+  ├── Profiler                       # Core: collects, stores, loads profiles
+  ├── Profile                        # Container for one request's collected data
+  ├── DataCollector/
+  │   ├── DataCollectorInterface     # Contract for data collectors
+  │   ├── DataCollector              # Base class with serialization
+  │   ├── LateDataCollectorInterface # Collects data at terminate phase
+  │   ├── RequestDataCollector       # Request/response/session/cookies
+  │   ├── TimeDataCollector          # Request timing
+  │   ├── MemoryDataCollector        # Memory usage
+  │   ├── ExceptionDataCollector     # Exceptions
+  │   ├── EventDataCollector         # Dispatched events
+  │   ├── LoggerDataCollector        # Monolog messages
+  │   ├── RouterDataCollector        # Route matching
+  │   └── AjaxDataCollector          # AJAX requests detection
+  └── Profiling/
+      └── Storage/
+          └── FileProfilerStorage    # Default: var/cache/{env}/profiler/
+```
+
+## Profiler Lifecycle
+
+```
+kernel.request (ProfilerListener, priority 1024)
+  → $profiler->enable()
+  → set X-Debug-Token on request
+
+kernel.response (ProfilerListener, priority -100)
+  → $profiler->collect($request, $response)
+    → foreach DataCollector:
+      → $collector->collect($request, $response, $exception)
+    → create Profile with token
+  → add X-Debug-Token-Link header to response
+
+kernel.terminate (ProfilerListener, priority -1024)
+  → foreach LateDataCollectorInterface:
+    → $collector->lateCollect()    # Collect data available only after response
+  → $profiler->saveProfile($profile)
+    → ProfilerStorageInterface::write($profile)
+    → serialize all collector data to storage
+
+kernel.response (WebDebugToolbarListener, priority -128)
+  → if HTML response + not redirect + dev env:
+    → inject toolbar <div> before </body>
+    → toolbar loads via AJAX: GET /_profiler/{token}/toolbar
+```
+
+## DataCollector System
+
+### Interface
+
+```php
+interface DataCollectorInterface extends ResetInterface
+{
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void;
+    public function getName(): string;
+    public function reset(): void;
+}
+
+interface LateDataCollectorInterface
+{
+    public function lateCollect(): void;  // Called during kernel.terminate
+}
+```
+
+### Base Class Internals
+
+```php
+abstract class DataCollector implements DataCollectorInterface
+{
+    protected array|Data $data = [];
+
+    // Serialization uses igbinary if available, then serialize()
+    public function __sleep(): array { return ['data']; }
+    public function __wakeup(): void {}
+
+    // Cloner for safe data serialization
+    protected function cloneVar(mixed $var): Data
+    {
+        // Uses VarCloner → converts to Data object
+        // Safe to serialize (handles circular refs, resources, closures)
+        return (new VarCloner())->cloneVar($var);
+    }
+}
+```
+
+### Built-in Collectors Detail
+
+| Collector | `collect()` source | `lateCollect()` | Key data |
+|-----------|-------------------|-----------------|----------|
+| `RequestDataCollector` | Request/Response objects | No | Method, URI, headers, content, status, format, locale, route |
+| `TimeDataCollector` | Stopwatch events | Yes | Start time, duration, memory |
+| `MemoryDataCollector` | `memory_get_peak_usage()` | Yes | Peak memory, limit |
+| `ExceptionDataCollector` | `$exception` param | No | Exception class, message, trace |
+| `EventDataCollector` | EventDispatcher | Yes (listener details) | Events dispatched, listeners called, not called, orphans |
+| `LoggerDataCollector` | DebugLoggerInterface | Yes | Log messages (priority-grouped), error count, deprecation count |
+| `RouterDataCollector` | Router `_route` attribute | No | Matched route, redirect info |
+| `ConfigDataCollector` | Kernel | No | PHP version, Symfony version, environment, debug mode, bundles |
+| `SecurityDataCollector` | TokenStorage, Firewall | Yes | User, roles, firewall name, authentication status |
+| `TwigDataCollector` | Twig Profiler | Yes | Templates rendered, render time, template count |
+| `DoctrineDataCollector` | Debug DBAL logger | Yes | Queries, params, time, explain plans |
+| `CacheDataCollector` | TraceableAdapter | Yes | Cache operations, hits, misses, writes |
+| `ValidatorDataCollector` | TraceableValidator | Yes | Constraint violations |
+| `FormDataCollector` | Form debug tree | Yes | Form types, submitted data, errors, views |
+| `MailerDataCollector` | MessageEvents | Yes | Emails: to, subject, body, headers |
+| `MessengerDataCollector` | TraceableMiddleware | Yes | Messages dispatched, handled, failed |
+
+### Profile Storage
+
+**Default:** `FileProfilerStorage` — one file per profile token:
+```
+var/cache/dev/profiler/
+  ├── ab/                # First 2 chars of token
+  │   └── cd/            # Next 2 chars
+  │       └── abcdef     # Full token → serialized Profile
+  └── index.csv          # Index: token,ip,method,url,time,parent,status_code
+```
+
+**Gotcha:** Profile data is serialized PHP. Large profiles (many queries, events) can be multi-MB. Profiler stores last 100 profiles by default (`framework.profiler.collect_parameter`).
+
+## Web Debug Toolbar Injection
+
+### WebDebugToolbarListener
+
+```php
+public function onKernelResponse(ResponseEvent $event): void
+{
+    $response = $event->getResponse();
+    $request = $event->getRequest();
+
+    if (!$event->isMainRequest()) return;
+    if ($request->isXmlHttpRequest()) return;  // No toolbar on AJAX
+    if ($response->isRedirection()) return;
+    if ($response->headers->has('X-Debug-Token')) {
+        // Already profiled (sub-request)
+    }
+
+    // Check Content-Type is HTML
+    if (!str_contains($response->headers->get('Content-Type', ''), 'text/html')) return;
+
+    $this->injectToolbar($response, $request);
+}
+
+private function injectToolbar(Response $response): void
+{
+    $content = $response->getContent();
+    // Find </body> tag
+    $pos = strripos($content, '</body>');
+    if ($pos !== false) {
+        // Insert toolbar div + AJAX loader script before </body>
+        $toolbar = '<div id="sfwdt{token}" ...></div><script>...</script>';
+        $content = substr($content, 0, $pos) . $toolbar . substr($content, $pos);
+        $response->setContent($content);
+    }
+}
+```
+
+**How the toolbar loads:**
+1. Listener injects a `<div>` placeholder + `<script>` before `</body>`
+2. Script makes AJAX GET to `/_profiler/{token}/toolbar`
+3. ProfilerController returns toolbar HTML
+4. Script replaces placeholder with toolbar content
+
+### How to NOT break user's responses
+
+The toolbar listener has multiple guards:
+- Only main request (not sub-requests/ESI)
+- Only HTML responses (Content-Type check)
+- Not on redirects
+- Not on AJAX (X-Requested-With header)
+- Not on streaming responses (no `getContent()`)
+- Only in dev environment (bundle registered only for `dev`)
+
+## Profiler Panel System
+
+### Creating a Custom Panel (Symfony way)
+
+```php
+// DataCollector
+class CustomCollector extends DataCollector
+{
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
+    {
+        $this->data = ['items' => $this->cloneVar($collectedData)];
+    }
+
+    public function getName(): string { return 'custom'; }
+    public function reset(): void { $this->data = []; }
+
+    // Accessor methods for Twig template
+    public function getItems(): Data { return $this->data['items']; }
+}
+
+// Twig template: templates/data_collector/custom.html.twig
+// Extends @WebProfiler/Profiler/layout.html.twig
+// Block: toolbar (summary), menu (sidebar), panel (detail page)
+```
+
+```yaml
+# services.yaml
+services:
+    App\DataCollector\CustomCollector:
+        tags:
+            - name: data_collector
+              template: '@App/data_collector/custom.html.twig'
+              id: 'custom'
+              priority: 300
+```
+
+### Panel Rendering Pipeline
+
+```
+ProfilerController::panelAction($token, $panel)
+  → $profiler->loadProfile($token)
+  → find collector by panel name
+  → render Twig template with collector data
+  → return Response
+```
+
+### Limitations of Symfony Profiler
+
+| Limitation | Details |
+|-----------|---------|
+| Twig-coupled UI | Panels are Twig templates — no SPA, no API |
+| Serialized PHP storage | Not portable, not queryable |
+| No real-time | Data available only after request completes |
+| No cross-app | Single Symfony app only |
+| HTML injection | Toolbar modifies response body — fragile |
+| No structured data | Collectors return opaque `Data` objects |
+| No SSE/WebSocket | Polling only (manual page refresh) |
+| Heavy serialization | Large profiles slow to store/load |
+| Memory overhead | All collectors run on every request |
+| No collector communication | Collectors can't share data (no timeline) |
+
+### How ADP Differs from Symfony Profiler
+
+| Aspect | Symfony Profiler | ADP Symfony Adapter |
+|--------|-----------------|---------------------|
+| Storage | Serialized PHP files | JSON via Kernel FileStorage |
+| UI | Twig templates in toolbar | React SPA (separate app) |
+| Transport | Page refresh / AJAX | REST API + SSE real-time |
+| Data format | `VarCloner\Data` objects | Structured JSON (Kernel Dumper) |
+| Architecture | `DataCollectorInterface` | `CollectorInterface` (Kernel) |
+| Cross-framework | Symfony only | Any PHP framework |
+| Extensibility | Twig templates + tags | Kernel collectors + API |
+| Console | Limited (ConsoleEvents) | Full (ConsoleSubscriber) |
+| Persistence | 100 profiles, then purge | Configurable history_size |
+| Timeline | Stopwatch component (partial) | TimelineCollector (cross-collector) |
+
+## How User Config Doesn't Override Bundle Defaults
+
+### Configuration Merge Strategy
+
+```yaml
+# Bundle default (in Configuration.php):
+#   collectors.request: true (defaultTrue)
+#   collectors.log: true (defaultTrue)
+#   storage.path: '%kernel.project_dir%/var/debug'
+
+# User writes (config/packages/app_dev_panel.yaml):
+app_dev_panel:
+    collectors:
+        log: false            # Override: disable log collector
+    # request not mentioned → keeps default (true)
+    # storage not mentioned → keeps default
+```
+
+**Merge rules:**
+- Scalar nodes: user value overrides default
+- Array nodes with `addDefaultsIfNotSet()`: missing keys get defaults
+- `canBeDisabled()`: generates `enabled: true` default + allows `enabled: false`
+- `arrayNode()->useAttributeAsKey('name')`: merges by key, not replaces
+- Environment override: `config/packages/dev/` overrides `config/packages/`
+
+### Protecting Against Accidental Overwrites
+
+```php
+$rootNode
+    ->children()
+        // User CAN'T set invalid types — tree builder validates
+        ->integerNode('history_size')
+            ->defaultValue(50)
+            ->min(1)->max(1000)  // Validated range
+        ->end()
+
+        // User CAN'T remove required children
+        ->arrayNode('storage')
+            ->isRequired()
+            ->children()
+                ->scalarNode('path')->isRequired()->cannotBeEmpty()->end()
+            ->end()
+        ->end()
+
+        // User CAN disable but defaults are safe
+        ->arrayNode('collectors')
+            ->addDefaultsIfNotSet()  // Key: missing keys get defaults
+            ->children()
+                ->booleanNode('request')->defaultTrue()->end()
+            ->end()
+        ->end()
+    ->end();
+```
+
+### Config Environments
+
+```
+config/packages/
+  ├── app_dev_panel.yaml          # Base config (all environments)
+  ├── dev/
+  │   └── app_dev_panel.yaml      # Dev overrides
+  └── prod/
+      └── app_dev_panel.yaml      # Prod: enabled: false
+```
+
+Symfony merges: base → environment-specific. Deep merge for arrays.


### PR DESCRIPTION
## Summary

- **VitePress documentation site** (`website/`) with bilingual EN/RU support, blog, custom theme with duck mascot, GitHub Pages deploy workflow
- **5 new/updated Claude skills:**
  - `yii2-expert` — Yii 2 framework internals, module system, debug module architecture
  - `laravel-expert` — Laravel container, service providers, Telescope/DebugBar internals and limitations
  - `symfony-expert` — Symfony DI compilation, bundles, profiler/toolbar architecture, config tree builder
  - `docs-expert` — VitePress site ownership, i18n workflow, content quality rules
  - `testing-expert` — renamed from `test` for naming consistency
- **Bug fixes:** SSE non-blocking shutdown, stream proxy dedup, collector simplification
- **Tests:** comprehensive SSE endpoint and controller tests

## Test plan

- [ ] `make test-php` — all PHP tests pass
- [ ] `make mago-fix` — code quality clean
- [ ] `cd website && npm run build` — VitePress builds without errors
- [ ] Verify all skills load correctly via `/yii2-expert`, `/laravel-expert`, `/symfony-expert`, `/docs-expert`, `/testing-expert`

https://claude.ai/code/session_01XpRnuitY4GCJVNnsekgVU1