### PR TITLE
Add monorepo split and frontend publish workflows

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Split ${{ matrix.package.name }}
         env:


### PR DESCRIPTION
## Summary

- **`split.yml`** — Monorepo subtree split on push to master and tags. Uses `git subtree split` + `git push` with `set -euo pipefail`. `persist-credentials: false` so SPLIT_TOKEN is used instead of GITHUB_TOKEN.
- **`npm-publish.yml`** — Frontend publish on tags. Single build job, then publish to GitHub Packages and upload release assets in parallel via shared artifacts.

## Test plan

- [ ] Push to master → split jobs push to split repos using SPLIT_TOKEN
- [ ] Push a tag → split jobs push tag + frontend publish + release assets

https://claude.ai/code/session_01VasRs3vTmKL2r8d7dMz6CL