### PR TITLE
Fix PathResolver root path resolution in Yii2 adapter

### DIFF
--- a/libs/Adapter/Yii2/src/Module.php
+++ b/libs/Adapter/Yii2/src/Module.php
@@ -292,12 +292,12 @@ class Module extends \yii\base\Module implements BootstrapInterface
             \Yii::$container->setSingleton(ClientInterface::class, static fn() => new Client(['timeout' => 10]));
         }
 
-        $basePath = \Yii::getAlias('@app');
+        $rootPath = dirname(\Yii::getAlias('@vendor'));
         $runtimePath = \Yii::getAlias('@runtime');
 
         \Yii::$container->setSingleton(
             PathResolverInterface::class,
-            static fn() => new PathResolver($basePath, $runtimePath),
+            static fn() => new PathResolver($rootPath, $runtimePath),
         );
 
         $pathMapping = $this->pathMapping;


### PR DESCRIPTION
## Summary
Updated the PathResolver initialization in the Yii2 adapter module to use the actual project root path instead of the application base path.

## Key Changes
- Changed `PathResolver` initialization to derive the root path from the vendor directory location (`dirname(\Yii::getAlias('@vendor'))`) instead of using the application base path (`\Yii::getAlias('@app')`)
- This ensures the PathResolver correctly identifies the project root directory, which is the parent of the vendor folder, rather than relying on the application base path alias

## Implementation Details
The change affects how the `PathResolverInterface` singleton is configured during core service registration. By calculating the root path as the parent directory of the vendor folder, the resolver will have a more reliable reference point for path operations, particularly useful in scenarios where the application base path and project root may differ.

https://claude.ai/code/session_012uhWD1rrDNJYKQV3fgig8o