### PR TITLE
Move event buttons to the right, fix class resolution

### DIFF
--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EventPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EventPanel.tsx
@@ -224,20 +224,18 @@ export const EventPanel = ({events}: EventTimelineProps) => {
                         </EventRow>
                         <Collapse in={expanded}>
                             <DetailBox>
-                                <Typography
-                                    variant="caption"
-                                    sx={{
-                                        fontFamily: primitives.fontFamilyMono,
-                                        color: 'text.secondary',
-                                        display: 'block',
-                                        mb: 1,
-                                    }}
-                                >
-                                    {event.name}
-                                </Typography>
-
-                                <Box sx={{display: 'flex', gap: 0.5, mb: 1.5}}>
-                                    <FileLink path={event.line}>
+                                <Box sx={{display: 'flex', alignItems: 'center', gap: 0.5, mb: 1}}>
+                                    <Typography
+                                        variant="caption"
+                                        sx={{
+                                            fontFamily: primitives.fontFamilyMono,
+                                            color: 'text.secondary',
+                                            flex: 1,
+                                        }}
+                                    >
+                                        {event.name}
+                                    </Typography>
+                                    <FileLink className={event.name}>
                                         <Tooltip title="Open File">
                                             <IconButton
                                                 size="small"


### PR DESCRIPTION
## Summary
- Move "Open File" button from below the event class name to inline on the right side
- Fix `FileLink` to use `className={event.name}` instead of `path={event.line}` so the file is resolved via class-based lookup in the inspector endpoint, instead of trying to open a raw file path that doesn't exist

## Test plan
- [ ] Expand an event in the EventPanel — verify the "Open File" button appears to the right of the class name, not below it
- [ ] Click the "Open File" button — verify it navigates to `/inspector/files?class=...` and resolves correctly

https://claude.ai/code/session_01AbfC9zyMrpCnKu9dC6E23z