### PR TITLE
Add null safety checks to ComposerPage package data handling

### DIFF
--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/ComposerPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/ComposerPage.tsx
@@ -48,9 +48,11 @@ export const ComposerPage = () => {
         if (!getComposerQuery.data || !getComposerQuery.data.lock) {
             return packages;
         }
-        getComposerQuery.data.lock.packages.concat(getComposerQuery.data.lock['packages-dev']).forEach((value) => {
-            packages[value.name] = value.version;
-        });
+        (getComposerQuery.data.lock.packages ?? [])
+            .concat(getComposerQuery.data.lock['packages-dev'] ?? [])
+            .forEach((value) => {
+                packages[value.name] = value.version;
+            });
         return packages;
     }, [getComposerQuery.data]);
     const onClickHandler = (name: string) => {
@@ -79,7 +81,7 @@ export const ComposerPage = () => {
                     <List sx={{width: '100%'}}>
                         <Divider>Require</Divider>
                         {getComposerQuery.data &&
-                            Object.entries(getComposerQuery.data.json.require).map(([name, version], index) => (
+                            Object.entries(getComposerQuery.data.json.require ?? {}).map(([name, version], index) => (
                                 <PackageItem
                                     key={index}
                                     packageName={name}
@@ -95,18 +97,20 @@ export const ComposerPage = () => {
                     <List sx={{width: '100%'}}>
                         <Divider>Require Dev</Divider>
                         {getComposerQuery.data &&
-                            Object.entries(getComposerQuery.data.json['require-dev']).map(([name, version], index) => (
-                                <PackageItem
-                                    key={index}
-                                    packageName={name}
-                                    version={
-                                        name in installedVersions
-                                            ? `Required: ${version}, Installed: ${installedVersions[name]}`
-                                            : `${version}`
-                                    }
-                                    onClick={onClickDevHandler}
-                                />
-                            ))}
+                            Object.entries(getComposerQuery.data.json['require-dev'] ?? {}).map(
+                                ([name, version], index) => (
+                                    <PackageItem
+                                        key={index}
+                                        packageName={name}
+                                        version={
+                                            name in installedVersions
+                                                ? `Required: ${version}, Installed: ${installedVersions[name]}`
+                                                : `${version}`
+                                        }
+                                        onClick={onClickDevHandler}
+                                    />
+                                ),
+                            )}
                     </List>
                 </Box>
             </TabPanel>


### PR DESCRIPTION
## Summary
This PR adds null safety checks throughout the ComposerPage component to prevent potential runtime errors when accessing package data that may be undefined.

## Key Changes
- Added nullish coalescing operators (`??`) to handle potentially undefined `packages` and `packages-dev` arrays in the lock file data
- Added nullish coalescing operators to `require` and `require-dev` objects when mapping over their entries
- Improved code formatting for better readability, particularly for the `require-dev` mapping which now spans multiple lines

## Implementation Details
- The changes ensure that if `getComposerQuery.data.lock.packages`, `getComposerQuery.data.lock['packages-dev']`, `getComposerQuery.data.json.require`, or `getComposerQuery.data.json['require-dev']` are undefined, empty arrays/objects are used as fallbacks
- This prevents potential "Cannot read property of undefined" errors when the API response doesn't include these fields
- No functional behavior changes; this is purely defensive programming to handle edge cases in the data structure

https://claude.ai/code/session_01XufcXKoW7AKWMp6aDbU8zc