### PR TITLE
Redesign Configuration pages and add error handling

### DIFF
--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.test.tsx
@@ -139,4 +139,28 @@ describe('ContainerPage', () => {
 
         expect(mockLazyLoadObject).toHaveBeenCalledWith('App\\Controller\\HomeController');
     });
+
+    it('shows error message when load fails', async () => {
+        mockLazyLoadObject.mockResolvedValueOnce({
+            error: {status: 500, data: {error: 'Class "Foo" is not registered in the DI container.'}},
+        });
+        const user = userEvent.setup();
+        renderPage();
+
+        const loadButtons = screen.getAllByLabelText('Load object state');
+        await user.click(loadButtons[0]);
+
+        expect(await screen.findByText('Class "Foo" is not registered in the DI container.')).toBeInTheDocument();
+    });
+
+    it('shows retry button after load error', async () => {
+        mockLazyLoadObject.mockResolvedValueOnce({error: {status: 500, data: {error: 'Some error'}}});
+        const user = userEvent.setup();
+        renderPage();
+
+        const loadButtons = screen.getAllByLabelText('Load object state');
+        await user.click(loadButtons[0]);
+
+        expect(await screen.findByLabelText('Retry loading')).toBeInTheDocument();
+    });
 });

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.tsx
@@ -7,7 +7,7 @@ import {JsonRenderer} from '@app-dev-panel/sdk/Component/JsonRenderer';
 import {primitives} from '@app-dev-panel/sdk/Component/Theme/tokens';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';
 import {regexpQuote} from '@app-dev-panel/sdk/Helper/regexpQuote';
-import {ContentCopy, Download, OpenInNew} from '@mui/icons-material';
+import {ContentCopy, Download, ErrorOutline, OpenInNew} from '@mui/icons-material';
 import {Box, CircularProgress, IconButton, TablePagination, Tooltip, Typography} from '@mui/material';
 import {styled} from '@mui/material/styles';
 import clipboardCopy from 'clipboard-copy';
@@ -90,13 +90,18 @@ const HeaderLabel = styled(Typography)(({theme}) => ({
 // Sub-components
 // ---------------------------------------------------------------------------
 
-const ContainerValue = ({entry, onLoad}: {entry: ContainerEntry; onLoad: (id: string) => void}) => {
+const ContainerValue = ({entry, onLoad}: {entry: ContainerEntry; onLoad: (id: string) => Promise<string | null>}) => {
     const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
 
     const handleLoad = useCallback(async () => {
         setLoading(true);
-        await onLoad(entry.id);
+        setError(null);
+        const errorMessage = await onLoad(entry.id);
         setLoading(false);
+        if (errorMessage) {
+            setError(errorMessage);
+        }
     }, [entry.id, onLoad]);
 
     if (entry.value) {
@@ -104,11 +109,20 @@ const ContainerValue = ({entry, onLoad}: {entry: ContainerEntry; onLoad: (id: st
     }
 
     return (
-        <Tooltip title="Load object state">
-            <IconButton size="small" onClick={handleLoad} disabled={loading}>
-                {loading ? <CircularProgress size={14} /> : <Download sx={{fontSize: 14}} />}
-            </IconButton>
-        </Tooltip>
+        <Box>
+            <Tooltip title={error ? 'Retry loading' : 'Load object state'}>
+                <IconButton size="small" onClick={handleLoad} disabled={loading}>
+                    {loading ? (
+                        <CircularProgress size={14} />
+                    ) : error ? (
+                        <ErrorOutline sx={{fontSize: 14, color: 'error.main'}} />
+                    ) : (
+                        <Download sx={{fontSize: 14}} />
+                    )}
+                </IconButton>
+            </Tooltip>
+            {error && <Typography sx={{fontSize: '11px', color: 'error.main', mt: 0.5}}>{error}</Typography>}
+        </Box>
     );
 };
 
@@ -128,13 +142,15 @@ export const ContainerPage = () => {
     const [rowsPerPage, setRowsPerPage] = useState(50);
 
     const handleLoadObject = useCallback(
-        async (id: string) => {
+        async (id: string): Promise<string | null> => {
             const result = await lazyLoadObject(id);
             if (result.data) {
                 insertObject(id, result.data.object);
+                return null;
             }
+            const errorData = (result.error as any)?.data;
+            return errorData?.error || errorData?.data?.message || 'Failed to load object';
         },
-
         [lazyLoadObject],
     );
 
@@ -142,7 +158,6 @@ export const ContainerPage = () => {
         if (!isLoading && data) {
             setObjects(data.map((row) => ({id: row, value: null})));
         }
-
     }, [isLoading, data]);
 
     const filteredRows = useMemo(() => {

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.test.tsx
@@ -149,4 +149,28 @@ describe('DefinitionsPage', () => {
 
         expect(mockLazyLoadObject).toHaveBeenCalledWith('assetManager');
     });
+
+    it('shows error message when load fails', async () => {
+        mockLazyLoadObject.mockResolvedValueOnce({
+            error: {status: 500, data: {error: 'Class "Foo" is not registered in the DI container.'}},
+        });
+        const user = userEvent.setup();
+        renderPage();
+
+        const loadButtons = screen.getAllByLabelText('Load object state');
+        await user.click(loadButtons[0]);
+
+        expect(await screen.findByText('Class "Foo" is not registered in the DI container.')).toBeInTheDocument();
+    });
+
+    it('shows retry button after load error', async () => {
+        mockLazyLoadObject.mockResolvedValueOnce({error: {status: 500, data: {error: 'Some error'}}});
+        const user = userEvent.setup();
+        renderPage();
+
+        const loadButtons = screen.getAllByLabelText('Load object state');
+        await user.click(loadButtons[0]);
+
+        expect(await screen.findByLabelText('Retry loading')).toBeInTheDocument();
+    });
 });

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.tsx
@@ -7,7 +7,7 @@ import {JsonRenderer} from '@app-dev-panel/sdk/Component/JsonRenderer';
 import {primitives} from '@app-dev-panel/sdk/Component/Theme/tokens';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';
 import {regexpQuote} from '@app-dev-panel/sdk/Helper/regexpQuote';
-import {ContentCopy, DataObject, Download} from '@mui/icons-material';
+import {ContentCopy, DataObject, Download, ErrorOutline} from '@mui/icons-material';
 import {Box, CircularProgress, IconButton, TablePagination, Tooltip, Typography} from '@mui/material';
 import {styled} from '@mui/material/styles';
 import clipboardCopy from 'clipboard-copy';
@@ -98,17 +98,20 @@ const HeaderLabel = styled(Typography)(({theme}) => ({
 // Sub-components
 // ---------------------------------------------------------------------------
 
-const DefinitionValue = ({entry, onLoad}: {entry: DefinitionEntry; onLoad: (id: string) => void}) => {
+const DefinitionValue = ({entry, onLoad}: {entry: DefinitionEntry; onLoad: (id: string) => Promise<string | null>}) => {
     const [loading, setLoading] = useState(false);
-    const [expanded, setExpanded] = useState(false);
+    const [error, setError] = useState<string | null>(null);
 
     const isClassName = typeof entry.value === 'string' && /^[\w\\]+$/i.test(entry.value);
 
     const handleLoad = useCallback(async () => {
         setLoading(true);
-        await onLoad(entry.id);
+        setError(null);
+        const errorMessage = await onLoad(entry.id);
         setLoading(false);
-        setExpanded(true);
+        if (errorMessage) {
+            setError(errorMessage);
+        }
     }, [entry.id, onLoad]);
 
     if (typeof entry.value === 'string' && isClassName) {
@@ -116,12 +119,19 @@ const DefinitionValue = ({entry, onLoad}: {entry: DefinitionEntry; onLoad: (id: 
             <Box>
                 <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
                     <ClassValue>{entry.value}</ClassValue>
-                    <Tooltip title="Load object state">
+                    <Tooltip title={error ? 'Retry loading' : 'Load object state'}>
                         <IconButton size="small" onClick={handleLoad} disabled={loading} sx={{flexShrink: 0}}>
-                            {loading ? <CircularProgress size={14} /> : <Download sx={{fontSize: 14}} />}
+                            {loading ? (
+                                <CircularProgress size={14} />
+                            ) : error ? (
+                                <ErrorOutline sx={{fontSize: 14, color: 'error.main'}} />
+                            ) : (
+                                <Download sx={{fontSize: 14}} />
+                            )}
                         </IconButton>
                     </Tooltip>
                 </Box>
+                {error && <Typography sx={{fontSize: '11px', color: 'error.main', mt: 0.5}}>{error}</Typography>}
             </Box>
         );
     }
@@ -150,13 +160,15 @@ export const DefinitionsPage = () => {
     const [rowsPerPage, setRowsPerPage] = useState(50);
 
     const handleLoadObject = useCallback(
-        async (id: string) => {
+        async (id: string): Promise<string | null> => {
             const result = await lazyLoadObject(id);
             if (result.data) {
                 insertObject(id, result.data.object);
+                return null;
             }
+            const errorData = (result.error as any)?.data;
+            return errorData?.error || errorData?.data?.message || 'Failed to load object';
         },
-
         [lazyLoadObject],
     );
 
@@ -166,7 +178,6 @@ export const DefinitionsPage = () => {
             const items = rows.map((el) => ({id: el[0], value: el[1]}));
             setObjects(items);
         }
-
     }, [isLoading, data]);
 
     const filteredRows = useMemo(() => {

--- a/libs/frontend/packages/sdk/src/API/errorNotificationMiddleware.test.ts
+++ b/libs/frontend/packages/sdk/src/API/errorNotificationMiddleware.test.ts
@@ -1,0 +1,89 @@
+import {configureStore} from '@reduxjs/toolkit';
+import {createApi} from '@reduxjs/toolkit/query/react';
+import {describe, expect, it} from 'vitest';
+import {NotificationsSlice, selectNotifications} from '../Component/Notifications';
+import {errorNotificationMiddleware} from './errorNotificationMiddleware';
+
+function createTestStore(baseQueryFn: any) {
+    const api = createApi({
+        reducerPath: 'api',
+        baseQuery: baseQueryFn,
+        endpoints: (builder) => ({getData: builder.query<unknown, void>({query: () => '/test'})}),
+    });
+
+    const store = configureStore({
+        reducer: {[NotificationsSlice.name]: NotificationsSlice.reducer, [api.reducerPath]: api.reducer},
+        middleware: (getDefaultMiddleware) =>
+            getDefaultMiddleware({serializableCheck: false}).concat(api.middleware, errorNotificationMiddleware),
+    });
+
+    return {store, api};
+}
+
+describe('errorNotificationMiddleware', () => {
+    it('dispatches notification on FETCH_ERROR', async () => {
+        const {store, api} = createTestStore(() => ({
+            error: {status: 'FETCH_ERROR', error: 'Network error'},
+            meta: {request: {url: 'http://localhost/test'}},
+        }));
+
+        await store.dispatch(api.endpoints.getData.initiate());
+        const notifications = selectNotifications({notifications: store.getState().notifications});
+
+        expect(notifications).toHaveLength(1);
+        expect(notifications[0].color).toBe('error');
+        expect(notifications[0].title).toBe('Network error');
+        expect(notifications[0].text).toContain('http://localhost/test');
+    });
+
+    it('dispatches notification on HTTP 500 error', async () => {
+        const {store, api} = createTestStore(() => ({
+            error: {status: 500, data: {error: 'Class "Foo" is not registered in the DI container.'}},
+            meta: {request: {url: 'http://localhost/inspect/api/object'}},
+        }));
+
+        await store.dispatch(api.endpoints.getData.initiate());
+        const notifications = selectNotifications({notifications: store.getState().notifications});
+
+        expect(notifications).toHaveLength(1);
+        expect(notifications[0].color).toBe('error');
+        expect(notifications[0].title).toBe('Request failed (500)');
+        expect(notifications[0].text).toBe('Class "Foo" is not registered in the DI container.');
+    });
+
+    it('dispatches notification on HTTP 404 error', async () => {
+        const {store, api} = createTestStore(() => ({
+            error: {status: 404, data: {error: 'Not found'}},
+            meta: {request: {url: 'http://localhost/test'}},
+        }));
+
+        await store.dispatch(api.endpoints.getData.initiate());
+        const notifications = selectNotifications({notifications: store.getState().notifications});
+
+        expect(notifications).toHaveLength(1);
+        expect(notifications[0].title).toBe('Request failed (404)');
+        expect(notifications[0].text).toBe('Not found');
+    });
+
+    it('uses fallback message when error field is missing', async () => {
+        const {store, api} = createTestStore(() => ({
+            error: {status: 500, data: {}},
+            meta: {request: {url: 'http://localhost/test'}},
+        }));
+
+        await store.dispatch(api.endpoints.getData.initiate());
+        const notifications = selectNotifications({notifications: store.getState().notifications});
+
+        expect(notifications).toHaveLength(1);
+        expect(notifications[0].text).toBe('HTTP 500');
+    });
+
+    it('does not dispatch notification on successful request', async () => {
+        const {store, api} = createTestStore(() => ({data: {result: 'ok'}}));
+
+        await store.dispatch(api.endpoints.getData.initiate());
+        const notifications = selectNotifications({notifications: store.getState().notifications});
+
+        expect(notifications).toHaveLength(0);
+    });
+});

--- a/libs/frontend/packages/sdk/src/API/errorNotificationMiddleware.ts
+++ b/libs/frontend/packages/sdk/src/API/errorNotificationMiddleware.ts
@@ -3,12 +3,23 @@ import {isRejectedWithValue, Middleware, MiddlewareAPI} from '@reduxjs/toolkit';
 
 export const errorNotificationMiddleware: Middleware = (api: MiddlewareAPI) => (next) => (action) => {
     if (isRejectedWithValue(action)) {
+        const requestUrl = action.meta?.baseQueryMeta?.request?.url ?? 'unknown';
+
         if (action.payload.status === 'FETCH_ERROR') {
-            const requestUrl = action.meta?.baseQueryMeta?.request?.url ?? 'unknown';
             api.dispatch(
                 addNotification({
                     title: action.payload.error,
                     text: `An error occurred during the request to ${requestUrl}`,
+                    color: 'error',
+                }),
+            );
+        } else if (typeof action.payload.status === 'number' && action.payload.status >= 400) {
+            const data = action.payload.data;
+            const errorMessage = data?.error || data?.message || `HTTP ${action.payload.status}`;
+            api.dispatch(
+                addNotification({
+                    title: `Request failed (${action.payload.status})`,
+                    text: errorMessage,
                     color: 'error',
                 }),
             );


### PR DESCRIPTION
## Summary

- Redesign Inspector Configuration Definitions and Container pages from DataGrid to custom styled components matching the Minimal Zen (Variant D) design pattern used by ParametersPage
- Fix infinite re-render loop (`Maximum update depth exceeded`) caused by unstable `setObjects`/`insertObject` refs from DataContext in useEffect/useCallback deps
- Extend `errorNotificationMiddleware` to dispatch toast notifications for HTTP error responses (4xx/5xx), not just network errors
- Show inline error messages with retry button when object loading fails (e.g. "Class is not registered in the DI container")

## Changes

### UI Redesign (DefinitionsPage, ContainerPage)
- Replace MUI DataGrid with custom styled `ListContainer` with column headers, hover rows, and `TablePagination`
- Add search bar with result count ("3 of 13 definitions"), empty state with icon
- Use `JetBrains Mono` for class names, `Download` icon for lazy load, separate Actions column
- Remove dependency on `LoaderContext` — load logic handled directly in page components

### Error Handling
- `errorNotificationMiddleware`: catch HTTP 4xx/5xx errors, extract `error`/`message` from response body, dispatch notification
- `DefinitionValue`/`ContainerValue`: track error state, show red `ErrorOutline` icon + error text, tooltip changes to "Retry loading"

### Tests
- 12 unit tests for DefinitionsPage (rendering, filtering, empty state, load, error handling)
- 11 unit tests for ContainerPage (same coverage)
- 5 unit tests for errorNotificationMiddleware (FETCH_ERROR, HTTP 500, 404, fallback, success)
- 3 E2E tests for Configuration tabs with mock API data
- Updated E2E mock handlers with proper data for `/inspect/api/config`, `/classes`, `/object`

## Test plan

- [x] `npm test` — 742 tests pass (78 files)
- [x] `npm run build` — all 3 packages build successfully
- [x] `npm run lint` — 0 errors (44 pre-existing warnings)
- [ ] Manual: open Definitions tab, verify entries render with search + pagination
- [ ] Manual: click Load on a class that errors — verify inline error + toast notification
- [ ] Manual: click retry — verify error clears and retries

https://claude.ai/code/session_01ViK9MgqkXpK5XWfdiXgAAN