### PR TITLE
claude/fix-ai-connection-link-QRQZd

### DIFF
--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -92,6 +92,117 @@ const App = () => (
 );
 ```
 
+## React 19 Pitfalls & Review Checklist
+
+**Apply this checklist whenever you write or review React code. A self-review that skips these points is not a review.** For every hook, every ref, every effect, every postMessage, walk through the relevant items below. Call out the issue with `file:line` and a concrete fix — don't write "looks good" on hot paths without explicit justification.
+
+### Render purity — never do these during render
+
+The function body of a component runs on every render, can be interrupted (concurrent features, Suspense retries), and runs twice in development (StrictMode). Nothing in the render phase may have observable side effects.
+
+- **No ref mutation during render.** `ref.current = ...` at the top level of a component body is a bug: unpredictable under StrictMode double-invocation and concurrent rendering. If you need "compute once, never recompute," use `useState(() => init)` — that's exactly what lazy state is for. If you need "latest value captured in a closure for later," move the assignment into `useEffect` / `useLayoutEffect`.
+- **No state setters during render without a guard.** `setX(...)` in the body without an `if (condition) setX(...)` + idempotency guard causes infinite loops. Prefer deriving the value during render instead of storing it.
+- **No timers, subscriptions, network I/O in render.** `setTimeout`, `fetch`, `addEventListener`, `new Observer()` all belong in effects.
+- **No `Date.now()` / `Math.random()` / `new Date()` during render without lazy state.** Non-deterministic output breaks hydration and StrictMode double-render assertions. Seed them with `useState(() => ...)`.
+- **No reading DOM geometry during render.** Use `useLayoutEffect` or a ref callback.
+
+Anti-pattern to flag on sight:
+
+```tsx
+// BAD — ref mutation during render
+const srcRef = useRef<string | undefined>(undefined);
+if (srcRef.current === undefined) {
+    srcRef.current = buildUrl(props);
+}
+
+// GOOD — lazy state initializer
+const [src] = useState(() => buildUrl(props));
+```
+
+### useRef usage
+
+- **`useRef<T>(null)` for DOM refs.** React assigns `null` on unmount, never `undefined`. `useRef<T | undefined>(undefined)` and `useRef<T>(null!)` are both wrong by default.
+- **Refs hold values you don't render.** If the JSX reads `ref.current`, it should probably be state instead.
+- **"Latest prop/callback" refs must sync in an effect, not in render.** Reading the latest value in handlers is fine; keeping the ref up to date must happen in `useEffect(() => { ref.current = value; })` or `useLayoutEffect` — not at the top of the function body.
+- **No `ref!.current`.** Fix the type or narrow it. Non-null assertions hide real bugs (ref can genuinely be null during the first render or after unmount).
+
+### useEffect discipline
+
+- **Every effect has a reason this can't be expressed as derived state, an event handler, or a ref callback.** If an effect only syncs state A to state B, delete it and compute B during render.
+- **Every subscription / listener / timer / `AbortController` has matching cleanup.** `return () => observer.unsubscribe()` / `clearTimeout(id)` / `controller.abort()`.
+- **Dependency arrays are complete.** Trust `eslint-plugin-react-hooks/exhaustive-deps`. Suppressing the rule is a smell — either lift the dependency or genuinely accept the stale closure with a comment explaining why.
+- **Effects that fetch data handle races.** Either use an `AbortController` or a local `cancelled` flag set to true in cleanup. Latest-response-wins is a classic bug.
+- **Effects that read props inside async code capture stale values.** Use a ref (updated in another effect) or include the prop in deps.
+- **Never write to props.** They're inputs.
+
+### Hook rules
+
+- **No conditional hooks, no hooks in loops, no hooks inside handlers.** Same call order on every render.
+- **Custom hooks start with `use`** so the rules-of-hooks linter enforces #1.
+- **No hooks past an early return.** All hooks must run before any conditional `return`.
+
+### useCallback / useMemo
+
+- **Don't add them reflexively.** They have a cost (the deps array, the allocation, the reader confusion). Add only when the value is passed to a memoized child or a dep of another hook, or the computation is genuinely expensive.
+- **Empty dep arrays are usually wrong.** A callback with `[]` that references state or props captures a stale closure forever. Either list the deps or store the value in a ref.
+- **Memoization is broken by inline objects/arrays at the call site.** `<Child config={{...}} />` defeats `memo(Child)` regardless of what Child does.
+
+### Keys
+
+- **Stable, unique, content-derived keys.** `key={item.id}`, not `key={index}` in dynamic lists. Index is acceptable only for fixed-length lists that never reorder.
+- **No random / `Math.random()` / `Date.now()` keys.** They remount children on every render, nuking state and focus.
+
+### Cross-window / postMessage
+
+- **Validate `event.source`.** Only accept messages from the window you expect (your own iframe's `contentWindow`, or `window.opener`). Any frame on the page can `postMessage` into yours.
+- **Validate `event.origin`** when the message carries security or integrity meaning.
+- **Validate `event.data` shape.** `typeof data === 'object' && data !== null && 'event' in data && (data.event === '...')` — not `data.event === '...'` on an unknown.
+- **Document `targetOrigin: '*'` usages.** Default should be a specific origin; `*` needs a comment explaining why the wider audience is safe.
+
+### Accessibility — auto-flag in review
+
+- **`<div onClick>` without `role`, `tabIndex`, and keyboard handler** is a non-operable button. Use `<button>` or add all three.
+- **`<Link href="#" onClick={preventDefault}>`** is not a link — it's a button styled as a link. Use `<button>` or the library's button-as-link form (`<Link component="button" type="button">` in MUI).
+- **Icon-only interactive elements need `aria-label`.**
+- **Dynamic regions** (toasts, live validation, async results) need `aria-live`, `role="status"`, or `role="alert"`.
+- **Form controls must have associated `<label>`** — not placeholders, not `title`.
+- **Focus management on modals / route changes / async content swaps.**
+- **`outline: none`** without an equivalent `:focus-visible` style is an accessibility regression.
+
+### TypeScript hygiene
+
+- **No `as unknown as X` double-casts.** Declare the global augmentation, fix the generic, or narrow properly.
+- **No `!` non-null assertions** on values that can actually be null at runtime (refs during first render, optional chaining targets, array finds).
+- **Global augmentations go in `.d.ts` and use `interface` for merging.** `type` aliases shadow; interfaces merge.
+- **`as const` + derived unions** instead of `enum`.
+
+### Performance red flags
+
+- **`React.memo(Child)` while Child receives inline `{...}` / `() => ...`** — memo is a no-op.
+- **Large lists without virtualization** (>100 rows).
+- **Context value computed inline every render** makes every consumer rerender.
+- **Images without `width`/`height`** cause cumulative layout shift.
+
+### State colocation
+
+- **Don't duplicate derived state.** If it can be computed from props/state, compute it during render.
+- **Don't lift state higher than it needs to be.** Siblings that both read a value → lift. Otherwise keep it local.
+- **Server data belongs in an async cache** (RTK Query / TanStack Query), not `useState` + `useEffect(fetch)`.
+
+### Self-review protocol
+
+Before claiming work is done — and **before writing any review summary** — walk through these in order:
+
+1. Grep your own diff for `\.current\s*=` — is every mutation inside an effect or handler?
+2. Grep for `useRef<[^>]*\|\s*undefined>` and `useRef<[^>]*>\(null!\)` — fix the types.
+3. For each `useEffect`, ask: cleanup? complete deps? race? Could this be derived instead?
+4. For each `postMessage` listener, verify `event.source` and data shape.
+5. For each interactive non-`<button>` / non-`<a>`, verify `role`, `tabIndex`, keyboard handler, and `aria-*`.
+6. For each `as`, `!`, `any`, `@ts-*` — justify or remove.
+7. Re-read your "what's good" section and delete anything you didn't audit against items 1–6.
+
+If you wrote the code, you owe the user items 1–6 before saying "done". If you're reviewing, items 1–6 determine whether the review is honest.
+
 ## TypeScript Rules
 
 1. **`type` over `interface`** — use `type` for all type definitions.

--- a/libs/API/src/Toolbar/ToolbarInjector.php
+++ b/libs/API/src/Toolbar/ToolbarInjector.php
@@ -60,11 +60,13 @@ final class ToolbarInjector
         $escapedStaticUrl = htmlspecialchars($staticUrl, ENT_QUOTES, 'UTF-8');
         $jsBackendUrl = addslashes($backendUrl);
         $jsDebugId = addslashes($debugId);
+        $jsPanelPath = addslashes(rtrim($this->panelConfig->viewerBasePath, '/'));
 
         return <<<HTML
             <div id="app-dev-toolbar" style="flex: 1"></div>
             <link rel="stylesheet" href="{$escapedStaticUrl}/toolbar/bundle.css" />
             <script>
+                window['__adp_panel_url'] = '{$jsPanelPath}';
                 window['AppDevPanelToolbarWidget'] = {
                     config: {
                         containerId: 'app-dev-toolbar',
@@ -76,6 +78,7 @@ final class ToolbarInjector
                                 usePreferredUrl: true,
                                 debugId: '{$jsDebugId}',
                             },
+                            panelPath: '{$jsPanelPath}',
                         },
                     },
                 };

--- a/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
@@ -215,14 +215,28 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
         getDebugQuery();
     }, [getDebugQuery, backendUrl, dispatch]);
 
-    // Auto-select first entry when data loads
+    // Auto-select entry: honor ?debugEntry= URL param first (used by the embedded
+    // toolbar's iframe so the panel renders the same entry the toolbar is showing),
+    // otherwise fall back to the latest entry.
     useEffect(() => {
-        if (getDebugQueryInfo.isSuccess && getDebugQueryInfo.data && getDebugQueryInfo.data.length) {
-            if (!debugEntry) {
-                dispatch(changeEntryAction(getDebugQueryInfo.data[0]));
+        if (!getDebugQueryInfo.isSuccess || !getDebugQueryInfo.data?.length) {
+            return;
+        }
+        const requestedId = searchParams.get('debugEntry');
+        if (requestedId) {
+            if (debugEntry?.id === requestedId) {
+                return;
+            }
+            const requested = getDebugQueryInfo.data.find((e) => e.id === requestedId);
+            if (requested) {
+                dispatch(changeEntryAction(requested));
+                return;
             }
         }
-    }, [getDebugQueryInfo.isSuccess, getDebugQueryInfo.data, dispatch, debugEntry]);
+        if (!debugEntry) {
+            dispatch(changeEntryAction(getDebugQueryInfo.data[0]));
+        }
+    }, [getDebugQueryInfo.isSuccess, getDebugQueryInfo.data, dispatch, debugEntry, searchParams]);
 
     // SSE for auto-refresh
     const changeEntry = useCallback(

--- a/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
@@ -44,7 +44,7 @@ import Tooltip from '@mui/material/Tooltip';
 import {styled, useTheme as useMuiTheme} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import * as React from 'react';
-import {useCallback, useEffect, useMemo, useReducer} from 'react';
+import {useCallback, useEffect, useMemo, useReducer, useRef} from 'react';
 import {ErrorBoundary} from 'react-error-boundary';
 import {useDispatch} from 'react-redux';
 import {Outlet, useLocation, useNavigate, useSearchParams} from 'react-router';
@@ -215,24 +215,31 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
         getDebugQuery();
     }, [getDebugQuery, backendUrl, dispatch]);
 
-    // Auto-select entry: honor ?debugEntry= URL param first (used by the embedded
-    // toolbar's iframe so the panel renders the same entry the toolbar is showing),
-    // otherwise fall back to the latest entry.
+    // Entry selection rules:
+    // - Honor `?debugEntry=<id>` from the URL on first load and when the URL
+    //   genuinely changes (the embedded toolbar's iframe navigates via
+    //   postMessage which rewrites the query string — we want to follow it).
+    // - Don't re-apply the URL when only the entries list refreshes (SSE),
+    //   otherwise the user's manual prev/next-arrow navigation (which updates
+    //   Redux but not the URL) would be overwritten every second.
+    // - If the URL has no `debugEntry` and nothing is selected yet, fall back
+    //   to the latest entry.
+    const lastSyncedUrlEntryIdRef = useRef<string | null>(null);
     useEffect(() => {
-        if (!getDebugQueryInfo.isSuccess || !getDebugQueryInfo.data?.length) {
-            return;
-        }
+        if (!getDebugQueryInfo.isSuccess || !getDebugQueryInfo.data?.length) return;
+
         const requestedId = searchParams.get('debugEntry');
-        if (requestedId) {
-            if (debugEntry?.id === requestedId) {
-                return;
-            }
+        if (requestedId && requestedId !== lastSyncedUrlEntryIdRef.current) {
             const requested = getDebugQueryInfo.data.find((e) => e.id === requestedId);
             if (requested) {
-                dispatch(changeEntryAction(requested));
+                lastSyncedUrlEntryIdRef.current = requestedId;
+                if (debugEntry?.id !== requestedId) {
+                    dispatch(changeEntryAction(requested));
+                }
                 return;
             }
         }
+
         if (!debugEntry) {
             dispatch(changeEntryAction(getDebugQueryInfo.data[0]));
         }

--- a/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
@@ -222,6 +222,8 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
     // - Don't re-apply the URL when only the entries list refreshes (SSE),
     //   otherwise the user's manual prev/next-arrow navigation (which updates
     //   Redux but not the URL) would be overwritten every second.
+    // - If the URL pins an entry that hasn't arrived in the list yet, wait for
+    //   SSE to bring it in; don't flash the latest entry in the meantime.
     // - If the URL has no `debugEntry` and nothing is selected yet, fall back
     //   to the latest entry.
     const lastSyncedUrlEntryIdRef = useRef<string | null>(null);
@@ -229,15 +231,15 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
         if (!getDebugQueryInfo.isSuccess || !getDebugQueryInfo.data?.length) return;
 
         const requestedId = searchParams.get('debugEntry');
-        if (requestedId && requestedId !== lastSyncedUrlEntryIdRef.current) {
+        if (requestedId) {
+            if (requestedId === lastSyncedUrlEntryIdRef.current) return;
             const requested = getDebugQueryInfo.data.find((e) => e.id === requestedId);
-            if (requested) {
-                lastSyncedUrlEntryIdRef.current = requestedId;
-                if (debugEntry?.id !== requestedId) {
-                    dispatch(changeEntryAction(requested));
-                }
-                return;
+            if (!requested) return; // pinned but not loaded yet — wait for SSE
+            lastSyncedUrlEntryIdRef.current = requestedId;
+            if (debugEntry?.id !== requestedId) {
+                dispatch(changeEntryAction(requested));
             }
+            return;
         }
 
         if (!debugEntry) {

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/AiChatPopup.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/AiChatPopup.tsx
@@ -335,10 +335,9 @@ export const AiChatPopup = ({open, onClose, entry, toolbarPosition = 'bottom'}: 
                                 href="#"
                                 onClick={(e: React.MouseEvent) => {
                                     e.preventDefault();
-                                    window.open(
-                                        (window as unknown as {__adp_panel_url?: string}).__adp_panel_url || '/debug',
-                                        '_blank',
-                                    );
+                                    const panelUrl =
+                                        (window as unknown as {__adp_panel_url?: string}).__adp_panel_url || '/debug';
+                                    window.open(`${panelUrl.replace(/\/$/, '')}/llm`, '_blank');
                                 }}
                                 sx={{fontSize: 11, fontWeight: 600, color: 'warning.dark'}}
                             >

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/AiChatPopup.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/AiChatPopup.tsx
@@ -305,6 +305,7 @@ export const AiChatPopup = ({open, onClose, entry, toolbarPosition = 'bottom'}: 
                             window.open(`${panelUrl}/llm`, '_blank');
                         }}
                         sx={{color: 'text.secondary'}}
+                        aria-label="Open full chat panel"
                         title="Open full chat panel"
                     >
                         <OpenInNewIcon sx={{fontSize: 16}} />

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/AiChatPopup.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/AiChatPopup.tsx
@@ -301,9 +301,8 @@ export const AiChatPopup = ({open, onClose, entry, toolbarPosition = 'bottom'}: 
                     <IconButton
                         size="small"
                         onClick={() => {
-                            const panelUrl =
-                                (window as unknown as {__adp_panel_url?: string}).__adp_panel_url || '/debug';
-                            window.open(`${panelUrl.replace(/\/$/, '')}/llm`, '_blank');
+                            const panelUrl = (window.__adp_panel_url || '/debug').replace(/\/$/, '');
+                            window.open(`${panelUrl}/llm`, '_blank');
                         }}
                         sx={{color: 'text.secondary'}}
                         title="Open full chat panel"
@@ -332,12 +331,11 @@ export const AiChatPopup = ({open, onClose, entry, toolbarPosition = 'bottom'}: 
                         <Typography sx={{fontSize: 11, color: 'warning.dark'}}>
                             AI not connected.{' '}
                             <Link
-                                href="#"
-                                onClick={(e: React.MouseEvent) => {
-                                    e.preventDefault();
-                                    const panelUrl =
-                                        (window as unknown as {__adp_panel_url?: string}).__adp_panel_url || '/debug';
-                                    window.open(`${panelUrl.replace(/\/$/, '')}/llm`, '_blank');
+                                component="button"
+                                type="button"
+                                onClick={() => {
+                                    const panelUrl = (window.__adp_panel_url || '/debug').replace(/\/$/, '');
+                                    window.open(`${panelUrl}/llm`, '_blank');
                                 }}
                                 sx={{fontSize: 11, fontWeight: 600, color: 'warning.dark'}}
                             >

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
@@ -135,6 +135,16 @@ const serviceWorker = navigator?.serviceWorker;
 
 type DebugIFrameProps = {baseUrlState: string; iframeEnabled: boolean; iframeSrc: string | null};
 
+/**
+ * Resolve the path under `baseUrl` where the panel SPA is mounted.
+ * Set by `ToolbarInjector` (PHP) from `PanelConfig::viewerBasePath`.
+ * Defaults to `/debug` to match the default adapter setup.
+ */
+const getPanelMountPath = (): string => {
+    const value = (window as unknown as {__adp_panel_url?: string}).__adp_panel_url;
+    return value && value.length > 0 ? value : '/debug';
+};
+
 const DebugIFrame = forwardRef(
     ({baseUrlState, iframeEnabled, iframeSrc}: DebugIFrameProps, ref: ForwardedRef<HTMLIFrameElement>) => {
         // Lock the src at mount time. Subsequent navigations are routed through
@@ -143,9 +153,13 @@ const DebugIFrame = forwardRef(
         // and re-fetch every API resource on every chip click.
         const srcRef = useRef<string | undefined>(undefined);
         if (srcRef.current === undefined) {
+            // The chip URL (e.g. `/debug?collector=Log&debugEntry=ABC`) is the
+            // panel-internal route path; the panel's React Router uses `panelMount`
+            // as basename, so the browser URL must include both: baseUrl + mount + path.
+            const panelMount = getPanelMountPath();
             srcRef.current = iframeSrc
-                ? baseUrlState + iframeSrc + (iframeSrc.includes('?') ? '&' : '?') + 'toolbar=0'
-                : baseUrlState + '/debug?toolbar=0';
+                ? baseUrlState + panelMount + iframeSrc + (iframeSrc.includes('?') ? '&' : '?') + 'toolbar=0'
+                : baseUrlState + panelMount + '?toolbar=0';
         }
         return (
             <iframe
@@ -241,8 +255,9 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
 
     const [open, setOpen] = useState(false);
     const handleDebugWindowOpen = useCallback(() => {
-        window.open(debugEntry ? baseUrlState + '/debug?debugEntry=' + debugEntry.id : baseUrlState + '/debug');
-    }, [debugEntry]);
+        const mount = getPanelMountPath();
+        window.open(debugEntry ? baseUrlState + mount + '?debugEntry=' + debugEntry.id : baseUrlState + mount);
+    }, [debugEntry, baseUrlState]);
 
     const handleClickOpen = useCallback(() => setOpen(true), []);
     const handleClose = useCallback(() => setOpen(false), []);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
@@ -8,8 +8,8 @@ import {
 import {addCurrentPageRequestId, changeEntryAction, useDebugEntry} from '@app-dev-panel/sdk/API/Debug/Context';
 import {debugApi, DebugEntry, useGetDebugQuery} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {DuckIcon} from '@app-dev-panel/sdk/Component/SvgIcon/DuckIcon';
-import {dispatchWindowEvent} from '@app-dev-panel/sdk/Helper/dispatchWindowEvent';
 import {isDebugEntryAboutConsole, isDebugEntryAboutWeb} from '@app-dev-panel/sdk/Helper/debugEntry';
+import {dispatchWindowEvent} from '@app-dev-panel/sdk/Helper/dispatchWindowEvent';
 import {DebugEntriesListModal} from '@app-dev-panel/toolbar/Module/Toolbar/Component/DebugEntriesListModal';
 import {AiChatPopup} from '@app-dev-panel/toolbar/Module/Toolbar/Component/Toolbar/AiChatPopup';
 import {CommandItem} from '@app-dev-panel/toolbar/Module/Toolbar/Component/Toolbar/Console/CommandItem';
@@ -141,8 +141,20 @@ type DebugIFrameProps = {baseUrlState: string; iframeEnabled: boolean; iframeSrc
  * Defaults to `/debug` to match the default adapter setup.
  */
 const getPanelMountPath = (): string => {
-    const value = (window as unknown as {__adp_panel_url?: string}).__adp_panel_url;
+    const value = window.__adp_panel_url;
     return value && value.length > 0 ? value : '/debug';
+};
+
+/**
+ * Build the initial iframe URL combining origin + panel mount + panel-internal
+ * route + a forced `toolbar=0` flag. Uses the URL API so trailing/leading
+ * slashes and existing query strings are handled safely.
+ */
+const buildIframeSrc = (baseUrl: string, panelMount: string, internalPath: string | null): string => {
+    const path = panelMount + (internalPath ?? '');
+    const url = new URL(path, baseUrl);
+    url.searchParams.set('toolbar', '0');
+    return url.toString();
 };
 
 const DebugIFrame = forwardRef(
@@ -153,13 +165,7 @@ const DebugIFrame = forwardRef(
         // and re-fetch every API resource on every chip click.
         const srcRef = useRef<string | undefined>(undefined);
         if (srcRef.current === undefined) {
-            // The chip URL (e.g. `/debug?collector=Log&debugEntry=ABC`) is the
-            // panel-internal route path; the panel's React Router uses `panelMount`
-            // as basename, so the browser URL must include both: baseUrl + mount + path.
-            const panelMount = getPanelMountPath();
-            srcRef.current = iframeSrc
-                ? baseUrlState + panelMount + iframeSrc + (iframeSrc.includes('?') ? '&' : '?') + 'toolbar=0'
-                : baseUrlState + panelMount + '?toolbar=0';
+            srcRef.current = buildIframeSrc(baseUrlState, getPanelMountPath(), iframeSrc);
         }
         return (
             <iframe
@@ -239,37 +245,55 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
     useEffect(() => setIsToolbarOpened(toolbarOpenState), [toolbarOpenState]);
     useEffect(() => setPosition(toolbarPosition), [toolbarPosition]);
 
+    const iframeRef = useRef<HTMLIFrameElement>(null);
+
+    // Unmounting the iframe must always clear `iframeReady` so the next open
+    // triggers a proper cold start (src-based load) instead of posting messages
+    // to a stale or not-yet-booted contentWindow.
+    const closeIframe = useCallback(() => {
+        setIframeEnabled(false);
+        setIframeReady(false);
+    }, []);
+
     const onToolbarClickHandler = useCallback(() => {
         const next = !isToolbarOpened;
         setIsToolbarOpened(next);
         dispatch(setToolbarOpen(next));
-        if (!next && iframeEnabled) setIframeEnabled(false);
-    }, [isToolbarOpened, iframeEnabled]);
+        if (!next && iframeEnabled) closeIframe();
+    }, [isToolbarOpened, iframeEnabled, closeIframe, dispatch]);
 
-    const onChangeHandler = useCallback((entry: DebugEntry) => {
-        setSelectedEntry(entry);
-        setIsToolbarOpened(true);
-        dispatch(setToolbarOpen(true));
-        dispatch(changeEntryAction(entry));
-    }, []);
+    const onChangeHandler = useCallback(
+        (entry: DebugEntry) => {
+            setSelectedEntry(entry);
+            setIsToolbarOpened(true);
+            dispatch(setToolbarOpen(true));
+            dispatch(changeEntryAction(entry));
+        },
+        [dispatch],
+    );
 
     const [open, setOpen] = useState(false);
     const handleDebugWindowOpen = useCallback(() => {
-        const mount = getPanelMountPath();
-        window.open(debugEntry ? baseUrlState + mount + '?debugEntry=' + debugEntry.id : baseUrlState + mount);
+        const url = new URL(getPanelMountPath(), baseUrlState);
+        if (debugEntry) {
+            url.searchParams.set('debugEntry', debugEntry.id);
+        }
+        window.open(url.toString());
     }, [debugEntry, baseUrlState]);
 
     const handleClickOpen = useCallback(() => setOpen(true), []);
     const handleClose = useCallback(() => setOpen(false), []);
 
-    const iframeRef = useRef<HTMLIFrameElement | undefined>(undefined);
-
     // Track when the embedded panel finishes booting so we can switch from
     // src-based loading (cold start) to postMessage-based navigation.
+    // Validate the source — any frame on the page can postMessage, but only
+    // our own iframe's contentWindow should flip the ready flag.
     useEffect(() => {
         const listener = (event: MessageEvent) => {
+            if (event.source !== iframeRef.current?.contentWindow) return;
             const data = event.data;
-            if (data && typeof data === 'object' && data.event === 'panel.loaded') {
+            if (typeof data !== 'object' || data === null || !('event' in data)) return;
+            if ((data as {event: unknown}).event === 'panel.loaded') {
                 setIframeReady(true);
             }
         };
@@ -277,18 +301,31 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
         return () => window.removeEventListener('message', listener);
     }, []);
 
+    // Flush the latest requested URL once the panel is ready. Covers two races:
+    // 1) The user clicks a chip after cold-start but before `panel.loaded` arrives;
+    //    the click lands in `iframeSrc` state but `srcRef` already locked in the
+    //    original URL. Sending it as postMessage once ready reconciles the state.
+    // 2) Close → reopen → immediate chip click with the same semantics.
+    useEffect(() => {
+        if (!iframeReady || !iframeSrc) return;
+        const contentWindow = iframeRef.current?.contentWindow;
+        if (!contentWindow) return;
+        dispatchWindowEvent(contentWindow, 'router.navigate', iframeSrc);
+    }, [iframeReady, iframeSrc]);
+
     const iframeRouteNavigate = useCallback(
         (url: string) => {
             if (!activeComponents.iframe) return;
             setIframeSrc(url);
-            // If the panel is already mounted and booted, navigate via postMessage
-            // to preserve panel state and avoid a full iframe reload.
+            // Hot path: panel already mounted and booted — navigate via postMessage
+            // to preserve panel state and avoid a full iframe reload. The flush
+            // effect above covers the "enabled but not ready yet" race.
             if (iframeEnabled && iframeReady && iframeRef.current?.contentWindow) {
                 dispatchWindowEvent(iframeRef.current.contentWindow, 'router.navigate', url);
                 return;
             }
-            // Cold start: enable the iframe; the URL we just stored becomes the
-            // initial src that DebugIFrame locks in at mount.
+            // Cold start: mount the iframe. The URL we just stored in `iframeSrc`
+            // becomes the initial src that `DebugIFrame` locks in at mount.
             if (!iframeEnabled) setIframeEnabled(true);
         },
         [iframeEnabled, iframeReady, activeComponents],
@@ -296,12 +333,12 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
 
     const toggleIframeHandler = useCallback(() => {
         if (!activeComponents.iframe) return;
-        setIframeEnabled((v) => {
-            // Closing unmounts the iframe; on next open we cold-start again.
-            if (v) setIframeReady(false);
-            return !v;
-        });
-    }, [activeComponents]);
+        if (iframeEnabled) {
+            closeIframe();
+        } else {
+            setIframeEnabled(true);
+        }
+    }, [activeComponents, iframeEnabled, closeIframe]);
 
     const {
         height: panelHeight,

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
@@ -138,11 +138,15 @@ type DebugIFrameProps = {baseUrlState: string; iframeEnabled: boolean; iframeSrc
 /**
  * Resolve the path under `baseUrl` where the panel SPA is mounted.
  * Set by `ToolbarInjector` (PHP) from `PanelConfig::viewerBasePath`.
- * Defaults to `/debug` to match the default adapter setup.
+ * Defaults to `/debug` to match the default adapter setup. Trailing slashes
+ * are stripped so `panelMount + '/...'` never produces a `//...` sequence
+ * which `new URL()` would parse as a protocol-relative authority.
  */
 const getPanelMountPath = (): string => {
-    const value = window.__adp_panel_url;
-    return value && value.length > 0 ? value : '/debug';
+    const raw = window.__adp_panel_url;
+    if (!raw) return '/debug';
+    const trimmed = raw.replace(/\/+$/, '');
+    return trimmed.length > 0 ? trimmed : '';
 };
 
 /**
@@ -247,12 +251,19 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
 
     const iframeRef = useRef<HTMLIFrameElement>(null);
 
+    // Queue for navigation requests that arrive before the panel has booted.
+    // Set inside event handlers (pre-flush) and consumed by the ready-flush
+    // effect; never read or written during render.
+    const pendingNavUrlRef = useRef<string | null>(null);
+
     // Unmounting the iframe must always clear `iframeReady` so the next open
     // triggers a proper cold start (src-based load) instead of posting messages
-    // to a stale or not-yet-booted contentWindow.
+    // to a stale or not-yet-booted contentWindow. Drop any pending navigation
+    // too — it was targeted at the now-destroyed panel instance.
     const closeIframe = useCallback(() => {
         setIframeEnabled(false);
         setIframeReady(false);
+        pendingNavUrlRef.current = null;
     }, []);
 
     const onToolbarClickHandler = useCallback(() => {
@@ -289,44 +300,52 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
     // Validate the source — any frame on the page can postMessage, but only
     // our own iframe's contentWindow should flip the ready flag.
     useEffect(() => {
+        const isPanelLoaded = (data: unknown): data is {event: 'panel.loaded'} =>
+            typeof data === 'object' && data !== null && 'event' in data && data.event === 'panel.loaded';
+
         const listener = (event: MessageEvent) => {
             if (event.source !== iframeRef.current?.contentWindow) return;
-            const data = event.data;
-            if (typeof data !== 'object' || data === null || !('event' in data)) return;
-            if ((data as {event: unknown}).event === 'panel.loaded') {
-                setIframeReady(true);
-            }
+            if (isPanelLoaded(event.data)) setIframeReady(true);
         };
         window.addEventListener('message', listener);
         return () => window.removeEventListener('message', listener);
     }, []);
 
-    // Flush the latest requested URL once the panel is ready. Covers two races:
-    // 1) The user clicks a chip after cold-start but before `panel.loaded` arrives;
-    //    the click lands in `iframeSrc` state but `srcRef` already locked in the
-    //    original URL. Sending it as postMessage once ready reconciles the state.
-    // 2) Close → reopen → immediate chip click with the same semantics.
+    // Flush a single pending navigation on the `iframeReady` false→true edge.
+    // Deps intentionally exclude `iframeSrc` — that would re-dispatch
+    // `router.navigate` on every hot-path click (since the hot path already
+    // calls `dispatchWindowEvent` synchronously and also `setIframeSrc`),
+    // causing duplicate postMessages.
     useEffect(() => {
-        if (!iframeReady || !iframeSrc) return;
+        if (!iframeReady) return;
+        const pending = pendingNavUrlRef.current;
+        if (!pending) return;
         const contentWindow = iframeRef.current?.contentWindow;
         if (!contentWindow) return;
-        dispatchWindowEvent(contentWindow, 'router.navigate', iframeSrc);
-    }, [iframeReady, iframeSrc]);
+        dispatchWindowEvent(contentWindow, 'router.navigate', pending);
+        pendingNavUrlRef.current = null;
+    }, [iframeReady]);
 
     const iframeRouteNavigate = useCallback(
         (url: string) => {
             if (!activeComponents.iframe) return;
             setIframeSrc(url);
             // Hot path: panel already mounted and booted — navigate via postMessage
-            // to preserve panel state and avoid a full iframe reload. The flush
-            // effect above covers the "enabled but not ready yet" race.
+            // to preserve panel state and avoid a full iframe reload.
             if (iframeEnabled && iframeReady && iframeRef.current?.contentWindow) {
                 dispatchWindowEvent(iframeRef.current.contentWindow, 'router.navigate', url);
                 return;
             }
-            // Cold start: mount the iframe. The URL we just stored in `iframeSrc`
-            // becomes the initial src that `DebugIFrame` locks in at mount.
-            if (!iframeEnabled) setIframeEnabled(true);
+            // Already mounted but still booting: queue so the ready-flush
+            // effect can dispatch the latest requested URL via postMessage.
+            if (iframeEnabled) {
+                pendingNavUrlRef.current = url;
+                return;
+            }
+            // Cold start: mount the iframe. `iframeSrc` (just set above)
+            // becomes the initial src that `DebugIFrame` locks in — no need
+            // to queue, the browser load carries the URL to the panel.
+            setIframeEnabled(true);
         },
         [iframeEnabled, iframeReady, activeComponents],
     );

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
@@ -159,18 +159,18 @@ const buildIframeSrc = (baseUrl: string, panelMount: string, internalPath: strin
 
 const DebugIFrame = forwardRef(
     ({baseUrlState, iframeEnabled, iframeSrc}: DebugIFrameProps, ref: ForwardedRef<HTMLIFrameElement>) => {
-        // Lock the src at mount time. Subsequent navigations are routed through
-        // postMessage (router.navigate) so the iframe never fully reloads —
-        // changing the src attribute would discard panel state, scroll, filters,
-        // and re-fetch every API resource on every chip click.
-        const srcRef = useRef<string | undefined>(undefined);
-        if (srcRef.current === undefined) {
-            srcRef.current = buildIframeSrc(baseUrlState, getPanelMountPath(), iframeSrc);
-        }
+        // Lock the src at mount time via `useState` with a lazy initializer:
+        // computed once on first render and never recomputed on subsequent
+        // renders, even when `iframeSrc` / `baseUrlState` props change.
+        // Subsequent navigations are routed through postMessage
+        // (router.navigate) so the iframe never fully reloads — changing the
+        // src attribute would discard panel state, scroll, filters, and
+        // re-fetch every API resource on every chip click.
+        const [src] = useState(() => buildIframeSrc(baseUrlState, getPanelMountPath(), iframeSrc));
         return (
             <iframe
                 ref={ref}
-                src={srcRef.current}
+                src={src}
                 style={{height: '100%', width: '100%', border: 'none'}}
                 hidden={!iframeEnabled}
                 loading="lazy"

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
@@ -8,6 +8,7 @@ import {
 import {addCurrentPageRequestId, changeEntryAction, useDebugEntry} from '@app-dev-panel/sdk/API/Debug/Context';
 import {debugApi, DebugEntry, useGetDebugQuery} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {DuckIcon} from '@app-dev-panel/sdk/Component/SvgIcon/DuckIcon';
+import {dispatchWindowEvent} from '@app-dev-panel/sdk/Helper/dispatchWindowEvent';
 import {isDebugEntryAboutConsole, isDebugEntryAboutWeb} from '@app-dev-panel/sdk/Helper/debugEntry';
 import {DebugEntriesListModal} from '@app-dev-panel/toolbar/Module/Toolbar/Component/DebugEntriesListModal';
 import {AiChatPopup} from '@app-dev-panel/toolbar/Module/Toolbar/Component/Toolbar/AiChatPopup';
@@ -136,13 +137,20 @@ type DebugIFrameProps = {baseUrlState: string; iframeEnabled: boolean; iframeSrc
 
 const DebugIFrame = forwardRef(
     ({baseUrlState, iframeEnabled, iframeSrc}: DebugIFrameProps, ref: ForwardedRef<HTMLIFrameElement>) => {
-        const src = iframeSrc
-            ? baseUrlState + iframeSrc + (iframeSrc.includes('?') ? '&' : '?') + 'toolbar=0'
-            : baseUrlState + '/debug?toolbar=0';
+        // Lock the src at mount time. Subsequent navigations are routed through
+        // postMessage (router.navigate) so the iframe never fully reloads —
+        // changing the src attribute would discard panel state, scroll, filters,
+        // and re-fetch every API resource on every chip click.
+        const srcRef = useRef<string | undefined>(undefined);
+        if (srcRef.current === undefined) {
+            srcRef.current = iframeSrc
+                ? baseUrlState + iframeSrc + (iframeSrc.includes('?') ? '&' : '?') + 'toolbar=0'
+                : baseUrlState + '/debug?toolbar=0';
+        }
         return (
             <iframe
                 ref={ref}
-                src={src}
+                src={srcRef.current}
                 style={{height: '100%', width: '100%', border: 'none'}}
                 hidden={!iframeEnabled}
                 loading="lazy"
@@ -207,6 +215,7 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
 
     const [iframeEnabled, setIframeEnabled] = useState(false);
     const [iframeSrc, setIframeSrc] = useState<string | null>(null);
+    const [iframeReady, setIframeReady] = useState(false);
     const [chatOpen, setChatOpen] = useState(false);
     const [position, setPosition] = useState<ToolbarPosition>(toolbarPosition);
     const [floatPos, setFloatPos] = useState(savedFloatRect ?? {x: 0, y: 0, width: 320, height: 360});
@@ -240,18 +249,43 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
 
     const iframeRef = useRef<HTMLIFrameElement | undefined>(undefined);
 
+    // Track when the embedded panel finishes booting so we can switch from
+    // src-based loading (cold start) to postMessage-based navigation.
+    useEffect(() => {
+        const listener = (event: MessageEvent) => {
+            const data = event.data;
+            if (data && typeof data === 'object' && data.event === 'panel.loaded') {
+                setIframeReady(true);
+            }
+        };
+        window.addEventListener('message', listener);
+        return () => window.removeEventListener('message', listener);
+    }, []);
+
     const iframeRouteNavigate = useCallback(
         (url: string) => {
             if (!activeComponents.iframe) return;
             setIframeSrc(url);
+            // If the panel is already mounted and booted, navigate via postMessage
+            // to preserve panel state and avoid a full iframe reload.
+            if (iframeEnabled && iframeReady && iframeRef.current?.contentWindow) {
+                dispatchWindowEvent(iframeRef.current.contentWindow, 'router.navigate', url);
+                return;
+            }
+            // Cold start: enable the iframe; the URL we just stored becomes the
+            // initial src that DebugIFrame locks in at mount.
             if (!iframeEnabled) setIframeEnabled(true);
         },
-        [iframeEnabled, activeComponents],
+        [iframeEnabled, iframeReady, activeComponents],
     );
 
     const toggleIframeHandler = useCallback(() => {
         if (!activeComponents.iframe) return;
-        setIframeEnabled((v) => !v);
+        setIframeEnabled((v) => {
+            // Closing unmounts the iframe; on next open we cold-start again.
+            if (v) setIframeReady(false);
+            return !v;
+        });
     }, [activeComponents]);
 
     const {

--- a/libs/frontend/packages/toolbar/src/vite-env.d.ts
+++ b/libs/frontend/packages/toolbar/src/vite-env.d.ts
@@ -1,3 +1,19 @@
 /// <reference types="vite/client" />
 
 declare module '@fontsource/*';
+
+/**
+ * Global `Window` augmentations for ADP.
+ *
+ * Set by `ToolbarInjector` (PHP) before the toolbar/panel bundles load.
+ * `interface` is required here — only interfaces merge into the global
+ * `Window` declaration; a `type` alias would shadow it instead.
+ */
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+interface Window {
+    /**
+     * Path under the host origin where the debug panel SPA is mounted.
+     * Sourced from `PanelConfig::viewerBasePath`. Defaults to `/debug` when absent.
+     */
+    __adp_panel_url?: string;
+}


### PR DESCRIPTION
The "AI not connected. Configure in panel" link in the toolbar's AI chat
popup opened the debugger root instead of the LLM configuration page.
Now it appends `/llm` so the user lands directly on the connection setup,
matching the behavior of the popup's "open full panel" icon button.