### PR TITLE
claude/symfony-asset-publishing-N7sxR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,8 @@ build-panel: ## Build panel + toolbar and copy to all adapter asset directories
 
 install-panel: ## Publish built panel assets into playground applications
 	@echo "$(CYAN)Publishing panel assets to playgrounds...$(RESET)"
-	cd $(PLAYGROUND_DIR)/symfony-app && rm -rf public/bundles/appdevpanel && php bin/console assets:install public --symlink
+	cd $(PLAYGROUND_DIR)/symfony-app && rm -rf public/bundles/appdevpanel && php bin/console assets:install public --symlink --relative
+	cd $(PLAYGROUND_DIR)/laravel-app && rm -rf public/vendor/app-dev-panel && php artisan vendor:publish --tag=app-dev-panel-assets --force --ansi
 	@echo "$(GREEN)Done. Panel available at /debug on each playground.$(RESET)"
 
 build-install-panel: build-panel install-panel ## Build panel + publish to all playgrounds

--- a/libs/Adapter/Laravel/src/AppDevPanelServiceProvider.php
+++ b/libs/Adapter/Laravel/src/AppDevPanelServiceProvider.php
@@ -185,7 +185,7 @@ final class AppDevPanelServiceProvider extends ServiceProvider
         if (is_dir($assetSource) && file_exists($assetSource . '/bundle.js')) {
             $this->publishes([
                 $assetSource => $this->app->publicPath('vendor/app-dev-panel'),
-            ], 'app-dev-panel-assets');
+            ], ['app-dev-panel-assets', 'laravel-assets']);
         }
 
         $this->loadRoutesFrom(__DIR__ . '/../routes/adp.php');

--- a/playground/laravel-app/composer.json
+++ b/playground/laravel-app/composer.json
@@ -38,6 +38,11 @@
         }
     },
     "scripts": {
+        "post-autoload-dump": [
+            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+            "@php artisan package:discover --ansi || true",
+            "@php artisan vendor:publish --tag=app-dev-panel-assets --force --ansi || true"
+        ],
         "serve": [
             "Composer\\Config::disableProcessTimeout",
             "bash ../../bin/serve.sh 8104"

--- a/playground/symfony-app/composer.json
+++ b/playground/symfony-app/composer.json
@@ -63,8 +63,14 @@
         }
     },
     "scripts": {
-        "post-install-cmd": ["php bin/console cache:clear --no-warmup || true"],
-        "post-update-cmd": ["php bin/console cache:clear --no-warmup || true"],
+        "post-install-cmd": [
+            "php bin/console cache:clear --no-warmup || true",
+            "php bin/console assets:install public --symlink --relative || true"
+        ],
+        "post-update-cmd": [
+            "php bin/console cache:clear --no-warmup || true",
+            "php bin/console assets:install public --symlink --relative || true"
+        ],
         "serve": [
             "Composer\\Config::disableProcessTimeout",
             "bash ../../bin/serve.sh 8102"


### PR DESCRIPTION
Symfony's /debug broke after composer reinstall because assets:install
wasn't in post-install-cmd. Laravel had the same latent issue.

- playground/symfony-app: add assets:install --symlink --relative to
  post-install-cmd and post-update-cmd
- playground/laravel-app: add post-autoload-dump running vendor:publish
  with --force for the app-dev-panel-assets tag
- adapter-laravel: also expose publish under the shared laravel-assets
  tag (Telescope/Horizon/Nova convention), so bulk publish picks it up

https://claude.ai/code/session_01BTQwdAYt9eUDNe7RkxYE6R