### PR TITLE
claude/enhance-chat-message-params-wKVtl

### DIFF
--- a/libs/API/src/Llm/Controller/LlmController.php
+++ b/libs/API/src/Llm/Controller/LlmController.php
@@ -350,6 +350,8 @@ final class LlmController
         $model = $body['model'] ?? $this->settings->getModel() ?? $this->providerService->getDefaultModel($provider);
         $temperature = isset($body['temperature']) ? (float) $body['temperature'] : 0.7;
 
+        $context = is_array($body['context'] ?? null) ? $body['context'] : null;
+        $messages = $this->prependBrowserContext($messages, $provider, $context);
         $messages = $this->prependCustomPrompt($messages, $provider);
 
         $acpSessionId = $this->extractAcpSessionId($request);
@@ -496,6 +498,100 @@ final class LlmController
         $this->historyStorage->clear();
 
         return $this->responseFactory->createJsonResponse([]);
+    }
+
+    /**
+     * Prepend a hidden system prompt describing the user's current browser
+     * context (URL, selected debug entry/collector, environment). Invisible
+     * to the end user — injected only into the outgoing LLM payload.
+     */
+    private function prependBrowserContext(array $messages, string $provider, ?array $context): array
+    {
+        if ($context === null || $context === []) {
+            return $messages;
+        }
+
+        $lines = ['Browser context for the user who is chatting with you (do not mention this block unless asked):'];
+
+        $url = is_string($context['url'] ?? null) ? $context['url'] : null;
+        if ($url !== null && $url !== '') {
+            $lines[] = '- URL: ' . $url;
+
+            $query = parse_url($url, PHP_URL_QUERY);
+            if (is_string($query) && $query !== '') {
+                parse_str($query, $params);
+                if (isset($params['debugEntry']) && is_string($params['debugEntry']) && $params['debugEntry'] !== '') {
+                    $lines[] = '- Debug entry ID: ' . $params['debugEntry'];
+                }
+                if (isset($params['collector']) && is_string($params['collector']) && $params['collector'] !== '') {
+                    $lines[] = '- Selected collector: ' . $params['collector'];
+                }
+            }
+        }
+
+        if (isset($context['title']) && is_string($context['title']) && $context['title'] !== '') {
+            $lines[] = '- Page title: ' . $context['title'];
+        }
+        if (isset($context['userAgent']) && is_string($context['userAgent']) && $context['userAgent'] !== '') {
+            $lines[] = '- User agent: ' . $context['userAgent'];
+        }
+        if (isset($context['language']) && is_string($context['language']) && $context['language'] !== '') {
+            $lines[] = '- Language: ' . $context['language'];
+        }
+        if (isset($context['timezone']) && is_string($context['timezone']) && $context['timezone'] !== '') {
+            $lines[] = '- Timezone: ' . $context['timezone'];
+        }
+        if (
+            isset($context['viewport']['width'], $context['viewport']['height'])
+            && is_numeric($context['viewport']['width'])
+            && is_numeric($context['viewport']['height'])
+        ) {
+            $lines[] = sprintf(
+                '- Viewport: %dx%d',
+                (int) $context['viewport']['width'],
+                (int) $context['viewport']['height'],
+            );
+        }
+        if (
+            isset($context['screen']['width'], $context['screen']['height'])
+            && is_numeric($context['screen']['width'])
+            && is_numeric($context['screen']['height'])
+        ) {
+            $dpr = isset($context['screen']['devicePixelRatio']) && is_numeric($context['screen']['devicePixelRatio'])
+                ? (float) $context['screen']['devicePixelRatio']
+                : 1.0;
+            $lines[] = sprintf(
+                '- Screen: %dx%d @%.2gx',
+                (int) $context['screen']['width'],
+                (int) $context['screen']['height'],
+                $dpr,
+            );
+        }
+        if (isset($context['theme']) && is_string($context['theme']) && $context['theme'] !== '') {
+            $lines[] = '- Theme: ' . $context['theme'];
+        }
+        if (isset($context['referrer']) && is_string($context['referrer']) && $context['referrer'] !== '') {
+            $lines[] = '- Referrer: ' . $context['referrer'];
+        }
+
+        if (count($lines) === 1) {
+            return $messages;
+        }
+
+        $contextPrompt = implode("\n", $lines);
+
+        if ($provider === 'anthropic' || $provider === 'openai') {
+            array_unshift($messages, ['role' => 'system', 'content' => $contextPrompt]);
+        } else {
+            for ($i = 0, $len = count($messages); $i < $len; $i++) {
+                if ($messages[$i]['role'] === 'user') {
+                    $messages[$i]['content'] = "[{$contextPrompt}]\n\n" . $messages[$i]['content'];
+                    break;
+                }
+            }
+        }
+
+        return $messages;
     }
 
     /**

--- a/libs/API/tests/Unit/Llm/Controller/LlmControllerTest.php
+++ b/libs/API/tests/Unit/Llm/Controller/LlmControllerTest.php
@@ -350,6 +350,83 @@ final class LlmControllerTest extends TestCase
         $this->assertTrue(true);
     }
 
+    public function testChatWithBrowserContextDoesNotCrash(): void
+    {
+        $controller = $this->makeController('openrouter', 'sk-test');
+        try {
+            $controller->chat($this->post([
+                'messages' => [['role' => 'user', 'content' => 'hi']],
+                'context' => [
+                    'url' => 'http://localhost:5173/debug?collector=request&debugEntry=abc123',
+                    'userAgent' => 'Mozilla/5.0',
+                    'language' => 'en-US',
+                    'timezone' => 'UTC',
+                    'viewport' => ['width' => 1920, 'height' => 1080],
+                    'screen' => ['width' => 2560, 'height' => 1440, 'devicePixelRatio' => 2],
+                    'theme' => 'dark',
+                    'title' => 'ADP',
+                ],
+            ]));
+        } catch (\Throwable) {
+            // Expected — outbound HTTP call fails.
+        }
+        $this->assertTrue(true);
+    }
+
+    public function testPrependBrowserContextAddsSystemMessageForAnthropic(): void
+    {
+        $controller = $this->makeController('anthropic', 'sk-ant-test');
+        $reflection = new \ReflectionMethod($controller, 'prependBrowserContext');
+
+        $messages = [['role' => 'user', 'content' => 'hi']];
+        $context = [
+            'url' => 'http://localhost/debug?collector=log&debugEntry=xyz',
+            'userAgent' => 'TestUA/1.0',
+        ];
+
+        $result = $reflection->invoke($controller, $messages, 'anthropic', $context);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('system', $result[0]['role']);
+        $this->assertStringContainsString(
+            'URL: http://localhost/debug?collector=log&debugEntry=xyz',
+            $result[0]['content'],
+        );
+        $this->assertStringContainsString('Debug entry ID: xyz', $result[0]['content']);
+        $this->assertStringContainsString('Selected collector: log', $result[0]['content']);
+        $this->assertStringContainsString('User agent: TestUA/1.0', $result[0]['content']);
+        $this->assertSame('user', $result[1]['role']);
+        $this->assertSame('hi', $result[1]['content']);
+    }
+
+    public function testPrependBrowserContextMergesIntoUserForOtherProviders(): void
+    {
+        $controller = $this->makeController('openrouter', 'sk-test');
+        $reflection = new \ReflectionMethod($controller, 'prependBrowserContext');
+
+        $messages = [['role' => 'user', 'content' => 'hi']];
+        $context = ['url' => 'http://localhost/debug?debugEntry=abc'];
+
+        $result = $reflection->invoke($controller, $messages, 'openrouter', $context);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('user', $result[0]['role']);
+        $this->assertStringContainsString('Debug entry ID: abc', $result[0]['content']);
+        $this->assertStringEndsWith('hi', $result[0]['content']);
+    }
+
+    public function testPrependBrowserContextNoOpForEmptyContext(): void
+    {
+        $controller = $this->makeController('anthropic', 'sk-ant-test');
+        $reflection = new \ReflectionMethod($controller, 'prependBrowserContext');
+
+        $messages = [['role' => 'user', 'content' => 'hi']];
+
+        $this->assertSame($messages, $reflection->invoke($controller, $messages, 'anthropic', null));
+        $this->assertSame($messages, $reflection->invoke($controller, $messages, 'anthropic', []));
+        $this->assertSame($messages, $reflection->invoke($controller, $messages, 'anthropic', ['url' => '']));
+    }
+
     public function testChatWithCustomPromptMergedIntoUser(): void
     {
         $settings = new FileLlmSettings($this->tmpDir);

--- a/libs/frontend/packages/panel/src/Module/Llm/Component/ChatPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Llm/Component/ChatPanel.tsx
@@ -16,6 +16,7 @@ import {
 } from '@app-dev-panel/sdk/API/Llm/AiChatSlice';
 import {ChatMessageList} from '@app-dev-panel/sdk/Component/ChatMessageList';
 import {Markdown} from '@app-dev-panel/sdk/Component/Markdown';
+import {collectChatContext} from '@app-dev-panel/sdk/Helper/collectChatContext';
 import {extractErrorMessage} from '@app-dev-panel/sdk/Helper/extractErrorMessage';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
@@ -163,6 +164,7 @@ export const ChatPanel = () => {
                     messages: outgoing
                         .filter((m) => m.status !== 'error' && m.status !== 'sending')
                         .map((m) => ({role: m.role, content: m.content})),
+                    context: collectChatContext(),
                 }).unwrap();
 
                 const assistantContent = result.choices?.[0]?.message?.content ?? 'No response.';
@@ -199,6 +201,7 @@ export const ChatPanel = () => {
             try {
                 const result = await chat({
                     messages: outgoing.map((m) => ({role: m.role, content: m.content})),
+                    context: collectChatContext(),
                 }).unwrap();
 
                 const assistantContent = result.choices?.[0]?.message?.content ?? 'No response.';

--- a/libs/frontend/packages/sdk/src/API/Llm/Llm.ts
+++ b/libs/frontend/packages/sdk/src/API/Llm/Llm.ts
@@ -31,7 +31,19 @@ type ModelsResponse = {models: LlmModel[]};
 
 export type ChatMessage = {role: 'system' | 'user' | 'assistant'; content: string};
 
-export type ChatRequest = {messages: ChatMessage[]; model?: string; temperature?: number};
+export type ChatContext = {
+    url?: string;
+    userAgent?: string;
+    language?: string;
+    timezone?: string;
+    viewport?: {width: number; height: number};
+    screen?: {width: number; height: number; devicePixelRatio: number};
+    theme?: 'light' | 'dark';
+    title?: string;
+    referrer?: string;
+};
+
+export type ChatRequest = {messages: ChatMessage[]; model?: string; temperature?: number; context?: ChatContext};
 
 export type ChatResponse = {choices?: Array<{message?: {content?: string}}>; error?: unknown};
 

--- a/libs/frontend/packages/sdk/src/Helper/collectChatContext.test.ts
+++ b/libs/frontend/packages/sdk/src/Helper/collectChatContext.test.ts
@@ -1,0 +1,81 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {collectChatContext} from './collectChatContext';
+
+describe('collectChatContext', () => {
+    beforeEach(() => {
+        window.history.replaceState({}, '', '/debug?collector=log&debugEntry=abc123');
+        document.title = 'ADP Test';
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('collects url, user agent, language, viewport, screen and title in JSDOM', () => {
+        const ctx = collectChatContext();
+
+        expect(ctx.url).toBe(window.location.href);
+        expect(ctx.url).toContain('collector=log');
+        expect(ctx.url).toContain('debugEntry=abc123');
+        expect(ctx.userAgent).toBe(window.navigator.userAgent);
+        expect(ctx.language).toBe(window.navigator.language);
+        expect(ctx.title).toBe('ADP Test');
+        expect(ctx.viewport).toEqual({width: window.innerWidth, height: window.innerHeight});
+        expect(ctx.screen).toEqual({
+            width: window.screen.width,
+            height: window.screen.height,
+            devicePixelRatio: window.devicePixelRatio,
+        });
+    });
+
+    it('includes a resolved IANA timezone', () => {
+        const ctx = collectChatContext();
+        expect(typeof ctx.timezone).toBe('string');
+        expect(ctx.timezone).not.toBe('');
+    });
+
+    it('reports light theme when prefers-color-scheme: dark does not match', () => {
+        vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        }));
+
+        expect(collectChatContext().theme).toBe('light');
+    });
+
+    it('reports dark theme when prefers-color-scheme: dark matches', () => {
+        vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+            matches: query.includes('dark'),
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        }));
+
+        expect(collectChatContext().theme).toBe('dark');
+    });
+
+    it('omits referrer when document.referrer is empty', () => {
+        Object.defineProperty(document, 'referrer', {configurable: true, value: ''});
+        expect(collectChatContext().referrer).toBeUndefined();
+    });
+
+    it('includes referrer when document.referrer is set', () => {
+        Object.defineProperty(document, 'referrer', {configurable: true, value: 'https://example.com/prev'});
+        expect(collectChatContext().referrer).toBe('https://example.com/prev');
+    });
+
+    it('returns an empty object when window is not defined (SSR)', async () => {
+        vi.stubGlobal('window', undefined);
+        expect(collectChatContext()).toEqual({});
+    });
+});

--- a/libs/frontend/packages/sdk/src/Helper/collectChatContext.ts
+++ b/libs/frontend/packages/sdk/src/Helper/collectChatContext.ts
@@ -1,0 +1,41 @@
+import type {ChatContext} from '@app-dev-panel/sdk/API/Llm/Llm';
+
+/**
+ * Collects browser-side context to attach to an AI chat message.
+ *
+ * Used by the chat panel to give the LLM implicit context about the current
+ * page (URL, selected debug entry, collector) and the user's environment
+ * (locale, timezone, viewport, theme). This is injected into the system/dev
+ * prompt on the backend and is not shown to the user.
+ */
+export const collectChatContext = (): ChatContext => {
+    if (typeof window === 'undefined') {
+        return {};
+    }
+
+    const context: ChatContext = {
+        url: window.location.href,
+        userAgent: window.navigator.userAgent,
+        language: window.navigator.language,
+        viewport: {width: window.innerWidth, height: window.innerHeight},
+        screen: {
+            width: window.screen.width,
+            height: window.screen.height,
+            devicePixelRatio: window.devicePixelRatio,
+        },
+        theme: window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
+        title: document.title,
+    };
+
+    try {
+        context.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch {
+        // Intl may be unavailable in some environments; skip silently.
+    }
+
+    if (document.referrer !== '') {
+        context.referrer = document.referrer;
+    }
+
+    return context;
+};

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/AiChatPopup.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/AiChatPopup.tsx
@@ -14,6 +14,7 @@ import {
 } from '@app-dev-panel/sdk/API/Llm/Llm';
 import {ChatMessageList} from '@app-dev-panel/sdk/Component/ChatMessageList';
 import {DuckIcon} from '@app-dev-panel/sdk/Component/SvgIcon/DuckIcon';
+import {collectChatContext} from '@app-dev-panel/sdk/Helper/collectChatContext';
 import {isDebugEntryAboutConsole, isDebugEntryAboutWeb} from '@app-dev-panel/sdk/Helper/debugEntry';
 import {extractErrorMessage} from '@app-dev-panel/sdk/Helper/extractErrorMessage';
 import CloseIcon from '@mui/icons-material/Close';
@@ -231,7 +232,7 @@ export const AiChatPopup = ({open, onClose, entry, toolbarPosition = 'bottom'}: 
             reduxDispatch(addMessage({role: 'assistant', content: '', status: 'sending'}));
 
             try {
-                const result = await chat({messages: apiMessages}).unwrap();
+                const result = await chat({messages: apiMessages, context: collectChatContext()}).unwrap();
                 const assistantContent = result.choices?.[0]?.message?.content ?? 'No response.';
 
                 // Update chat history for multi-turn


### PR DESCRIPTION
The panel now collects the current URL, selected debug entry / collector
(parsed from the URL query), user agent, language, timezone, viewport,
screen, theme and page title, and sends them alongside chat messages.

On the backend, the context is injected into a hidden system prompt
(merged into the first user message for providers without a system role)
so the assistant can answer questions about "this entry" / "this log" /
"why is this slow" without the user having to paste IDs manually.

The context block is invisible to the user in the chat UI.