### PR TITLE
claude/add-menu-links-mqEi6

### DIFF
--- a/libs/frontend/packages/sdk/src/Component/Layout/TopBar.test.tsx
+++ b/libs/frontend/packages/sdk/src/Component/Layout/TopBar.test.tsx
@@ -100,6 +100,27 @@ describe('TopBar', () => {
         expect(screen.queryByLabelText('Custom URL template')).not.toBeInTheDocument();
     });
 
+    it('renders external links to donate, website and github in more menu', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<TopBar />);
+
+        const moreButton = screen.getAllByRole('button').find((b) => b.textContent?.includes('more_vert'));
+        await user.click(moreButton!);
+
+        const donate = screen.getByRole('menuitem', {name: /Donate/});
+        expect(donate).toHaveAttribute('href', 'https://app-dev-panel.github.io/app-dev-panel/sponsor');
+        expect(donate).toHaveAttribute('target', '_blank');
+        expect(donate).toHaveAttribute('rel', 'noopener noreferrer');
+
+        const website = screen.getByRole('menuitem', {name: /Website/});
+        expect(website).toHaveAttribute('href', 'https://app-dev-panel.github.io/app-dev-panel/');
+        expect(website).toHaveAttribute('target', '_blank');
+
+        const github = screen.getByRole('menuitem', {name: /GitHub/});
+        expect(github).toHaveAttribute('href', 'https://github.com/app-dev-panel/app-dev-panel');
+        expect(github).toHaveAttribute('target', '_blank');
+    });
+
     it('calls onEditorConfigChange with patched template when edited', async () => {
         const user = userEvent.setup();
         const onChange = vi.fn();

--- a/libs/frontend/packages/sdk/src/Component/Layout/TopBar.tsx
+++ b/libs/frontend/packages/sdk/src/Component/Layout/TopBar.tsx
@@ -9,6 +9,7 @@ import {
     type EditorConfig,
     type EditorPreset,
 } from '@app-dev-panel/sdk/Helper/editorUrl';
+import GitHubIcon from '@mui/icons-material/GitHub';
 import {
     Autocomplete,
     Badge,
@@ -415,6 +416,43 @@ export const TopBar = React.memo(
                             <Icon sx={{fontSize: 20}}>settings</Icon>
                         </ListItemIcon>
                         <ListItemText>Settings</ListItemText>
+                    </MenuItem>
+                    <Divider />
+                    <MenuItem
+                        component="a"
+                        href="https://app-dev-panel.github.io/app-dev-panel/sponsor"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={handleMenuClose}
+                    >
+                        <ListItemIcon>
+                            <Icon sx={{fontSize: 20}}>favorite</Icon>
+                        </ListItemIcon>
+                        <ListItemText>Donate</ListItemText>
+                    </MenuItem>
+                    <MenuItem
+                        component="a"
+                        href="https://app-dev-panel.github.io/app-dev-panel/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={handleMenuClose}
+                    >
+                        <ListItemIcon>
+                            <Icon sx={{fontSize: 20}}>public</Icon>
+                        </ListItemIcon>
+                        <ListItemText>Website</ListItemText>
+                    </MenuItem>
+                    <MenuItem
+                        component="a"
+                        href="https://github.com/app-dev-panel/app-dev-panel"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={handleMenuClose}
+                    >
+                        <ListItemIcon>
+                            <GitHubIcon sx={{fontSize: 20}} />
+                        </ListItemIcon>
+                        <ListItemText>GitHub</ListItemText>
                     </MenuItem>
                 </Menu>
 


### PR DESCRIPTION
Adds three external links to the "more options" dropdown after Settings,
separated by a divider: Donate (favorite icon), Website (public icon)
and GitHub (brand icon from @mui/icons-material). All open in a new tab
with rel="noopener noreferrer".