### PR TITLE
claude/fix-badge-hover-color-u7eHb

### DIFF
--- a/libs/frontend/CLAUDE.md
+++ b/libs/frontend/CLAUDE.md
@@ -73,6 +73,7 @@ packages/
     │   │   ├── EmptyState.tsx              # Generic empty state (icon + title + desc)
     │   │   ├── SectionTitle.tsx            # Section heading component
     │   │   ├── SqlHighlight.tsx            # SQL syntax highlighting (Prism, inline/formatted modes)
+    │   │   ├── FilterChip.tsx              # Unified colored filter/tag badge (fixes gray-on-hover bug)
     │   │   ├── FilterInput.tsx             # Reusable filter text input with debounce
     │   │   ├── BodyPreview.tsx             # HTTP body preview (JSON, HTML, text)
     │   │   ├── ExplainPlanVisualizer.tsx   # SQL EXPLAIN plan tree visualizer

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/ElasticsearchPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/ElasticsearchPanel.tsx
@@ -1,5 +1,6 @@
 import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRenderer';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
+import {FilterChip} from '@app-dev-panel/sdk/Component/FilterChip';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
 import {monoFontFamily} from '@app-dev-panel/sdk/Component/Theme/DefaultTheme';
@@ -317,58 +318,29 @@ export const ElasticsearchPanel = ({data}: ElasticsearchPanelProps) => {
             {(methodBadgeCounts.length > 1 || statusBadgeCounts.length > 1) && (
                 <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75, mb: 2}}>
                     {statusBadgeCounts.map(([label, count]) => {
-                        const isActive = activeFilters.has(label);
                         const color = label === 'error' ? theme.palette.error.main : theme.palette.success.main;
                         return (
-                            <Chip
+                            <FilterChip
                                 key={label}
-                                label={`${label} (${count})`}
-                                size="small"
+                                label={label}
+                                count={count}
+                                color={color}
+                                active={activeFilters.has(label)}
                                 onClick={() => toggleFilter(label)}
-                                sx={{
-                                    fontSize: '11px',
-                                    height: 24,
-                                    borderRadius: 1,
-                                    fontWeight: 600,
-                                    cursor: 'pointer',
-                                    backgroundColor: isActive ? color : 'transparent',
-                                    color: isActive ? 'common.white' : color,
-                                    border: `1px solid ${color}`,
-                                }}
                             />
                         );
                     })}
-                    {methodBadgeCounts.map(([method, count]) => {
-                        const isActive = activeFilters.has(method);
-                        const color = methodColor(method, theme);
-                        return (
-                            <Chip
-                                key={method}
-                                label={`${method} (${count})`}
-                                size="small"
-                                onClick={() => toggleFilter(method)}
-                                sx={{
-                                    fontSize: '11px',
-                                    height: 24,
-                                    borderRadius: 1,
-                                    fontWeight: 600,
-                                    cursor: 'pointer',
-                                    backgroundColor: isActive ? color : 'transparent',
-                                    color: isActive ? 'common.white' : color,
-                                    border: `1px solid ${color}`,
-                                }}
-                            />
-                        );
-                    })}
-                    {activeFilters.size > 0 && (
-                        <Chip
-                            label="Clear"
-                            size="small"
-                            onClick={() => setActiveFilters(new Set())}
-                            variant="outlined"
-                            sx={{fontSize: '11px', height: 24, borderRadius: 1}}
+                    {methodBadgeCounts.map(([method, count]) => (
+                        <FilterChip
+                            key={method}
+                            label={method}
+                            count={count}
+                            color={methodColor(method, theme)}
+                            active={activeFilters.has(method)}
+                            onClick={() => toggleFilter(method)}
                         />
-                    )}
+                    ))}
+                    {activeFilters.size > 0 && <FilterChip label="Clear" onClick={() => setActiveFilters(new Set())} />}
                 </Box>
             )}
 

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/HttpClientPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/HttpClientPanel.tsx
@@ -5,6 +5,7 @@ import {BodyPreview} from '@app-dev-panel/sdk/Component/BodyPreview';
 import {CodeHighlight} from '@app-dev-panel/sdk/Component/CodeHighlight';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
+import {FilterChip} from '@app-dev-panel/sdk/Component/FilterChip';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
 import {monoFontFamily} from '@app-dev-panel/sdk/Component/Theme/DefaultTheme';
@@ -716,58 +717,27 @@ const HttpClientTabContent = ({data}: HttpClientPanelProps) => {
 
             {(badgeCounts.length > 1 || statusBadgeCounts.length > 1) && (
                 <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75, mb: 2}}>
-                    {statusBadgeCounts.map(([group, count]) => {
-                        const isActive = activeFilters.has(group);
-                        return (
-                            <Chip
-                                key={group}
-                                label={`${group} (${count})`}
-                                size="small"
-                                onClick={() => toggleFilter(group)}
-                                sx={{
-                                    fontSize: '11px',
-                                    height: 24,
-                                    borderRadius: 1,
-                                    fontWeight: 600,
-                                    cursor: 'pointer',
-                                    backgroundColor: isActive ? statusBadgeBg(group) : 'transparent',
-                                    color: isActive ? 'common.white' : statusBadgeBg(group),
-                                    border: `1px solid ${statusBadgeBg(group)}`,
-                                }}
-                            />
-                        );
-                    })}
-                    {badgeCounts.map(([method, count]) => {
-                        const isActive = activeFilters.has(method);
-                        const color = methodColor(method, theme);
-                        return (
-                            <Chip
-                                key={method}
-                                label={`${method} (${count})`}
-                                size="small"
-                                onClick={() => toggleFilter(method)}
-                                sx={{
-                                    fontSize: '11px',
-                                    height: 24,
-                                    borderRadius: 1,
-                                    fontWeight: 600,
-                                    cursor: 'pointer',
-                                    backgroundColor: isActive ? color : 'transparent',
-                                    color: isActive ? 'common.white' : color,
-                                    border: `1px solid ${color}`,
-                                }}
-                            />
-                        );
-                    })}
-                    {activeFilters.size > 0 && (
-                        <Chip
-                            label="Clear"
-                            size="small"
-                            onClick={() => setActiveFilters(new Set())}
-                            variant="outlined"
-                            sx={{fontSize: '11px', height: 24, borderRadius: 1}}
+                    {statusBadgeCounts.map(([group, count]) => (
+                        <FilterChip
+                            key={group}
+                            label={group}
+                            count={count}
+                            color={statusBadgeBg(group)}
+                            active={activeFilters.has(group)}
+                            onClick={() => toggleFilter(group)}
                         />
-                    )}
+                    ))}
+                    {badgeCounts.map(([method, count]) => (
+                        <FilterChip
+                            key={method}
+                            label={method}
+                            count={count}
+                            color={methodColor(method, theme)}
+                            active={activeFilters.has(method)}
+                            onClick={() => toggleFilter(method)}
+                        />
+                    ))}
+                    {activeFilters.size > 0 && <FilterChip label="Clear" onClick={() => setActiveFilters(new Set())} />}
                 </Box>
             )}
 

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/TimelinePanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/TimelinePanel.tsx
@@ -7,10 +7,11 @@ import {
 } from '@app-dev-panel/panel/Module/Debug/Component/Panel/timelineTypes';
 import {useTimelineEnrichment} from '@app-dev-panel/panel/Module/Debug/Component/Panel/useTimelineEnrichment';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
+import {FilterChip} from '@app-dev-panel/sdk/Component/FilterChip';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
 import {getCollectorLabel} from '@app-dev-panel/sdk/Helper/collectorMeta';
-import {Box, Chip, Collapse, IconButton, Tooltip, Typography} from '@mui/material';
+import {Box, Collapse, IconButton, Tooltip, Typography} from '@mui/material';
 import {styled, useTheme} from '@mui/material/styles';
 import {useCallback, useDeferredValue, useMemo, useState} from 'react';
 
@@ -241,34 +242,18 @@ export const TimelinePanel = ({data}: TimelinePanelProps) => {
                 {uniqueCollectors.map((col) => {
                     const isActive = activeFilters.has(col.shortName);
                     const color = getCollectorColor(col.fqcn);
+                    const clickable = uniqueCollectors.length > 1;
                     return (
-                        <Chip
+                        <FilterChip
                             key={col.shortName}
                             label={col.label !== 'Unknown' ? col.label : col.shortName}
-                            size="small"
-                            onClick={() => uniqueCollectors.length > 1 && toggleFilter(col.shortName)}
-                            sx={{
-                                fontSize: '11px',
-                                height: 24,
-                                borderRadius: 1,
-                                fontWeight: 600,
-                                cursor: uniqueCollectors.length > 1 ? 'pointer' : 'default',
-                                backgroundColor: isActive ? color.fg : 'transparent',
-                                color: isActive ? 'common.white' : color.fg,
-                                border: `1px solid ${color.fg}`,
-                            }}
+                            color={color.fg}
+                            active={isActive}
+                            onClick={clickable ? () => toggleFilter(col.shortName) : undefined}
                         />
                     );
                 })}
-                {activeFilters.size > 0 && (
-                    <Chip
-                        label="Clear"
-                        size="small"
-                        onClick={() => setActiveFilters(new Set())}
-                        variant="outlined"
-                        sx={{fontSize: '11px', height: 24, borderRadius: 1}}
-                    />
-                )}
+                {activeFilters.size > 0 && <FilterChip label="Clear" onClick={() => setActiveFilters(new Set())} />}
             </Box>
 
             {viewMode === 'list' ? (

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/ComposerPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/ComposerPage.tsx
@@ -1,6 +1,7 @@
 import {useGetComposerQuery} from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
 import {SwitchDialog} from '@app-dev-panel/panel/Module/Inspector/Component/Composer/SwitchDialog';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
+import {FilterChip} from '@app-dev-panel/sdk/Component/FilterChip';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
 import {JsonRenderer} from '@app-dev-panel/sdk/Component/JsonRenderer';
@@ -360,36 +361,18 @@ export const ComposerPage = () => {
 
                 {badgeCounts.length > 1 && (
                     <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75, mb: 2}}>
-                        {badgeCounts.map(([key, count]) => {
-                            const isActive = activeFilters.has(key);
-                            const color = badgeColor(key);
-                            return (
-                                <Chip
-                                    key={key}
-                                    label={`${badgeLabel(key)} (${count})`}
-                                    size="small"
-                                    onClick={() => toggleFilter(key)}
-                                    sx={{
-                                        fontSize: '11px',
-                                        height: 24,
-                                        borderRadius: 1,
-                                        fontWeight: 600,
-                                        cursor: 'pointer',
-                                        backgroundColor: isActive ? color : 'transparent',
-                                        color: isActive ? 'common.white' : color,
-                                        border: `1px solid ${color}`,
-                                    }}
-                                />
-                            );
-                        })}
-                        {activeFilters.size > 0 && (
-                            <Chip
-                                label="Clear"
-                                size="small"
-                                onClick={() => setActiveFilters(new Set())}
-                                variant="outlined"
-                                sx={{fontSize: '11px', height: 24, borderRadius: 1}}
+                        {badgeCounts.map(([key, count]) => (
+                            <FilterChip
+                                key={key}
+                                label={badgeLabel(key)}
+                                count={count}
+                                color={badgeColor(key)}
+                                active={activeFilters.has(key)}
+                                onClick={() => toggleFilter(key)}
                             />
+                        ))}
+                        {activeFilters.size > 0 && (
+                            <FilterChip label="Clear" onClick={() => setActiveFilters(new Set())} />
                         )}
                     </Box>
                 )}

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/RoutesPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/RoutesPage.tsx
@@ -1,6 +1,7 @@
 import {useGetRoutesQuery, useLazyGetCheckRouteQuery} from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
+import {FilterChip} from '@app-dev-panel/sdk/Component/FilterChip';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
 import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
@@ -494,36 +495,18 @@ export const RoutesPage = () => {
                     {/* Method filter badges */}
                     {badgeCounts.length > 1 && (
                         <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75, mb: 2}}>
-                            {badgeCounts.map(([method, count]) => {
-                                const isActive = activeFilters.has(method);
-                                const color = methodColor(method, theme);
-                                return (
-                                    <Chip
-                                        key={method}
-                                        label={`${method} (${count})`}
-                                        size="small"
-                                        onClick={() => toggleFilter(method)}
-                                        sx={{
-                                            fontSize: '11px',
-                                            height: 24,
-                                            borderRadius: 1,
-                                            fontWeight: 600,
-                                            cursor: 'pointer',
-                                            backgroundColor: isActive ? color : 'transparent',
-                                            color: isActive ? 'common.white' : color,
-                                            border: `1px solid ${color}`,
-                                        }}
-                                    />
-                                );
-                            })}
-                            {activeFilters.size > 0 && (
-                                <Chip
-                                    label="Clear"
-                                    size="small"
-                                    onClick={() => setActiveFilters(new Set())}
-                                    variant="outlined"
-                                    sx={{fontSize: '11px', height: 24, borderRadius: 1}}
+                            {badgeCounts.map(([method, count]) => (
+                                <FilterChip
+                                    key={method}
+                                    label={method}
+                                    count={count}
+                                    color={methodColor(method, theme)}
+                                    active={activeFilters.has(method)}
+                                    onClick={() => toggleFilter(method)}
                                 />
+                            ))}
+                            {activeFilters.size > 0 && (
+                                <FilterChip label="Clear" onClick={() => setActiveFilters(new Set())} />
                             )}
                         </Box>
                     )}

--- a/libs/frontend/packages/sdk/src/Component/FilterChip.test.tsx
+++ b/libs/frontend/packages/sdk/src/Component/FilterChip.test.tsx
@@ -1,0 +1,60 @@
+import {renderWithProviders} from '@app-dev-panel/sdk/test-utils';
+import {fireEvent, screen} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import {FilterChip} from './FilterChip';
+
+describe('FilterChip', () => {
+    it('renders the label', () => {
+        renderWithProviders(<FilterChip label="GET" />);
+        expect(screen.getByText('GET')).toBeInTheDocument();
+    });
+
+    it('appends count when provided', () => {
+        renderWithProviders(<FilterChip label="GET" count={5} />);
+        expect(screen.getByText('GET (5)')).toBeInTheDocument();
+    });
+
+    it('omits count when not provided', () => {
+        renderWithProviders(<FilterChip label="Clear" />);
+        expect(screen.getByText('Clear')).toBeInTheDocument();
+    });
+
+    it('renders count of 0 (distinct from undefined)', () => {
+        renderWithProviders(<FilterChip label="GET" count={0} />);
+        expect(screen.getByText('GET (0)')).toBeInTheDocument();
+    });
+
+    it('calls onClick when clicked', () => {
+        const onClick = vi.fn();
+        renderWithProviders(<FilterChip label="GET" onClick={onClick} />);
+        fireEvent.click(screen.getByText('GET'));
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not clickable without onClick', () => {
+        const {container} = renderWithProviders(<FilterChip label="GET" />);
+        expect(container.querySelector('.MuiChip-clickable')).toBeNull();
+    });
+
+    it('is clickable when onClick provided', () => {
+        const {container} = renderWithProviders(<FilterChip label="GET" onClick={() => {}} />);
+        expect(container.querySelector('.MuiChip-clickable')).toBeInTheDocument();
+    });
+
+    it('renders a chip root for the colored (inactive) variant', () => {
+        const {container} = renderWithProviders(<FilterChip label="error" color="#DC2626" />);
+        expect(container.querySelector('.MuiChip-root')).toBeInTheDocument();
+    });
+
+    it('renders a chip root for the active variant', () => {
+        const {container} = renderWithProviders(<FilterChip label="error" color="#DC2626" active />);
+        expect(container.querySelector('.MuiChip-root')).toBeInTheDocument();
+    });
+
+    it('does not forward the chipColor prop to the DOM', () => {
+        const {container} = renderWithProviders(<FilterChip label="error" color="#DC2626" />);
+        const chip = container.querySelector('.MuiChip-root') as HTMLElement;
+        expect(chip.hasAttribute('chipColor')).toBe(false);
+        expect(chip.hasAttribute('active')).toBe(false);
+    });
+});

--- a/libs/frontend/packages/sdk/src/Component/FilterChip.tsx
+++ b/libs/frontend/packages/sdk/src/Component/FilterChip.tsx
@@ -1,0 +1,73 @@
+import {Chip} from '@mui/material';
+import {alpha, styled} from '@mui/material/styles';
+
+/**
+ * FilterChip — unified colored filter/tag badge.
+ *
+ * Fixes the MUI default gray `action.hover` that clashes with a colored outline.
+ * When `color` is provided:
+ *   - inactive state: transparent background, colored border + text;
+ *     on hover/focus — a subtle tint of the same color instead of gray.
+ *   - active state: filled with the color + white text;
+ *     on hover/focus — slightly translucent to signal interactivity.
+ * When `color` is omitted:
+ *   - behaves as a neutral outlined chip (e.g. "Clear").
+ *
+ * Replaces the inline `sx` filter-chip pattern that existed across
+ * TimelinePanel, ElasticsearchPanel, HttpClientPanel, ComposerPage, RoutesPage.
+ */
+export type FilterChipProps = {
+    label: string;
+    count?: number;
+    /** Outline + text color (and active fill). Omit for the neutral "Clear" look. */
+    color?: string;
+    /** Whether the filter is currently active. Active chips are filled. */
+    active?: boolean;
+    onClick?: () => void;
+};
+
+type StyledChipProps = {chipColor?: string; active?: boolean};
+
+const StyledChip = styled(Chip, {
+    shouldForwardProp: (prop) => prop !== 'chipColor' && prop !== 'active',
+})<StyledChipProps>(({theme, chipColor, active}) => {
+    const accent = chipColor ?? theme.palette.text.secondary;
+    const borderColor = chipColor ?? theme.palette.divider;
+    const isActive = Boolean(active);
+    return {
+        fontSize: '11px',
+        height: 24,
+        borderRadius: theme.shape.borderRadius,
+        fontWeight: 600,
+        border: `1px solid ${borderColor}`,
+        backgroundColor: isActive ? accent : 'transparent',
+        color: isActive ? theme.palette.common.white : accent,
+        transition: theme.transitions.create(['background-color', 'color', 'box-shadow'], {
+            duration: theme.transitions.duration.shortest,
+        }),
+        '&.MuiChip-clickable:hover, &.MuiChip-clickable:focus-visible': {
+            backgroundColor: isActive
+                ? alpha(accent, 0.85)
+                : chipColor
+                  ? alpha(chipColor, 0.12)
+                  : theme.palette.action.hover,
+            color: isActive ? theme.palette.common.white : accent,
+            boxShadow: chipColor ? `0 0 0 1px ${alpha(chipColor, 0.35)}` : 'none',
+        },
+        '& .MuiChip-label': {paddingLeft: theme.spacing(1), paddingRight: theme.spacing(1)},
+    };
+});
+
+export const FilterChip = ({label, count, color, active = false, onClick}: FilterChipProps) => {
+    const displayLabel = count !== undefined ? `${label} (${count})` : label;
+    return (
+        <StyledChip
+            label={displayLabel}
+            size="small"
+            onClick={onClick}
+            clickable={Boolean(onClick)}
+            chipColor={color}
+            active={active}
+        />
+    );
+};


### PR DESCRIPTION
Colored outlined filter chips across TimelinePanel, ElasticsearchPanel,
HttpClientPanel, ComposerPage and RoutesPage all inlined the same Chip
sx recipe, which was visibly breaking on hover: MUI's default
`action.hover` painted a gray background on top of the colored border
and text.

Introduce a single `FilterChip` molecule in the SDK that:

- owns the colored outlined / filled-active design as one molecule;
- overrides the hover/focus state to use a tinted version of the chip's
  own color (alpha 0.12 inactive, 0.85 active) instead of the neutral
  `action.hover`, so colored chips stay on-brand on interaction;
- falls back to neutral `action.hover` only when no color is given
  (e.g. the "Clear" button), where gray is appropriate.

Replace all six inline Chip variants with `FilterChip`. Solid per-row
status tags (route method, package type, response code) are intentionally
left as raw Chip — they are a different molecule and not affected by the
hover bug.