### PR TITLE
claude/add-openapi-submenu-elements-iTFss

### DIFF
--- a/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
@@ -3,10 +3,12 @@ import {NotificationCenter} from '@app-dev-panel/panel/Application/Component/Not
 import {AiChatPopup} from '@app-dev-panel/toolbar/Module/Toolbar/Component/Toolbar/AiChatPopup';
 
 import {DuckIcon} from '@app-dev-panel/panel/Application/Component/DuckIcon';
+import {useFramesEntries} from '@app-dev-panel/panel/Module/Frames/Context/Context';
 import {
     useGetMcpSettingsQuery,
     useUpdateMcpSettingsMutation,
 } from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
+import {useOpenApiEntries} from '@app-dev-panel/panel/Module/OpenApi/Context/Context';
 import {useSelector} from '@app-dev-panel/panel/store';
 import {
     changeAutoLatest,
@@ -113,6 +115,19 @@ const hiddenCollectors = new Set<string>([
     CollectorsMap.RequestCollector,
     CollectorsMap.CommandCollector,
 ]);
+
+// ---------------------------------------------------------------------------
+// Derive a short label for an Open API / Frames entry URL
+// ---------------------------------------------------------------------------
+const labelFromUrl = (url: string): string => {
+    try {
+        const parsed = new URL(url);
+        const segments = parsed.pathname.split('/').filter(Boolean);
+        return segments[segments.length - 1] || parsed.host;
+    } catch {
+        return url;
+    }
+};
 
 // ---------------------------------------------------------------------------
 // Static inspector sub-items
@@ -398,6 +413,18 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
 
     // Build sidebar sections
     const selectedCollector = searchParams.get('collector') || '';
+    const openApiEntries = useOpenApiEntries();
+    const framesEntries = useFramesEntries();
+
+    const openApiChildren = useMemo(
+        () => Object.keys(openApiEntries).map((name) => ({key: name, icon: 'description', label: labelFromUrl(name)})),
+        [openApiEntries],
+    );
+
+    const framesChildren = useMemo(
+        () => Object.keys(framesEntries).map((name) => ({key: name, icon: 'web_asset', label: labelFromUrl(name)})),
+        [framesEntries],
+    );
 
     const debugChildren = useMemo(() => {
         const entriesList = [{key: '__entries__', icon: 'list', label: 'All Entries'}];
@@ -454,10 +481,10 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
                 href: '/llm',
                 children: [{key: '/llm/mcp', icon: 'hub', label: 'MCP'}],
             },
-            {key: 'open-api', icon: 'data_object', label: 'Open API', href: '/open-api'},
-            {key: 'frames', icon: 'web', label: 'Frames', href: '/frames'},
+            {key: 'open-api', icon: 'data_object', label: 'Open API', href: '/open-api', children: openApiChildren},
+            {key: 'frames', icon: 'web', label: 'Frames', href: '/frames', children: framesChildren},
         ],
-        [debugChildren],
+        [debugChildren, openApiChildren, framesChildren],
     );
 
     // Determine active child key
@@ -483,8 +510,11 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
         if (location.pathname.startsWith('/llm/mcp')) {
             return '/llm/mcp';
         }
+        if (location.pathname.startsWith('/open-api') || location.pathname.startsWith('/frames')) {
+            return searchParams.get('tab') || undefined;
+        }
         return undefined;
-    }, [location.pathname, selectedCollector]);
+    }, [location.pathname, selectedCollector, searchParams]);
 
     const handleNavigate = useCallback(
         (href: string) => {
@@ -506,6 +536,10 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
                 }
             } else if (sectionKey === 'inspector' || sectionKey === 'llm') {
                 navigate(childKey);
+            } else if (sectionKey === 'open-api') {
+                navigate(`/open-api?tab=${encodeURIComponent(childKey)}`);
+            } else if (sectionKey === 'frames') {
+                navigate(`/frames?tab=${encodeURIComponent(childKey)}`);
             }
         },
         [navigate, debugEntry],

--- a/libs/frontend/packages/panel/src/Module/Frames/Pages/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Module/Frames/Pages/Layout.tsx
@@ -8,6 +8,7 @@ import {TabContext, TabPanel} from '@mui/lab';
 import {IconButton, Link, Stack, Tab, Tabs, Typography, useTheme} from '@mui/material';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
+import {useSearchParams} from 'react-router';
 
 const PoliciesList = () => {
     return (
@@ -77,18 +78,27 @@ const NoEntries = React.memo(() => {
     );
 });
 export const Layout = () => {
-    const [tab, setTab] = useState<string>('');
+    const [searchParams, setSearchParams] = useSearchParams();
+    const requestedTab = searchParams.get('tab') ?? '';
+    const [tab, setTab] = useState<string>(requestedTab);
     const [settingsPopupOpen, setSettingsPopupOpen] = useState<boolean>(false);
-    const handleChange = (_event: React.SyntheticEvent, value: string) => setTab(value);
+    const handleChange = (_event: React.SyntheticEvent, value: string) => {
+        setTab(value);
+        setSearchParams({tab: value});
+    };
     const theme = useTheme();
 
     const frames = useFramesEntries();
 
     useEffect(() => {
-        if (frames && Object.keys(frames).length) {
-            setTab(Object.keys(frames)[0]);
+        const frameKeys = frames ? Object.keys(frames) : [];
+        if (!frameKeys.length) return;
+        if (requestedTab && frameKeys.includes(requestedTab)) {
+            setTab(requestedTab);
+        } else if (!tab || !frameKeys.includes(tab)) {
+            setTab(frameKeys[0]);
         }
-    }, [frames]);
+    }, [frames, requestedTab, tab]);
 
     return (
         <>

--- a/libs/frontend/packages/panel/src/Module/Frames/Pages/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Module/Frames/Pages/Layout.tsx
@@ -5,7 +5,7 @@ import {InfoBox} from '@app-dev-panel/sdk/Component/InfoBox';
 import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {Settings} from '@mui/icons-material';
 import {TabContext, TabPanel} from '@mui/lab';
-import {IconButton, Link, Stack, Tab, Tabs, Typography, useTheme} from '@mui/material';
+import {Box, IconButton, Link, Stack, Tab, Tabs, Typography, useTheme} from '@mui/material';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {useSearchParams} from 'react-router';
@@ -78,27 +78,37 @@ const NoEntries = React.memo(() => {
     );
 });
 export const Layout = () => {
-    const [searchParams, setSearchParams] = useSearchParams();
+    const [searchParams] = useSearchParams();
     const requestedTab = searchParams.get('tab') ?? '';
-    const [tab, setTab] = useState<string>(requestedTab);
+    const [tab, setTab] = useState<string>('');
     const [settingsPopupOpen, setSettingsPopupOpen] = useState<boolean>(false);
-    const handleChange = (_event: React.SyntheticEvent, value: string) => {
-        setTab(value);
-        setSearchParams({tab: value});
-    };
+    const handleChange = (_event: React.SyntheticEvent, value: string) => setTab(value);
     const theme = useTheme();
 
     const frames = useFramesEntries();
+    const focusedFrame = requestedTab && frames[requestedTab] ? requestedTab : null;
 
     useEffect(() => {
+        if (focusedFrame) return;
         const frameKeys = frames ? Object.keys(frames) : [];
         if (!frameKeys.length) return;
-        if (requestedTab && frameKeys.includes(requestedTab)) {
-            setTab(requestedTab);
-        } else if (!tab || !frameKeys.includes(tab)) {
+        if (!tab || !frameKeys.includes(tab)) {
             setTab(frameKeys[0]);
         }
-    }, [frames, requestedTab, tab]);
+    }, [frames, focusedFrame, tab]);
+
+    // Focused mode: a single frame is opened directly from the sidebar submenu.
+    // Render only the embedded content, filling the whole container.
+    if (focusedFrame) {
+        const url = frames[focusedFrame];
+        return (
+            <Box className={theme.palette.mode} sx={{width: '100%', height: 'calc(100vh - 140px)', display: 'flex'}}>
+                <object data={url} width="100%" height="100%" type="text/html" style={{flex: 1}}>
+                    <ErrorResolutionBox url={url} />
+                </object>
+            </Box>
+        );
+    }
 
     return (
         <>

--- a/libs/frontend/packages/panel/src/Module/OpenApi/Pages/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Module/OpenApi/Pages/Layout.tsx
@@ -5,7 +5,7 @@ import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {Settings} from '@mui/icons-material';
 import {TabContext, TabPanel} from '@mui/lab';
-import {IconButton, Stack, Tab, Tabs, useTheme} from '@mui/material';
+import {Box, IconButton, Stack, Tab, Tabs, useTheme} from '@mui/material';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {useSearchParams} from 'react-router';
@@ -20,27 +20,34 @@ const NoEntries = React.memo(() => (
     />
 ));
 export const Layout = () => {
-    const [searchParams, setSearchParams] = useSearchParams();
+    const [searchParams] = useSearchParams();
     const requestedTab = searchParams.get('tab') ?? '';
-    const [tab, setTab] = useState<string>(requestedTab);
+    const [tab, setTab] = useState<string>('');
     const [settingsPopupOpen, setSettingsPopupOpen] = useState<boolean>(false);
-    const handleChange = (_event: React.SyntheticEvent, value: string) => {
-        setTab(value);
-        setSearchParams({tab: value});
-    };
+    const handleChange = (_event: React.SyntheticEvent, value: string) => setTab(value);
     const theme = useTheme();
 
     const apiEntries = useOpenApiEntries();
+    const focusedEntry = requestedTab && apiEntries[requestedTab] ? requestedTab : null;
 
     useEffect(() => {
+        if (focusedEntry) return;
         const entryKeys = apiEntries ? Object.keys(apiEntries) : [];
         if (!entryKeys.length) return;
-        if (requestedTab && entryKeys.includes(requestedTab)) {
-            setTab(requestedTab);
-        } else if (!tab || !entryKeys.includes(tab)) {
+        if (!tab || !entryKeys.includes(tab)) {
             setTab(entryKeys[0]);
         }
-    }, [apiEntries, requestedTab, tab]);
+    }, [apiEntries, focusedEntry, tab]);
+
+    // Focused mode: a single entry is opened directly from the sidebar submenu.
+    // Render only the content, filling the whole container.
+    if (focusedEntry) {
+        return (
+            <Box className={theme.palette.mode} sx={{width: '100%', height: '100%'}}>
+                <SwaggerUI url={apiEntries[focusedEntry]} />
+            </Box>
+        );
+    }
 
     return (
         <>

--- a/libs/frontend/packages/panel/src/Module/OpenApi/Pages/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Module/OpenApi/Pages/Layout.tsx
@@ -8,6 +8,7 @@ import {TabContext, TabPanel} from '@mui/lab';
 import {IconButton, Stack, Tab, Tabs, useTheme} from '@mui/material';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
+import {useSearchParams} from 'react-router';
 import SwaggerUI from 'swagger-ui-react';
 import 'swagger-ui-react/swagger-ui.css';
 
@@ -19,18 +20,27 @@ const NoEntries = React.memo(() => (
     />
 ));
 export const Layout = () => {
-    const [tab, setTab] = useState<string>('');
+    const [searchParams, setSearchParams] = useSearchParams();
+    const requestedTab = searchParams.get('tab') ?? '';
+    const [tab, setTab] = useState<string>(requestedTab);
     const [settingsPopupOpen, setSettingsPopupOpen] = useState<boolean>(false);
-    const handleChange = (_event: React.SyntheticEvent, value: string) => setTab(value);
+    const handleChange = (_event: React.SyntheticEvent, value: string) => {
+        setTab(value);
+        setSearchParams({tab: value});
+    };
     const theme = useTheme();
 
     const apiEntries = useOpenApiEntries();
 
     useEffect(() => {
-        if (apiEntries && Object.keys(apiEntries).length) {
-            setTab(Object.keys(apiEntries)[0]);
+        const entryKeys = apiEntries ? Object.keys(apiEntries) : [];
+        if (!entryKeys.length) return;
+        if (requestedTab && entryKeys.includes(requestedTab)) {
+            setTab(requestedTab);
+        } else if (!tab || !entryKeys.includes(tab)) {
+            setTab(entryKeys[0]);
         }
-    }, [apiEntries]);
+    }, [apiEntries, requestedTab, tab]);
 
     return (
         <>


### PR DESCRIPTION
Each Open API spec and Frames entry now appears as a submenu item under
its parent section in the unified sidebar. Clicking a submenu item
navigates to the page with a ?tab=<url> query, which the corresponding
Layout syncs with its active tab — so deep-linking a specific entry now
works as well.

The submenu label is derived from the last URL path segment (falling back
to the host) to keep it readable in the narrow sidebar.

https://claude.ai/code/session_01KesZeCzfD7LRx1SGXfWuaq