### PR TITLE
Add outlined variant to command buttons in Inspector pages

### DIFF
--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/AnalysePage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/AnalysePage.tsx
@@ -186,6 +186,7 @@ export const AnalysePage = ({showHeader = true}: {showHeader?: boolean}) => {
                 {availableCommands.map((command) => (
                     <Box key={command.name} display="flex" alignItems="center">
                         <Button
+                            variant="outlined"
                             onClick={() => runCommand(command)}
                             color={
                                 activeCommand?.name === command.name && commandResponse !== null

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/TestsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/TestsPage.tsx
@@ -159,6 +159,7 @@ export const TestsPage = ({showHeader = true}: {showHeader?: boolean}) => {
                 {availableCommands.map((command) => (
                     <Box key={command.name} display="flex" alignItems="center">
                         <Button
+                            variant="outlined"
                             onClick={() => runCommand(command)}
                             color={
                                 activeCommand?.name === command.name && commandResponse !== null


### PR DESCRIPTION
## Summary
Updated the command execution buttons in the Inspector's Analyze and Tests pages to use the outlined button variant for improved visual consistency and styling.

## Key Changes
- Added `variant="outlined"` prop to Button components in AnalysePage.tsx
- Added `variant="outlined"` prop to Button components in TestsPage.tsx
- Both changes apply to the command execution buttons in the available commands list

## Implementation Details
The outlined variant provides a more subtle button appearance compared to the default variant, which is more appropriate for secondary actions like running individual commands within a list. This change affects the visual presentation without altering the functional behavior of the buttons.

https://claude.ai/code/session_01CvfRKV3qeVsXVdjHodo78X