### PR TITLE
Add authorization inspector for Yii 3 framework

### DIFF
--- a/libs/Adapter/Yii3/CLAUDE.md
+++ b/libs/Adapter/Yii3/CLAUDE.md
@@ -51,7 +51,8 @@ src/
 │   └── View/
 │       └── ViewEventListener.php
 ├── Inspector/
-│   └── DbSchemaProvider.php             # Database schema via Yiisoft DB
+│   ├── DbSchemaProvider.php             # Database schema via Yiisoft DB
+│   └── Yii3AuthorizationConfigProvider.php  # Live auth config via RBAC/User/Auth (all optional)
 ├── Proxy/
 │   ├── ContainerInterfaceProxy.php      # PSR-11 container proxy
 │   ├── ContainerProxyConfig.php
@@ -129,6 +130,19 @@ DebugHeaders → ToolbarMiddleware → ErrorCatcher → YiiApiMiddleware → Ses
 ```
 
 `DebugHeaders` must be outermost (before `ErrorCatcher`) to attach the debug ID even on error responses. `ToolbarMiddleware` must be after `DebugHeaders` (needs the debug ID) and before `ErrorCatcher` so the toolbar appears even on error pages. `YiiApiMiddleware` must be before `Router` to intercept API requests early.
+
+## Inspector
+
+`GET /inspect/api/authorization` is served by `Yii3AuthorizationConfigProvider`, wired in `config/di-api.php`. It introspects the DI container for optional Yii packages — if a package is absent, its section is empty rather than producing an error.
+
+| Section | Source |
+|---------|--------|
+| `guards` | `Yiisoft\Auth\AuthenticationMethodInterface` + concrete `HttpBasic`/`HttpBearer`/`HttpHeader`/`QueryParam`/`Composite` (yiisoft/auth). Deduplicated across the interface id and concrete class. |
+| `roleHierarchy` | `Yiisoft\Rbac\ItemsStorageInterface::getAll()` / `getChildren()` (yiisoft/rbac) — map `role name → list of child role names`. |
+| `voters` | `Yiisoft\Access\AccessCheckerInterface` (yiisoft/access) entry plus every rule returned by `Yiisoft\Rbac\RulesStorageInterface::getAll()`. |
+| `config` | `user`, `rbac`, `auth` subtrees of `app-dev-panel/yii3` params; plus live `CurrentUser` snapshot (`isGuest`, `id`) when `Yiisoft\User\CurrentUser` is in the container. |
+
+All four packages (`yiisoft/rbac`, `yiisoft/user`, `yiisoft/auth`, `yiisoft/access`) are declared in `composer.json` `suggest` — the adapter works without them, the inspector just renders an empty section.
 
 ## Configuration (`params.php`)
 

--- a/libs/Adapter/Yii3/composer.json
+++ b/libs/Adapter/Yii3/composer.json
@@ -70,6 +70,12 @@
         "yiisoft/yii-console": "^2.0",
         "yiisoft/yii-http": "^1.0"
     },
+    "suggest": {
+        "yiisoft/rbac": "Required for role/permission hierarchy in the Authorization inspector",
+        "yiisoft/user": "Required to show current identity and guest state in the Authorization inspector",
+        "yiisoft/auth": "Required to list configured authentication methods (guards) in the Authorization inspector",
+        "yiisoft/access": "Required to list the active access checker in the Authorization inspector"
+    },
     "repositories": [
         {
             "type": "path",

--- a/libs/Adapter/Yii3/config/di-api.php
+++ b/libs/Adapter/Yii3/config/di-api.php
@@ -11,6 +11,7 @@ use AppDevPanel\Adapter\Yii3\Api\AliasPathResolver;
 use AppDevPanel\Adapter\Yii3\Api\ToolbarMiddleware;
 use AppDevPanel\Adapter\Yii3\Api\YiiApiMiddleware;
 use AppDevPanel\Adapter\Yii3\Inspector\DbSchemaProvider;
+use AppDevPanel\Adapter\Yii3\Inspector\Yii3AuthorizationConfigProvider;
 use AppDevPanel\Api\ApiApplication;
 use AppDevPanel\Api\Debug\Controller\DebugController;
 use AppDevPanel\Api\Debug\Controller\SettingsController;
@@ -23,7 +24,6 @@ use AppDevPanel\Api\Http\JsonResponseFactoryInterface;
 use AppDevPanel\Api\Ingestion\Controller\IngestionController;
 use AppDevPanel\Api\Ingestion\Controller\OtlpController;
 use AppDevPanel\Api\Inspector\Authorization\AuthorizationConfigProviderInterface;
-use AppDevPanel\Api\Inspector\Authorization\NullAuthorizationConfigProvider;
 use AppDevPanel\Api\Inspector\Controller\AuthorizationController;
 use AppDevPanel\Api\Inspector\Controller\CacheController;
 use AppDevPanel\Api\Inspector\Controller\CommandController;
@@ -146,8 +146,16 @@ return [
         SchemaProviderInterface $schemaProvider,
     ) => new DatabaseController($jsonResponseFactory, $schemaProvider),
 
-    // Authorization provider
-    AuthorizationConfigProviderInterface::class => static fn() => new NullAuthorizationConfigProvider(),
+    // Authorization provider — wires Yii's RBAC/User/Auth services when available,
+    // falls back to the no-op provider when the whole `app-dev-panel/yii3` params subtree
+    // and none of the optional packages (yiisoft/rbac, yiisoft/user, yiisoft/auth,
+    // yiisoft/access) are present.
+    AuthorizationConfigProviderInterface::class => static function (ContainerInterface $container) use (
+        $params,
+    ): AuthorizationConfigProviderInterface {
+        $yii3Params = $params['app-dev-panel/yii3'] ?? [];
+        return new Yii3AuthorizationConfigProvider($container, is_array($yii3Params) ? $yii3Params : []);
+    },
 
     // Authorization controller
     AuthorizationController::class => static fn(

--- a/libs/Adapter/Yii3/src/Inspector/Yii3AuthorizationConfigProvider.php
+++ b/libs/Adapter/Yii3/src/Inspector/Yii3AuthorizationConfigProvider.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppDevPanel\Adapter\Yii3\Inspector;
+
+use AppDevPanel\Api\Inspector\Authorization\AuthorizationConfigProviderInterface;
+use Psr\Container\ContainerInterface;
+use Throwable;
+
+/**
+ * Yii 3 implementation of {@see AuthorizationConfigProviderInterface}.
+ *
+ * Exposes data from Yii's authorization ecosystem when the corresponding
+ * packages are installed (all optional):
+ *  - `yiisoft/rbac` — role/permission hierarchy
+ *  - `yiisoft/user` — current identity / guest role
+ *  - `yiisoft/auth` — authentication methods (as "guards")
+ *  - `yiisoft/access` — access checkers (as "voters")
+ *
+ * Missing packages produce empty sections rather than errors, so the class
+ * can safely be registered in any Yii 3 application regardless of which
+ * auth-related packages are present.
+ */
+final class Yii3AuthorizationConfigProvider implements AuthorizationConfigProviderInterface
+{
+    /**
+     * @param array<string, mixed> $params `app-dev-panel/yii3` params subtree.
+     *                                     Typically provided via `params.php`.
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly array $params = [],
+    ) {}
+
+    public function getGuards(): array
+    {
+        $guards = [];
+
+        foreach ($this->discoverAuthenticationMethods() as $name => $instance) {
+            $guards[] = [
+                'name' => $name,
+                'provider' => $instance::class,
+                'config' => $this->describeAuthenticationMethod($instance),
+            ];
+        }
+
+        return $guards;
+    }
+
+    public function getRoleHierarchy(): array
+    {
+        $itemsStorage = $this->tryGet('Yiisoft\\Rbac\\ItemsStorageInterface');
+        if ($itemsStorage === null || !method_exists($itemsStorage, 'getAll')) {
+            return [];
+        }
+
+        $hierarchy = [];
+
+        try {
+            /** @var iterable<object> $items */
+            $items = $itemsStorage->getAll();
+        } catch (Throwable) {
+            return [];
+        }
+
+        foreach ($items as $item) {
+            if (!method_exists($item, 'getName')) {
+                continue;
+            }
+            $name = (string) $item->getName();
+            if ($name === '') {
+                continue;
+            }
+            $hierarchy[$name] = $this->collectChildNames($itemsStorage, $name);
+        }
+
+        ksort($hierarchy);
+
+        return $hierarchy;
+    }
+
+    public function getVoters(): array
+    {
+        $voters = [];
+
+        $accessChecker = $this->tryGet('Yiisoft\\Access\\AccessCheckerInterface');
+        if ($accessChecker !== null) {
+            $voters[] = [
+                'name' => $accessChecker::class,
+                'type' => 'access_checker',
+                'priority' => null,
+            ];
+        }
+
+        foreach ($this->discoverRbacRules() as $rule) {
+            $voters[] = $rule;
+        }
+
+        return $voters;
+    }
+
+    public function getSecurityConfig(): array
+    {
+        $config = [];
+
+        $userParams = $this->params['user'] ?? null;
+        if (is_array($userParams)) {
+            $config['user'] = $userParams;
+        }
+
+        $rbacParams = $this->params['rbac'] ?? null;
+        if (is_array($rbacParams)) {
+            $config['rbac'] = $rbacParams;
+        }
+
+        $authParams = $this->params['auth'] ?? null;
+        if (is_array($authParams)) {
+            $config['auth'] = $authParams;
+        }
+
+        $currentUser = $this->tryGet('Yiisoft\\User\\CurrentUser');
+        if ($currentUser !== null) {
+            $config['currentUser'] = $this->describeCurrentUser($currentUser);
+        }
+
+        return $config;
+    }
+
+    /**
+     * @return array<string, object>
+     */
+    private function discoverAuthenticationMethods(): array
+    {
+        $candidates = [
+            'Yiisoft\\Auth\\Method\\HttpBasic',
+            'Yiisoft\\Auth\\Method\\HttpBearer',
+            'Yiisoft\\Auth\\Method\\HttpHeader',
+            'Yiisoft\\Auth\\Method\\QueryParam',
+            'Yiisoft\\Auth\\Method\\Composite',
+            'Yiisoft\\Auth\\AuthenticationMethodInterface',
+        ];
+
+        $methods = [];
+        foreach ($candidates as $class) {
+            $instance = $this->tryGet($class);
+            if ($instance === null) {
+                continue;
+            }
+            // De-duplicate: container may resolve the interface to one of the concrete classes.
+            $methods[$instance::class] = $instance;
+        }
+
+        return $methods;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function describeAuthenticationMethod(object $instance): array
+    {
+        $config = [];
+        foreach (['realm', 'headerName', 'tokenHeader', 'queryParameterName', 'pattern'] as $property) {
+            if (!property_exists($instance, $property)) {
+                continue;
+            }
+            try {
+                $reflection = new \ReflectionProperty($instance, $property);
+                $value = $reflection->getValue($instance);
+                if ($value === null || is_scalar($value)) {
+                    $config[$property] = $value;
+                }
+            } catch (Throwable $_) {
+                continue;
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectChildNames(object $itemsStorage, string $parentName): array
+    {
+        if (!method_exists($itemsStorage, 'getChildren')) {
+            return [];
+        }
+
+        try {
+            /** @var iterable<object>|array<string, object> $children */
+            $children = $itemsStorage->getChildren($parentName);
+        } catch (Throwable) {
+            return [];
+        }
+
+        $names = [];
+        foreach ($children as $key => $child) {
+            if (is_object($child) && method_exists($child, 'getName')) {
+                $name = (string) $child->getName();
+            } elseif (is_string($key) && $key !== '') {
+                $name = $key;
+            } else {
+                continue;
+            }
+            if ($name !== '') {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * @return list<array{name: string, type: string, priority: int|null}>
+     */
+    private function discoverRbacRules(): array
+    {
+        $rulesStorage = $this->tryGet('Yiisoft\\Rbac\\RulesStorageInterface');
+        if ($rulesStorage === null || !method_exists($rulesStorage, 'getAll')) {
+            return [];
+        }
+
+        try {
+            /** @var iterable<object>|array<string, object> $rules */
+            $rules = $rulesStorage->getAll();
+        } catch (Throwable) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($rules as $key => $rule) {
+            if (!is_object($rule)) {
+                continue;
+            }
+            $name = is_string($key) && $key !== '' ? $key : $rule::class;
+            $result[] = [
+                'name' => $name,
+                'type' => 'rbac_rule',
+                'priority' => null,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function describeCurrentUser(object $currentUser): array
+    {
+        $info = [];
+
+        if (method_exists($currentUser, 'isGuest')) {
+            try {
+                $info['isGuest'] = (bool) $currentUser->isGuest();
+            } catch (Throwable $_) {
+                // Unavailable outside a request — fall through without recording the value.
+                unset($_);
+            }
+        }
+
+        if (method_exists($currentUser, 'getId')) {
+            try {
+                $id = $currentUser->getId();
+                if ($id === null || is_scalar($id)) {
+                    $info['id'] = $id;
+                }
+            } catch (Throwable $_) {
+                // Identity unavailable — fall through.
+                unset($_);
+            }
+        }
+
+        return $info;
+    }
+
+    private function tryGet(string $id): ?object
+    {
+        if (!$this->container->has($id)) {
+            return null;
+        }
+        try {
+            $service = $this->container->get($id);
+        } catch (Throwable) {
+            return null;
+        }
+
+        return is_object($service) ? $service : null;
+    }
+}

--- a/libs/Adapter/Yii3/tests/Unit/Inspector/Yii3AuthorizationConfigProviderTest.php
+++ b/libs/Adapter/Yii3/tests/Unit/Inspector/Yii3AuthorizationConfigProviderTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppDevPanel\Adapter\Yii3\Tests\Unit\Inspector;
+
+use AppDevPanel\Adapter\Yii3\Inspector\Yii3AuthorizationConfigProvider;
+use AppDevPanel\Api\Inspector\Authorization\AuthorizationConfigProviderInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+final class Yii3AuthorizationConfigProviderTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $provider = new Yii3AuthorizationConfigProvider($this->emptyContainer());
+
+        $this->assertInstanceOf(AuthorizationConfigProviderInterface::class, $provider);
+    }
+
+    public function testReturnsEmptyDataWhenNoYiiAuthServicesPresent(): void
+    {
+        $provider = new Yii3AuthorizationConfigProvider($this->emptyContainer());
+
+        $this->assertSame([], $provider->getGuards());
+        $this->assertSame([], $provider->getRoleHierarchy());
+        $this->assertSame([], $provider->getVoters());
+        $this->assertSame([], $provider->getSecurityConfig());
+    }
+
+    public function testGetSecurityConfigReturnsParamsSubtreesWhenProvided(): void
+    {
+        $params = [
+            'user' => ['guestId' => null, 'authTimeout' => 3600],
+            'rbac' => ['itemFile' => '@runtime/rbac/items.php'],
+            'auth' => ['methods' => ['bearer']],
+            // Irrelevant keys are ignored.
+            'unrelated' => 'ignored',
+        ];
+
+        $provider = new Yii3AuthorizationConfigProvider($this->emptyContainer(), $params);
+
+        $this->assertSame(
+            [
+                'user' => ['guestId' => null, 'authTimeout' => 3600],
+                'rbac' => ['itemFile' => '@runtime/rbac/items.php'],
+                'auth' => ['methods' => ['bearer']],
+            ],
+            $provider->getSecurityConfig(),
+        );
+    }
+
+    public function testGetSecurityConfigIncludesCurrentUserWhenAvailable(): void
+    {
+        $currentUser = new class {
+            public function isGuest(): bool
+            {
+                return false;
+            }
+
+            public function getId(): string
+            {
+                return '42';
+            }
+        };
+
+        $provider = new Yii3AuthorizationConfigProvider($this->containerWith([
+            'Yiisoft\\User\\CurrentUser' => $currentUser,
+        ]));
+
+        $this->assertSame(['currentUser' => ['isGuest' => false, 'id' => '42']], $provider->getSecurityConfig());
+    }
+
+    public function testGetRoleHierarchyBuildsMapFromItemsStorage(): void
+    {
+        $admin = $this->namedItem('admin');
+        $editor = $this->namedItem('editor');
+        $user = $this->namedItem('user');
+
+        $itemsStorage = new class($admin, $editor, $user) {
+            /**
+             * @var array<string, list<object>>
+             */
+            private array $children;
+
+            /**
+             * @var list<object>
+             */
+            private array $all;
+
+            public function __construct(object $admin, object $editor, object $user)
+            {
+                $this->all = [$admin, $editor, $user];
+                $this->children = [
+                    'admin' => [$editor, $user],
+                    'editor' => [$user],
+                    'user' => [],
+                ];
+            }
+
+            public function getAll(): array
+            {
+                return $this->all;
+            }
+
+            public function getChildren(string $name): array
+            {
+                return $this->children[$name] ?? [];
+            }
+        };
+
+        $provider = new Yii3AuthorizationConfigProvider($this->containerWith([
+            'Yiisoft\\Rbac\\ItemsStorageInterface' => $itemsStorage,
+        ]));
+
+        $this->assertSame(
+            [
+                'admin' => ['editor', 'user'],
+                'editor' => ['user'],
+                'user' => [],
+            ],
+            $provider->getRoleHierarchy(),
+        );
+    }
+
+    public function testGetGuardsListsAuthenticationMethodsWithoutDuplicates(): void
+    {
+        $bearer = new class {
+            private string $realm = 'api';
+
+            private string $headerName = 'Authorization';
+        };
+
+        // Same instance exposed both by its concrete class and by the interface id —
+        // the provider must not produce duplicate entries.
+        $provider = new Yii3AuthorizationConfigProvider($this->containerWith([
+            'Yiisoft\\Auth\\Method\\HttpBearer' => $bearer,
+            'Yiisoft\\Auth\\AuthenticationMethodInterface' => $bearer,
+        ]));
+
+        $guards = $provider->getGuards();
+        $this->assertCount(1, $guards);
+        $this->assertSame($bearer::class, $guards[0]['name']);
+        $this->assertSame($bearer::class, $guards[0]['provider']);
+        $this->assertSame(['realm' => 'api', 'headerName' => 'Authorization'], $guards[0]['config']);
+    }
+
+    public function testGetVotersIncludesAccessCheckerAndRbacRules(): void
+    {
+        $accessChecker = new class {
+            public function userHasPermission(
+                int|string|null $userId,
+                string $permissionName,
+                array $parameters = [],
+            ): bool {
+                return false;
+            }
+        };
+
+        $ruleA = new class {};
+        $ruleB = new class {};
+
+        $rulesStorage = new class($ruleA, $ruleB) {
+            /**
+             * @var array<string, object>
+             */
+            private array $rules;
+
+            public function __construct(object $a, object $b)
+            {
+                $this->rules = ['ruleA' => $a, 'ruleB' => $b];
+            }
+
+            public function getAll(): array
+            {
+                return $this->rules;
+            }
+        };
+
+        $provider = new Yii3AuthorizationConfigProvider($this->containerWith([
+            'Yiisoft\\Access\\AccessCheckerInterface' => $accessChecker,
+            'Yiisoft\\Rbac\\RulesStorageInterface' => $rulesStorage,
+        ]));
+
+        $voters = $provider->getVoters();
+
+        $this->assertCount(3, $voters);
+        $this->assertSame('access_checker', $voters[0]['type']);
+        $this->assertSame($accessChecker::class, $voters[0]['name']);
+        $this->assertNull($voters[0]['priority']);
+
+        $this->assertSame('rbac_rule', $voters[1]['type']);
+        $this->assertSame('ruleA', $voters[1]['name']);
+        $this->assertSame('rbac_rule', $voters[2]['type']);
+        $this->assertSame('ruleB', $voters[2]['name']);
+    }
+
+    public function testGracefullyHandlesContainerExceptions(): void
+    {
+        $container = new class implements ContainerInterface {
+            public function has(string $id): bool
+            {
+                return true;
+            }
+
+            public function get(string $id): mixed
+            {
+                throw new class('boom') extends \RuntimeException implements NotFoundExceptionInterface {};
+            }
+        };
+
+        $provider = new Yii3AuthorizationConfigProvider($container);
+
+        $this->assertSame([], $provider->getGuards());
+        $this->assertSame([], $provider->getRoleHierarchy());
+        $this->assertSame([], $provider->getVoters());
+        $this->assertSame([], $provider->getSecurityConfig());
+    }
+
+    private function emptyContainer(): ContainerInterface
+    {
+        return $this->containerWith([]);
+    }
+
+    /**
+     * @param array<string, object> $services
+     */
+    private function containerWith(array $services): ContainerInterface
+    {
+        return new class($services) implements ContainerInterface {
+            /**
+             * @param array<string, object> $services
+             */
+            public function __construct(
+                private array $services,
+            ) {}
+
+            public function has(string $id): bool
+            {
+                return array_key_exists($id, $this->services);
+            }
+
+            public function get(string $id): object
+            {
+                if (!array_key_exists($id, $this->services)) {
+                    throw new class("Service {$id} not found") extends \RuntimeException implements
+                        NotFoundExceptionInterface {};
+                }
+                return $this->services[$id];
+            }
+        };
+    }
+
+    private function namedItem(string $name): object
+    {
+        return new class($name) {
+            public function __construct(
+                private string $name,
+            ) {}
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+        };
+    }
+}

--- a/mago.toml
+++ b/mago.toml
@@ -208,6 +208,8 @@ too-many-methods = { level = "warning", exclude = [
     "libs/Adapter/Symfony/src/DependencyInjection/AppDevPanelExtension.php",
     "libs/Adapter/Laravel/src/AppDevPanelServiceProvider.php",
     "libs/Adapter/Yii2/src/Module.php",
+    # Config providers — method count from introspecting framework internals
+    "libs/Adapter/Yii3/src/Inspector/Yii3AuthorizationConfigProvider.php",
     # Config value object — getters and withers for each config property
     "libs/Adapter/Yii3/src/Proxy/ContainerProxyConfig.php",
     # Recursive tree-walking dumper — method count inherent to object/array/resource type dispatch
@@ -252,6 +254,7 @@ cyclomatic-complexity = { level = "warning", threshold = 15, exclude = [
     "libs/Adapter/Symfony/src/Inspector/SymfonyConfigProvider.php",
     "libs/Adapter/Laravel/src/Inspector/LaravelConfigProvider.php",
     "libs/Adapter/Yii2/src/Inspector/Yii2ConfigProvider.php",
+    "libs/Adapter/Yii3/src/Inspector/Yii3AuthorizationConfigProvider.php",
     # CLI commands — complexity from multiple subcommands and output formatting
     "libs/Cli/src/Command/DebugQueryCommand.php",
     "libs/Adapter/Yii2/src/Controller/DebugQueryController.php",
@@ -277,6 +280,7 @@ kan-defect = { level = "warning", exclude = [
     "libs/Adapter/Symfony/src/Inspector/SymfonyConfigProvider.php",
     "libs/Adapter/Laravel/src/Inspector/LaravelConfigProvider.php",
     "libs/Adapter/Yii2/src/Inspector/Yii2ConfigProvider.php",
+    "libs/Adapter/Yii3/src/Inspector/Yii3AuthorizationConfigProvider.php",
     # CLI commands — high defect score from multiple subcommands
     "libs/Cli/src/Command/DebugQueryCommand.php",
     "libs/Adapter/Yii2/src/Controller/DebugQueryController.php",

--- a/website/guide/inspector/authorization.md
+++ b/website/guide/inspector/authorization.md
@@ -29,8 +29,16 @@ Inspect the security and authorization configuration of your application.
 | Adapter | Provider |
 |---------|----------|
 | Symfony | <class>AppDevPanel\Adapter\Symfony\Inspector\SymfonyConfigProvider</class> (reads `security.yaml` config) |
+| Yii 3 | <class>AppDevPanel\Adapter\Yii3\Inspector\Yii3AuthorizationConfigProvider</class> (reads RBAC / User / Auth / Access services) |
 | Others | <class>AppDevPanel\Api\Inspector\Authorization\NullAuthorizationConfigProvider</class> (returns empty) |
 
 ::: info
-Authorization inspection requires framework-specific integration. Currently, only the Symfony adapter provides full security config introspection.
+Authorization inspection requires framework-specific integration. The Yii 3 provider is installed automatically with `app-dev-panel/adapter-yii3`. Each section is filled in only when the corresponding Yii package is present in the container (all optional, listed under `suggest` in the adapter's `composer.json`):
+
+| Section | Required package |
+|---------|------------------|
+| Guards | `yiisoft/auth` |
+| Role hierarchy | `yiisoft/rbac` |
+| Voters | `yiisoft/access` and/or `yiisoft/rbac` |
+| Security config / current user | `yiisoft/user` |
 :::

--- a/website/ru/guide/inspector/authorization.md
+++ b/website/ru/guide/inspector/authorization.md
@@ -28,8 +28,16 @@ title: Инспектор авторизации
 | Адаптер | Провайдер |
 |---------|-----------|
 | Symfony | <class>AppDevPanel\Adapter\Symfony\Inspector\SymfonyConfigProvider</class> (читает конфигурацию `security.yaml`) |
+| Yii 3 | <class>AppDevPanel\Adapter\Yii3\Inspector\Yii3AuthorizationConfigProvider</class> (читает сервисы RBAC / User / Auth / Access) |
 | Другие | <class>AppDevPanel\Api\Inspector\Authorization\NullAuthorizationConfigProvider</class> (возвращает пустое значение) |
 
 ::: info
-Инспекция авторизации требует интеграции, специфичной для фреймворка. В настоящее время только адаптер Symfony предоставляет полную интроспекцию конфигурации безопасности.
+Инспекция авторизации требует интеграции, специфичной для фреймворка. Провайдер для Yii 3 устанавливается автоматически вместе с `app-dev-panel/adapter-yii3`. Каждый раздел заполняется только при наличии соответствующего пакета Yii в контейнере (все опциональны и перечислены в `suggest` в `composer.json` адаптера):
+
+| Раздел | Необходимый пакет |
+|--------|-------------------|
+| Guards | `yiisoft/auth` |
+| Иерархия ролей | `yiisoft/rbac` |
+| Voters | `yiisoft/access` и/или `yiisoft/rbac` |
+| Конфигурация безопасности / текущий пользователь | `yiisoft/user` |
 :::


### PR DESCRIPTION
## Summary

Implements authorization configuration introspection for Yii 3 applications by adding `Yii3AuthorizationConfigProvider`, enabling the `/inspect/api/authorization` endpoint to expose security and auth configuration from Yii's optional packages.

## Key Changes

- **New `Yii3AuthorizationConfigProvider` class**: Implements `AuthorizationConfigProviderInterface` to introspect Yii 3's authorization ecosystem
  - Discovers and lists authentication methods (guards) from `yiisoft/auth` package
  - Builds role/permission hierarchy from `yiisoft/rbac` ItemsStorage
  - Lists access checkers and RBAC rules as voters
  - Exposes current user identity and guest state from `yiisoft/user`
  - Gracefully handles missing packages by returning empty sections instead of errors

- **Comprehensive test coverage**: 268-line test suite covering:
  - Interface implementation
  - Empty data when services unavailable
  - Parameter extraction from config
  - Current user introspection
  - Role hierarchy building
  - Guard discovery with deduplication
  - Voter listing (access checkers + RBAC rules)
  - Exception handling for container failures

- **DI configuration**: Registered `Yii3AuthorizationConfigProvider` in `config/di-api.php` to replace the null provider

- **Documentation updates**: 
  - Updated `CLAUDE.md` with inspector architecture and package mapping
  - Updated English and Russian guides to document Yii 3 support
  - Added composer.json suggestions for optional auth packages

## Implementation Details

- Uses reflection to safely extract configuration properties from authentication method instances
- Implements defensive programming with try-catch blocks around container access and method calls
- Deduplicates authentication methods when the same instance is registered under multiple IDs
- Supports both keyed and indexed collections from storage interfaces
- All optional Yii packages are truly optional—missing packages produce empty sections rather than errors

https://claude.ai/code/session_0181rmFzubfCJR9kDkeEVYZ6