### PR TITLE
Fix TranslationController dependency injection in Yii3 adapter

### DIFF
--- a/libs/Adapter/Yii3/config/di-api.php
+++ b/libs/Adapter/Yii3/config/di-api.php
@@ -81,6 +81,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
+use Psr\Log\LoggerInterface;
 use Yiisoft\Aliases\Aliases;
 
 /** @var array $params */
@@ -292,8 +293,9 @@ return [
 
     TranslationController::class => static fn(
         JsonResponseFactoryInterface $jsonResponseFactory,
+        LoggerInterface $logger,
         ContainerInterface $container,
-    ) => new TranslationController($jsonResponseFactory, null, $container),
+    ) => new TranslationController($jsonResponseFactory, $logger, $container, $params),
 
     CommandController::class => static function (
         JsonResponseFactoryInterface $jsonResponseFactory,

--- a/libs/Adapter/Yii3/tests/Unit/Config/DiApiConfigTest.php
+++ b/libs/Adapter/Yii3/tests/Unit/Config/DiApiConfigTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppDevPanel\Adapter\Yii3\Tests\Unit\Config;
+
+use AppDevPanel\Api\Http\JsonResponseFactoryInterface;
+use AppDevPanel\Api\Inspector\Controller\TranslationController;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use ReflectionFunction;
+
+/**
+ * Tests that di-api.php factory closures resolve controller dependencies correctly.
+ *
+ * Regression: TranslationController was constructed with `null` for the required
+ * LoggerInterface argument, causing a TypeError when the translation inspector was used.
+ */
+final class DiApiConfigTest extends TestCase
+{
+    private array $definitions;
+
+    protected function setUp(): void
+    {
+        $params = [
+            'app-dev-panel/yii3' => [
+                'enabled' => true,
+                'api' => ['enabled' => true],
+            ],
+        ];
+        $this->definitions = (static function () use ($params): array {
+            return require dirname(__DIR__, 3) . '/config/di-api.php';
+        })();
+    }
+
+    public function testTranslationControllerFactoryInjectsLoggerInterface(): void
+    {
+        $this->assertArrayHasKey(TranslationController::class, $this->definitions);
+        $factory = $this->definitions[TranslationController::class];
+        $this->assertInstanceOf(\Closure::class, $factory);
+
+        $ref = new ReflectionFunction($factory);
+        $types = [];
+        foreach ($ref->getParameters() as $param) {
+            $type = $param->getType();
+            if ($type instanceof \ReflectionNamedType) {
+                $types[] = $type->getName();
+            }
+        }
+
+        $this->assertContains(
+            LoggerInterface::class,
+            $types,
+            'TranslationController factory must inject LoggerInterface — null triggers a TypeError',
+        );
+    }
+
+    public function testTranslationControllerFactoryProducesValidInstance(): void
+    {
+        $factory = $this->definitions[TranslationController::class];
+
+        $controller = $factory(
+            $this->createMock(JsonResponseFactoryInterface::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(ContainerInterface::class),
+        );
+
+        $this->assertInstanceOf(TranslationController::class, $controller);
+    }
+}

--- a/playground/yii3-app/config/common/params.php
+++ b/playground/yii3-app/config/common/params.php
@@ -34,6 +34,13 @@ return [
 
     'application' => require __DIR__ . '/application.php',
 
+    'locale' => [
+        'locales' => [
+            'en' => 'en-US',
+            'de' => 'de-DE',
+        ],
+    ],
+
     'yiisoft/aliases' => [
         'aliases' => require __DIR__ . '/aliases.php',
     ],


### PR DESCRIPTION
## Summary
Fixed a regression where `TranslationController` was being instantiated with `null` for the required `LoggerInterface` dependency, causing a `TypeError` when the translation inspector was used.

## Key Changes
- **Updated `di-api.php` factory closure**: Modified the `TranslationController` factory to properly inject `LoggerInterface` instead of passing `null`
- **Added logger parameter**: The factory now declares `LoggerInterface $logger` as a dependency and passes it to the controller constructor
- **Pass configuration params**: Updated the factory to also pass `$params` to the controller constructor
- **Added comprehensive test coverage**: Created `DiApiConfigTest` with two test cases:
  - Validates that the factory closure declares `LoggerInterface` as a parameter
  - Verifies the factory produces a valid `TranslationController` instance with all dependencies properly injected
- **Updated playground configuration**: Added locale configuration to the Yii3 test application params

## Implementation Details
The fix ensures that the dependency injection container properly resolves the `LoggerInterface` dependency when constructing `TranslationController`, preventing runtime errors when the translation inspector feature is accessed. The test suite provides regression protection by validating both the factory signature and the resulting controller instance.

https://claude.ai/code/session_01UL2FZMb6592oxZzyPiLimn