### PR TITLE
Update Yii3 adapter for Yii DB 2.0 API changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,7 @@
     "yiisoft/assets": "^4.0",
     "yiisoft/cache": "^3.2",
     "yiisoft/config": "^1.3",
-    "yiisoft/db-sqlite": "^1.2",
+    "yiisoft/db-sqlite": "^2.0",
     "yiisoft/di": "^1.0",
     "yiisoft/error-handler": "^4.3",
     "yiisoft/event-dispatcher": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdca3373ff829e37603a342ce2cf4826",
+    "content-hash": "f8b54c4a85c28bf3fc51718eae19c906",
     "packages": [
         {
             "name": "nikic/fast-route",
@@ -12604,46 +12604,52 @@
         },
         {
             "name": "yiisoft/db",
-            "version": "1.3.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/db.git",
-                "reference": "71c9f37596da41a910dee440d38f5d1bb303a39b"
+                "reference": "fae72a47856f6947de7e5e18d7e5dd0b46ee1daa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/db/zipball/71c9f37596da41a910dee440d38f5d1bb303a39b",
-                "reference": "71c9f37596da41a910dee440d38f5d1bb303a39b",
+                "url": "https://api.github.com/repos/yiisoft/db/zipball/fae72a47856f6947de7e5e18d7e5dd0b46ee1daa",
+                "reference": "fae72a47856f6947de7e5e18d7e5dd0b46ee1daa",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
-                "ext-json": "*",
-                "ext-mbstring": "*",
                 "ext-pdo": "*",
-                "php": "^8.0",
+                "php": "8.1 - 8.5",
                 "psr/log": "^2.0|^3.0",
-                "psr/simple-cache": "^2.0|^3.0"
+                "psr/simple-cache": "^2.0|^3.0",
+                "psr/simple-cache-implementation": "*",
+                "yiisoft/db-implementation": "1.0.0"
             },
             "require-dev": {
-                "maglnet/composer-require-checker": "^4.2",
-                "phpunit/phpunit": "^9.6|^10.0",
-                "rector/rector": "^1.0",
-                "roave/infection-static-analysis-plugin": "^1.16",
-                "spatie/phpunit-watcher": "^1.23",
-                "vimeo/psalm": "^4.30|^5.20",
+                "bamarni/composer-bin-plugin": "^1.8.3",
+                "friendsofphp/php-cs-fixer": "^3.89.1",
+                "maglnet/composer-require-checker": "^4.7.1",
+                "phpunit/phpunit": "^10.5.45",
+                "rector/rector": "^2.0.10",
+                "spatie/phpunit-watcher": "^1.24",
                 "yiisoft/aliases": "^3.0",
-                "yiisoft/cache-file": "^3.1",
-                "yiisoft/di": "^1.0",
-                "yiisoft/event-dispatcher": "^1.0",
-                "yiisoft/json": "^1.0",
-                "yiisoft/log": "^2.0",
-                "yiisoft/var-dumper": "^1.5",
-                "yiisoft/yii-debug": "dev-master|dev-php80"
+                "yiisoft/di": "^1.3",
+                "yiisoft/dummy-provider": "^1.1",
+                "yiisoft/event-dispatcher": "^1.1",
+                "yiisoft/log": "^2.1",
+                "yiisoft/psr-dummy-provider": "^1.0",
+                "yiisoft/test-support": "^3.0",
+                "yiisoft/var-dumper": "^1.7",
+                "yiisoft/yii-debug": "dev-master"
             },
             "type": "library",
             "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true,
+                    "target-directory": "tools"
+                },
                 "config-plugin": {
+                    "di": "di.php",
                     "params": "params.php"
                 },
                 "config-plugin-options": {
@@ -12659,7 +12665,7 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Yii Database",
+            "description": "Database abstraction layer and query builder",
             "homepage": "https://www.yiiframework.com/",
             "keywords": [
                 "database",
@@ -12678,51 +12684,59 @@
             },
             "funding": [
                 {
-                    "url": "https://github.com/yiisoft",
+                    "url": "https://github.com/sponsors/yiisoft",
                     "type": "github"
                 },
                 {
                     "url": "https://opencollective.com/yiisoft",
-                    "type": "open_collective"
+                    "type": "opencollective"
                 }
             ],
-            "time": "2024-03-21T07:18:22+00:00"
+            "time": "2026-02-09T19:21:43+00:00"
         },
         {
             "name": "yiisoft/db-sqlite",
-            "version": "1.2.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/db-sqlite.git",
-                "reference": "d8222a0ccd0b2b431f253bfb13af1f79e6d341d9"
+                "reference": "b0158543abb378e4524777c8000e3a2180ff6363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/db-sqlite/zipball/d8222a0ccd0b2b431f253bfb13af1f79e6d341d9",
-                "reference": "d8222a0ccd0b2b431f253bfb13af1f79e6d341d9",
+                "url": "https://api.github.com/repos/yiisoft/db-sqlite/zipball/b0158543abb378e4524777c8000e3a2180ff6363",
+                "reference": "b0158543abb378e4524777c8000e3a2180ff6363",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "ext-pdo": "*",
-                "php": "^8.0",
-                "yiisoft/db": "^1.2",
-                "yiisoft/json": "^1.0"
+                "php": "8.1 - 8.5",
+                "yiisoft/db": "^2.0"
+            },
+            "provide": {
+                "yiisoft/db-implementation": "1.0.0"
             },
             "require-dev": {
-                "ext-json": "*",
-                "maglnet/composer-require-checker": "^4.2",
-                "phpunit/phpunit": "^9.6|^10.0",
-                "rector/rector": "^1.0",
-                "roave/infection-static-analysis-plugin": "^1.16",
-                "spatie/phpunit-watcher": "^1.23",
-                "vimeo/psalm": "^4.30|^5.20",
+                "bamarni/composer-bin-plugin": "^1.8.3",
+                "friendsofphp/php-cs-fixer": "^3.89.1",
+                "maglnet/composer-require-checker": "^4.7.1",
+                "phpunit/phpunit": "^10.5.45",
+                "rector/rector": "^2.0.10",
+                "spatie/phpunit-watcher": "^1.24",
                 "yiisoft/aliases": "^2.0",
-                "yiisoft/cache-file": "^3.1",
-                "yiisoft/json": "^1.0",
-                "yiisoft/var-dumper": "^1.5"
+                "yiisoft/psr-dummy-provider": "^1.0",
+                "yiisoft/test-support": "^3.0",
+                "yiisoft/var-dumper": "^1.7"
             },
             "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true,
+                    "target-directory": "tools"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Yiisoft\\Db\\Sqlite\\": "src"
@@ -12745,22 +12759,22 @@
             "support": {
                 "chat": "https://t.me/yii3en",
                 "forum": "https://www.yiiframework.com/forum/",
-                "irc": "irc://irc.freenode.net/yii",
-                "issues": "https://github.com/yiisoft/db-sqlite/issues",
+                "irc": "ircs://irc.libera.chat:6697/yii",
+                "issues": "https://github.com/yiisoft/db-sqlite/issues?state=open",
                 "source": "https://github.com/yiisoft/db-sqlite",
                 "wiki": "https://www.yiiframework.com/wiki/"
             },
             "funding": [
                 {
-                    "url": "https://github.com/yiisoft",
+                    "url": "https://github.com/sponsors/yiisoft",
                     "type": "github"
                 },
                 {
                     "url": "https://opencollective.com/yiisoft",
-                    "type": "open_collective"
+                    "type": "opencollective"
                 }
             ],
-            "time": "2024-03-21T07:30:14+00:00"
+            "time": "2025-12-05T14:55:48+00:00"
         },
         {
             "name": "yiisoft/di",

--- a/libs/Adapter/Yii3/config/di-api.php
+++ b/libs/Adapter/Yii3/config/di-api.php
@@ -101,6 +101,11 @@ $authToken = $apiConfig['authToken'] ?? '';
 $inspectorUrl = $apiConfig['inspectorUrl'] ?? null;
 
 return [
+    // Alias so framework-agnostic inspector controllers can fetch the merged config
+    // via $container->has('config') / get('config'). Yii 3 registers the merged
+    // configuration under ConfigInterface::class; expose the same object under 'config'.
+    'config' => static fn(\Yiisoft\Config\ConfigInterface $config) => $config,
+
     // PSR-17 factories
     RequestFactoryInterface::class => static fn() => new HttpFactory(),
     ResponseFactoryInterface::class => static fn() => new HttpFactory(),
@@ -304,9 +309,19 @@ return [
         return new CommandController($jsonResponseFactory, $pathResolver, $container, $commandMap);
     },
 
-    RoutingController::class => static fn(JsonResponseFactoryInterface $jsonResponseFactory) => new RoutingController(
-        $jsonResponseFactory,
-    ),
+    RoutingController::class => static function (
+        JsonResponseFactoryInterface $jsonResponseFactory,
+        ContainerInterface $container,
+    ): RoutingController {
+        $routeCollection = $container->has(\Yiisoft\Router\RouteCollectionInterface::class)
+            ? $container->get(\Yiisoft\Router\RouteCollectionInterface::class)
+            : null;
+        $urlMatcher = $container->has(\Yiisoft\Router\UrlMatcherInterface::class)
+            ? $container->get(\Yiisoft\Router\UrlMatcherInterface::class)
+            : null;
+
+        return new RoutingController($jsonResponseFactory, $routeCollection, $urlMatcher);
+    },
 
     RequestController::class => static fn(
         JsonResponseFactoryInterface $jsonResponseFactory,

--- a/libs/Adapter/Yii3/src/Collector/Db/CommandInterfaceProxy.php
+++ b/libs/Adapter/Yii3/src/Collector/Db/CommandInterfaceProxy.php
@@ -8,9 +8,10 @@ use AppDevPanel\Kernel\Collector\DatabaseCollector;
 use Closure;
 use Throwable;
 use Yiisoft\Db\Command\CommandInterface;
-use Yiisoft\Db\Query\Data\DataReaderInterface;
+use Yiisoft\Db\Expression\ExpressionInterface;
+use Yiisoft\Db\Query\DataReaderInterface;
 use Yiisoft\Db\Query\QueryInterface;
-use Yiisoft\Db\Schema\Builder\ColumnInterface;
+use Yiisoft\Db\Schema\Column\ColumnInterface;
 
 final class CommandInterfaceProxy implements CommandInterface
 {
@@ -24,7 +25,7 @@ final class CommandInterfaceProxy implements CommandInterface
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
 
-    public function addColumn(string $table, string $column, string $type): static
+    public function addColumn(string $table, string $column, ColumnInterface|string $type): static
     {
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
@@ -71,7 +72,7 @@ final class CommandInterfaceProxy implements CommandInterface
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
 
-    public function batchInsert(string $table, array $columns, iterable $rows): static
+    public function insertBatch(string $table, iterable $rows, array $columns = []): static
     {
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
@@ -171,7 +172,7 @@ final class CommandInterfaceProxy implements CommandInterface
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
 
-    public function dropTable(string $table): static
+    public function dropTable(string $table, bool $ifExists = false, bool $cascade = false): static
     {
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
@@ -222,7 +223,7 @@ final class CommandInterfaceProxy implements CommandInterface
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
 
-    public function insertWithReturningPks(string $table, array $columns): bool|array
+    public function insertReturningPks(string $table, array|QueryInterface $columns): array
     {
         return $this->decorated->{__FUNCTION__}(...func_get_args());
     }
@@ -348,17 +349,53 @@ final class CommandInterfaceProxy implements CommandInterface
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
 
-    public function update(string $table, array $columns, array|string $condition = '', array $params = []): static
-    {
+    public function update(
+        string $table,
+        array $columns,
+        array|ExpressionInterface|string $condition = '',
+        array|ExpressionInterface|string|null $from = null,
+        array $params = [],
+    ): static {
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
 
     public function upsert(
         string $table,
-        QueryInterface|array $insertColumns,
-        bool|array $updateColumns = true,
-        array $params = [],
+        array|QueryInterface $insertColumns,
+        array|bool $updateColumns = true,
     ): static {
+        return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
+    }
+
+    public function upsertReturning(
+        string $table,
+        array|QueryInterface $insertColumns,
+        array|bool $updateColumns = true,
+        ?array $returnColumns = null,
+    ): array {
+        return $this->decorated->{__FUNCTION__}(...func_get_args());
+    }
+
+    public function upsertReturningPks(
+        string $table,
+        array|QueryInterface $insertColumns,
+        array|bool $updateColumns = true,
+    ): array {
+        return $this->decorated->{__FUNCTION__}(...func_get_args());
+    }
+
+    public function withDbTypecasting(bool $dbTypecasting = true): static
+    {
+        return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
+    }
+
+    public function withPhpTypecasting(bool $phpTypecasting = true): static
+    {
+        return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
+    }
+
+    public function withTypecasting(bool $typecasting = true): static
+    {
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
 

--- a/libs/Adapter/Yii3/src/Collector/Db/ConnectionInterfaceProxy.php
+++ b/libs/Adapter/Yii3/src/Collector/Db/ConnectionInterfaceProxy.php
@@ -8,9 +8,12 @@ use AppDevPanel\Kernel\Collector\DatabaseCollector;
 use Closure;
 use Yiisoft\Db\Command\CommandInterface;
 use Yiisoft\Db\Connection\ConnectionInterface;
+use Yiisoft\Db\Connection\ServerInfoInterface;
+use Yiisoft\Db\Expression\ExpressionInterface;
 use Yiisoft\Db\Query\BatchQueryResultInterface;
 use Yiisoft\Db\Query\QueryInterface;
 use Yiisoft\Db\QueryBuilder\QueryBuilderInterface;
+use Yiisoft\Db\Schema\Column\ColumnFactoryInterface;
 use Yiisoft\Db\Schema\QuoterInterface;
 use Yiisoft\Db\Schema\SchemaInterface;
 use Yiisoft\Db\Schema\TableSchemaInterface;
@@ -33,14 +36,19 @@ final class ConnectionInterfaceProxy implements ConnectionInterface
         return new TransactionInterfaceDecorator($result, $this->collector);
     }
 
-    public function createBatchQueryResult(QueryInterface $query, bool $each = false): BatchQueryResultInterface
+    public function createBatchQueryResult(QueryInterface $query): BatchQueryResultInterface
     {
-        return $this->connection->createBatchQueryResult($query, $each);
+        return $this->connection->createBatchQueryResult($query);
     }
 
     public function createCommand(?string $sql = null, array $params = []): CommandInterface
     {
         return new CommandInterfaceProxy($this->connection->createCommand($sql, $params), $this->collector);
+    }
+
+    public function createQuery(): QueryInterface
+    {
+        return $this->connection->createQuery();
     }
 
     public function createTransaction(): TransactionInterface
@@ -53,9 +61,19 @@ final class ConnectionInterfaceProxy implements ConnectionInterface
         $this->connection->close();
     }
 
-    public function getLastInsertID(?string $sequenceName = null): string
+    public function getColumnBuilderClass(): string
     {
-        return $this->connection->getLastInsertID($sequenceName);
+        return $this->connection->getColumnBuilderClass();
+    }
+
+    public function getColumnFactory(): ColumnFactoryInterface
+    {
+        return $this->connection->getColumnFactory();
+    }
+
+    public function getLastInsertId(?string $sequenceName = null): string
+    {
+        return $this->connection->getLastInsertId($sequenceName);
     }
 
     public function getQueryBuilder(): QueryBuilderInterface
@@ -73,9 +91,9 @@ final class ConnectionInterfaceProxy implements ConnectionInterface
         return $this->connection->getSchema();
     }
 
-    public function getServerVersion(): string
+    public function getServerInfo(): ServerInfoInterface
     {
-        return $this->connection->getServerVersion();
+        return $this->connection->getServerInfo();
     }
 
     public function getTablePrefix(): string
@@ -113,6 +131,13 @@ final class ConnectionInterfaceProxy implements ConnectionInterface
     public function quoteValue(mixed $value): mixed
     {
         return $this->connection->quoteValue($value);
+    }
+
+    public function select(
+        array|bool|float|int|string|ExpressionInterface $columns = [],
+        ?string $option = null,
+    ): QueryInterface {
+        return $this->connection->select($columns, $option);
     }
 
     public function setEnableSavepoint(bool $value): void

--- a/libs/Adapter/Yii3/src/Inspector/DbSchemaProvider.php
+++ b/libs/Adapter/Yii3/src/Inspector/DbSchemaProvider.php
@@ -107,7 +107,7 @@ class DbSchemaProvider implements SchemaProviderInterface
                 'dbType' => $columnSchema->getDbType(),
                 'defaultValue' => $columnSchema->getDefaultValue(),
                 'comment' => $columnSchema->getComment(),
-                'allowNull' => $columnSchema->isAllowNull(),
+                'allowNull' => !$columnSchema->isNotNull(),
             ];
         }
         return $result;

--- a/libs/Adapter/Yii3/tests/Unit/Collector/Db/CommandInterfaceProxyTest.php
+++ b/libs/Adapter/Yii3/tests/Unit/Collector/Db/CommandInterfaceProxyTest.php
@@ -10,7 +10,7 @@ use AppDevPanel\Kernel\Collector\TimelineCollector;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Yiisoft\Db\Command\CommandInterface;
-use Yiisoft\Db\Query\Data\DataReaderInterface;
+use Yiisoft\Db\Query\DataReaderInterface;
 
 final class CommandInterfaceProxyTest extends TestCase
 {

--- a/libs/Adapter/Yii3/tests/Unit/Collector/Db/ConnectionInterfaceProxyTest.php
+++ b/libs/Adapter/Yii3/tests/Unit/Collector/Db/ConnectionInterfaceProxyTest.php
@@ -178,16 +178,17 @@ final class ConnectionInterfaceProxyTest extends TestCase
         $this->assertSame('mysql', $proxy->getDriverName());
     }
 
-    public function testGetServerVersionDelegatesToDecorated(): void
+    public function testGetServerInfoDelegatesToDecorated(): void
     {
+        $serverInfo = $this->createMock(\Yiisoft\Db\Connection\ServerInfoInterface::class);
         $connection = $this->createMock(ConnectionInterface::class);
-        $connection->method('getServerVersion')->willReturn('8.0.32');
+        $connection->method('getServerInfo')->willReturn($serverInfo);
 
         $timeline = new TimelineCollector();
         $collector = new DatabaseCollector($timeline);
 
         $proxy = new ConnectionInterfaceProxy($connection, $collector);
-        $this->assertSame('8.0.32', $proxy->getServerVersion());
+        $this->assertSame($serverInfo, $proxy->getServerInfo());
     }
 
     public function testGetTablePrefixDelegatesToDecorated(): void
@@ -319,7 +320,7 @@ final class ConnectionInterfaceProxyTest extends TestCase
         $query = $this->createMock(QueryInterface::class);
         $batchResult = $this->createMock(BatchQueryResultInterface::class);
         $connection = $this->createMock(ConnectionInterface::class);
-        $connection->method('createBatchQueryResult')->with($query, false)->willReturn($batchResult);
+        $connection->method('createBatchQueryResult')->with($query)->willReturn($batchResult);
 
         $timeline = new TimelineCollector();
         $collector = new DatabaseCollector($timeline);

--- a/libs/Adapter/Yii3/tests/Unit/Inspector/DbSchemaProviderTest.php
+++ b/libs/Adapter/Yii3/tests/Unit/Inspector/DbSchemaProviderTest.php
@@ -108,46 +108,40 @@ final class DbSchemaProviderTest extends TestCase
         // insert data
         $db
             ->createCommand()
-            ->batchInsert(
+            ->insertBatch(
                 'test',
-                [
-                    'id',
-                    'email',
-                ],
                 [
                     [1, 'test1'],
                     [2, 'test2'],
                     [3, 'test3'],
                 ],
+                [
+                    'id',
+                    'email',
+                ],
             )
             ->execute();
 
         $db
             ->createCommand()
-            ->batchInsert(
+            ->insertBatch(
                 'test2',
+                [
+                    [1, 'test1', 1],
+                    [2, 'test2', 0],
+                ],
                 [
                     'id',
                     'name',
                     'flag',
                 ],
-                [
-                    [1, 'test1', 1],
-                    [2, 'test2', 0],
-                ],
             )
             ->execute();
 
         $db
             ->createCommand()
-            ->batchInsert(
+            ->insertBatch(
                 'test3',
-                [
-                    'id',
-                    'product',
-                    'price',
-                    'status',
-                ],
                 [
                     [1,  'test1',  1.1,   1],
                     [2,  'test2',  2.2,   0],
@@ -159,6 +153,12 @@ final class DbSchemaProviderTest extends TestCase
                     [8,  'test8',  8.8,   0],
                     [9,  'test9',  9.9,   1],
                     [10, 'test10', 10.10, 0],
+                ],
+                [
+                    'id',
+                    'product',
+                    'price',
+                    'status',
                 ],
             )
             ->execute();


### PR DESCRIPTION
This PR updates the Yii3 adapter to be compatible with Yii DB 2.0, which includes several breaking API changes and new features.

## Summary
Updates the database-related proxy classes and tests to align with the new Yii DB 2.0 API, including method signature changes, renamed methods, and new functionality.

## Key Changes

### CommandInterfaceProxy
- Updated import: `DataReaderInterface` moved from `Yiisoft\Db\Query\Data` to `Yiisoft\Db\Query`
- Updated import: `ColumnInterface` moved from `Yiisoft\Db\Schema\Builder` to `Yiisoft\Db\Schema\Column`
- Added import: `ExpressionInterface` for new parameter types
- `addColumn()`: Changed `$type` parameter from `string` to `ColumnInterface|string`
- `batchInsert()`: Renamed to `insertBatch()` with reordered parameters (rows before columns)
- `dropTable()`: Added optional `$ifExists` and `$cascade` parameters
- `insertWithReturningPks()`: Renamed to `insertReturningPks()` with updated parameter types and return type
- `update()`: Added `$from` parameter and updated `$condition` to accept `ExpressionInterface`
- `upsert()`: Removed `$params` parameter and reordered type unions
- Added new methods: `upsertReturning()`, `upsertReturningPks()`, `withDbTypecasting()`, `withPhpTypecasting()`, `withTypecasting()`

### ConnectionInterfaceProxy
- Added imports: `ServerInfoInterface`, `ExpressionInterface`, `ColumnFactoryInterface`
- `createBatchQueryResult()`: Removed `$each` parameter
- Added new method: `createQuery()`
- `getLastInsertID()`: Renamed to `getLastInsertId()`
- Added new methods: `getColumnBuilderClass()`, `getColumnFactory()`
- `getServerVersion()`: Replaced with `getServerInfo()` returning `ServerInfoInterface`
- Added new method: `select()` with expression support

### DbSchemaProvider
- Fixed `allowNull` serialization: Changed from `$columnSchema->isAllowNull()` to `!$columnSchema->isNotNull()`

### Tests
- Updated `CommandInterfaceProxyTest`: Fixed import path for `DataReaderInterface`
- Updated `ConnectionInterfaceProxyTest`: 
  - Renamed test method from `testGetServerVersionDelegatesToDecorated()` to `testGetServerInfoDelegatesToDecorated()`
  - Updated mock to use `ServerInfoInterface`
- Updated `DbSchemaProviderTest`: Changed all `batchInsert()` calls to `insertBatch()` with reordered parameters

### Configuration
- Updated `di-api.php`: 
  - Added config alias for framework-agnostic inspector controllers
  - Enhanced `RoutingController` factory to optionally inject `RouteCollectionInterface` and `UrlMatcherInterface`

### Dependencies
- Updated `yiisoft/db-sqlite` from `^1.2` to `^2.0`

## Notable Implementation Details
- The parameter reordering in `insertBatch()` (rows before columns) represents a significant API change that improves method usability
- New typecasting methods provide more granular control over data type conversion
- The `select()` method addition enables query building directly from the connection interface
- Server version information is now encapsulated in a `ServerInfoInterface` object for better extensibility

https://claude.ai/code/session_01RcDVYaza66EuDYqtvcNMJX