### PR TITLE
Remove StreamTarget from logger configuration

### DIFF
--- a/playground/yii3-app/config/common/di/logger.php
+++ b/playground/yii3-app/config/common/di/logger.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Psr\Log\LoggerInterface;
 use Yiisoft\Definitions\ReferencesArray;
 use Yiisoft\Log\Logger;
-use Yiisoft\Log\StreamTarget;
 use Yiisoft\Log\Target\File\FileTarget;
 
 /** @var array $params */
@@ -16,7 +15,6 @@ return [
         '__construct()' => [
             'targets' => ReferencesArray::from([
                 FileTarget::class,
-                StreamTarget::class,
             ]),
         ],
     ],


### PR DESCRIPTION
## Summary
Removed the `StreamTarget` from the logger's target configuration and its corresponding import statement.

## Changes
- Removed the `use Yiisoft\Log\StreamTarget;` import statement
- Removed `StreamTarget::class` from the logger targets array, keeping only `FileTarget::class`

## Details
The logger is now configured to use only the `FileTarget` for logging output. The `StreamTarget` dependency has been completely removed from the logger configuration in the DI container setup.

https://claude.ai/code/session_01ETEw8gWkxLdQmqbx3FoC6d