### PR TITLE
Decouple Live Feed from autoLatest toggle

### DIFF
--- a/libs/Kernel/src/DebugServer/LoggerDecorator.php
+++ b/libs/Kernel/src/DebugServer/LoggerDecorator.php
@@ -29,7 +29,7 @@ final class LoggerDecorator implements LoggerInterface
             'level' => (string) $level,
             'message' => $message,
             'context' => $context,
-        ])->asJson(false, 1));
+        ])->asJson(false, 5));
         $this->decorated->log($level, $message, $context);
     }
 }

--- a/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
@@ -312,7 +312,9 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
         },
         [getDebugQuery, changeEntry, dispatch],
     );
-    useServerSentEvents(backendUrl, onUpdatesHandler, autoLatest);
+    // Always subscribe so the Live Feed receives logs/dumps independently of autoLatest.
+    // autoLatest only controls whether the entry list jumps to newest entry on entry-created.
+    useServerSentEvents(backendUrl, onUpdatesHandler);
 
     // Entry navigation
     const entries = getDebugQueryInfo.data ?? [];

--- a/playground/laravel-app/config/session.php
+++ b/playground/laravel-app/config/session.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 return [
-    'driver' => 'array',
+    'driver' => 'file',
     'lifetime' => 120,
     'expire_on_close' => false,
     'encrypt' => false,

--- a/website/guide/live-feed-internals.md
+++ b/website/guide/live-feed-internals.md
@@ -160,10 +160,10 @@ php yii dev:broadcast -m "Test message"
 Manages the SSE connection lifecycle. Creates an `EventSource` to `/debug/api/event-stream` and dispatches incoming events to the callback.
 
 ```typescript
-useServerSentEvents(backendUrl, onUpdatesHandler, autoLatest);
+useServerSentEvents(backendUrl, onUpdatesHandler);
 ```
 
-The hook reconnects automatically when `backendUrl` changes. The `subscribe` flag (controlled by the `autoLatest` toggle) controls whether the connection is active.
+The hook reconnects automatically when `backendUrl` changes. The connection is always active so the Live Feed receives events independently of the `autoLatest` entry-list toggle.
 
 ### SSE Event Types
 

--- a/website/guide/live-feed.md
+++ b/website/guide/live-feed.md
@@ -39,7 +39,7 @@ Variable dumps are broadcast via the `VarDumperHandler` whenever your applicatio
 
 ## How It Works
 
-The Live Feed uses the same SSE connection as the auto-refresh feature. When the `autoLatest` toggle is enabled in the top bar, the panel connects to `/debug/api/event-stream` and listens for:
+The panel always connects to `/debug/api/event-stream` and listens for:
 
 | SSE Event Type | Source | Description |
 |----------------|--------|-------------|
@@ -66,5 +66,4 @@ Click the **trash icon** in the drawer header to clear all accumulated events. T
 ## Requirements
 
 - The **sockets** PHP extension must be installed for live event streaming
-- The `autoLatest` toggle must be enabled (the sync icon in the top bar should be green)
 - Your application must use the `LoggerDecorator` and/or `VarDumperHandler` proxies (automatically configured by adapters)


### PR DESCRIPTION
## Summary
This PR decouples the Live Feed feature from the `autoLatest` toggle, allowing the panel to always receive live events independently of the auto-refresh setting. The `autoLatest` toggle now only controls whether the entry list jumps to the newest entry when new entries are created.

## Key Changes
- **SSE Connection**: Modified `useServerSentEvents` hook call to always maintain an active connection to `/debug/api/event-stream`, removing the `autoLatest` parameter that previously controlled subscription
- **Documentation**: Updated live feed guides to reflect that the panel always connects to the event stream, removing the requirement that `autoLatest` must be enabled
- **Logger Serialization**: Increased JSON depth parameter in `LoggerDecorator` from 1 to 5 for better context serialization in logs
- **Session Driver**: Changed Laravel playground app session driver from 'array' to 'file' for persistence

## Implementation Details
- The Live Feed now receives logs and variable dumps continuously, regardless of the `autoLatest` setting
- The `autoLatest` toggle retains its original purpose: controlling whether the entry list auto-scrolls to the newest entry
- This change improves the user experience by ensuring live events are always captured and displayed in the Live Feed panel

https://claude.ai/code/session_019F8qMwnsBwE4phmsXshC4j