### PR TITLE
Add mailer fixture content and expand test email scenarios

### DIFF
--- a/playground/laravel-app/app/Http/Controllers/TestFixtures/MailerAction.php
+++ b/playground/laravel-app/app/Http/Controllers/TestFixtures/MailerAction.php
@@ -5,19 +5,53 @@ declare(strict_types=1);
 namespace App\Http\Controllers\TestFixtures;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Mail\Message;
 use Illuminate\Support\Facades\Mail;
 
 final class MailerAction
 {
     public function __invoke(): JsonResponse
     {
-        Mail::raw('This is a test email from the ADP mailer fixture.', static function ($message): void {
-            $message
-                ->from('noreply@example.com', 'ADP Test')
-                ->to('user@example.com', 'Test User')
-                ->subject('ADP Test Fixture Email');
-        });
+        Mail::raw(
+            "Hello!\n\nThis is a plain-text email sent from the ADP Laravel fixture.\n\nCheers,\nADP",
+            static function (Message $message): void {
+                $message
+                    ->from('noreply@example.com', 'ADP')
+                    ->to('user@example.com', 'Test User')
+                    ->subject('ADP fixture — plain text');
+            },
+        );
 
-        return new JsonResponse(['fixture' => 'mailer:basic', 'status' => 'ok']);
+        Mail::html(
+            MailerFixtureContent::tableHtml(),
+            static function (Message $message): void {
+                $message
+                    ->from('noreply@example.com', 'ADP')
+                    ->to('user@example.com', 'Test User')
+                    ->subject('ADP fixture — HTML table report');
+            },
+        );
+
+        Mail::html(
+            MailerFixtureContent::newsletterHtml(),
+            static function (Message $message): void {
+                $message
+                    ->from('noreply@example.com', 'ADP')
+                    ->to('user@example.com', 'Test User')
+                    ->subject('ADP fixture — newsletter with attachments')
+                    ->attachData(
+                        MailerFixtureContent::textAttachment(),
+                        'release-notes.txt',
+                        ['mime' => 'text/plain'],
+                    )
+                    ->attachData(
+                        MailerFixtureContent::pdfAttachment(),
+                        'adp-fixture.pdf',
+                        ['mime' => 'application/pdf'],
+                    );
+            },
+        );
+
+        return new JsonResponse(['fixture' => 'mailer:basic', 'status' => 'ok', 'sent' => 3]);
     }
 }

--- a/playground/laravel-app/app/Http/Controllers/TestFixtures/MailerFixtureContent.php
+++ b/playground/laravel-app/app/Http/Controllers/TestFixtures/MailerFixtureContent.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\TestFixtures;
+
+final class MailerFixtureContent
+{
+    private const PDF_BASE64 = 'JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgL01lZGlhQm94IFswIDAgNDAwIDIwMF0gPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA8PCAvVHlwZSAvRm9udCAvU3VidHlwZSAvVHlwZTEgL0Jhc2VGb250IC9IZWx2ZXRpY2EgPj4gPj4gPj4gL0NvbnRlbnRzIDQgMCBSID4+CmVuZG9iago0IDAgb2JqCjw8IC9MZW5ndGggNTMgPj4Kc3RyZWFtCkJUIC9GMSAxOCBUZiA0MCAxMjAgVGQgKEFEUCBmaXh0dXJlIGF0dGFjaG1lbnQpIFRqIEVUCmVuZHN0cmVhbQplbmRvYmoKeHJlZgowIDUKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDE1IDAwMDAwIG4gCjAwMDAwMDAwNjQgMDAwMDAgbiAKMDAwMDAwMDE0NSAwMDAwMCBuIAowMDAwMDAwMjk2IDAwMDAwIG4gCnRyYWlsZXIKPDwgL1NpemUgNSAvUm9vdCAxIDAgUiA+PgpzdGFydHhyZWYKMzk5CiUlRU9GCg==';
+
+    public static function tableHtml(): string
+    {
+        return <<<'HTML'
+            <!DOCTYPE html>
+            <html lang="en">
+            <body style="font-family: Arial, sans-serif; color: #222; margin: 0; padding: 24px; background: #f5f5f7;">
+              <h2 style="margin: 0 0 12px 0;">Weekly traffic report</h2>
+              <p style="margin: 0 0 16px 0; color: #555;">Aggregated metrics for the last 7 days.</p>
+              <table cellpadding="8" cellspacing="0" style="border-collapse: collapse; width: 100%; max-width: 520px; background: #fff; border: 1px solid #e2e2e4;">
+                <thead>
+                  <tr style="background: #111; color: #fff;">
+                    <th align="left">Metric</th>
+                    <th align="right">Value</th>
+                    <th align="right">Δ vs prev.</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr><td>Requests</td><td align="right">1 240</td><td align="right" style="color:#22863a;">+12%</td></tr>
+                  <tr style="background:#fafafa;"><td>Errors</td><td align="right">12</td><td align="right" style="color:#b31d28;">+3%</td></tr>
+                  <tr><td>Avg response</td><td align="right">84 ms</td><td align="right" style="color:#22863a;">-8%</td></tr>
+                  <tr style="background:#fafafa;"><td>P95 response</td><td align="right">220 ms</td><td align="right" style="color:#22863a;">-5%</td></tr>
+                </tbody>
+              </table>
+            </body>
+            </html>
+            HTML;
+    }
+
+    public static function newsletterHtml(): string
+    {
+        return <<<'HTML'
+            <!DOCTYPE html>
+            <html lang="en">
+            <body style="margin:0; padding:0; background:#eef0f3; font-family:'Segoe UI', Arial, sans-serif; color:#1c1e21;">
+              <table width="100%" cellpadding="0" cellspacing="0" style="background:#eef0f3;">
+                <tr><td align="center" style="padding: 32px 16px;">
+                  <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff; border-radius:8px; overflow:hidden; box-shadow:0 4px 12px rgba(0,0,0,0.06);">
+                    <tr><td style="background:linear-gradient(90deg,#4f46e5,#06b6d4); padding:28px; color:#fff;">
+                      <h1 style="margin:0; font-size:22px;">ADP Release 2.4</h1>
+                      <p style="margin:6px 0 0 0; opacity:0.9;">April 2026 · Product newsletter</p>
+                    </td></tr>
+                    <tr><td style="padding:24px 28px;">
+                      <h2 style="margin:0 0 12px 0; font-size:18px;">What's new</h2>
+                      <ul style="margin:0 0 16px 0; padding-left:20px; line-height:1.6;">
+                        <li>New <strong>Mailer</strong> collector across all adapters</li>
+                        <li>Faster storage driver (SQLite backend)</li>
+                        <li>MCP server with stdio + HTTP transports</li>
+                      </ul>
+                      <p style="margin:0 0 12px 0;">See attached files for release notes and a printable summary.</p>
+                      <p style="margin:16px 0;">
+                        <a href="https://example.com/changelog" style="background:#4f46e5; color:#fff; padding:10px 18px; text-decoration:none; border-radius:6px; display:inline-block;">Read full changelog</a>
+                      </p>
+                    </td></tr>
+                    <tr><td style="background:#f6f7f9; padding:14px 28px; color:#6b7280; font-size:12px;">
+                      You received this email as a fixture for ADP debugging. No real user action required.
+                    </td></tr>
+                  </table>
+                </td></tr>
+              </table>
+            </body>
+            </html>
+            HTML;
+    }
+
+    public static function textAttachment(): string
+    {
+        return "ADP Release Notes\n=================\n\n- Added MailerCollector across Yii3, Symfony, Laravel and Yii2 adapters.\n- Normalized mail payload: from, to, subject, text/html, attachments.\n- Storage persists each sent message for inspection in the debug panel.\n";
+    }
+
+    public static function pdfAttachment(): string
+    {
+        return (string) base64_decode(self::PDF_BASE64, true);
+    }
+}

--- a/playground/symfony-app/src/Controller/TestFixtures/MailerAction.php
+++ b/playground/symfony-app/src/Controller/TestFixtures/MailerAction.php
@@ -18,22 +18,37 @@ final readonly class MailerAction
 
     public function __invoke(): JsonResponse
     {
-        // Send a real email via Symfony Mailer — the MailerSubscriber listens to
-        // MessageEvent and feeds email metadata to MailerCollector.
-        $email = new Email()
+        $plain = new Email()
             ->from('noreply@example.com')
             ->to('user@example.com')
-            ->subject('ADP Test Fixture Email')
-            ->text('This is a test email from the ADP mailer fixture.')
-            ->html('<p>This is a test email from the ADP mailer fixture.</p>');
+            ->subject('ADP fixture — plain text')
+            ->text("Hello!\n\nThis is a plain-text email sent from the ADP Symfony fixture.\n\nCheers,\nADP");
 
-        try {
-            $this->mailer->send($email);
-            $sent = true;
-        } catch (\Throwable) {
-            // Mailer may fail without a configured transport — that's OK for fixtures.
-            // The MailerSubscriber captures the email before the transport sends it.
-            $sent = false;
+        $table = new Email()
+            ->from('noreply@example.com')
+            ->to('user@example.com')
+            ->subject('ADP fixture — HTML table report')
+            ->text("Weekly report:\n- Requests: 1240\n- Errors: 12\n- Avg response: 84ms")
+            ->html(MailerFixtureContent::tableHtml());
+
+        $rich = new Email()
+            ->from('noreply@example.com')
+            ->to('user@example.com')
+            ->subject('ADP fixture — newsletter with attachments')
+            ->text('Please see the attached TXT and PDF files.')
+            ->html(MailerFixtureContent::newsletterHtml())
+            ->attach(MailerFixtureContent::textAttachment(), 'release-notes.txt', 'text/plain')
+            ->attach(MailerFixtureContent::pdfAttachment(), 'adp-fixture.pdf', 'application/pdf');
+
+        $sent = 0;
+        foreach ([$plain, $table, $rich] as $email) {
+            try {
+                $this->mailer->send($email);
+                $sent++;
+            } catch (\Throwable) {
+                // Mailer may fail without a configured transport — that's OK for fixtures.
+                // The MailerSubscriber captures the email before the transport sends it.
+            }
         }
 
         return new JsonResponse(['fixture' => 'mailer:basic', 'status' => 'ok', 'sent' => $sent]);

--- a/playground/symfony-app/src/Controller/TestFixtures/MailerFixtureContent.php
+++ b/playground/symfony-app/src/Controller/TestFixtures/MailerFixtureContent.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\TestFixtures;
+
+final class MailerFixtureContent
+{
+    private const PDF_BASE64 = 'JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgL01lZGlhQm94IFswIDAgNDAwIDIwMF0gPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA8PCAvVHlwZSAvRm9udCAvU3VidHlwZSAvVHlwZTEgL0Jhc2VGb250IC9IZWx2ZXRpY2EgPj4gPj4gPj4gL0NvbnRlbnRzIDQgMCBSID4+CmVuZG9iago0IDAgb2JqCjw8IC9MZW5ndGggNTMgPj4Kc3RyZWFtCkJUIC9GMSAxOCBUZiA0MCAxMjAgVGQgKEFEUCBmaXh0dXJlIGF0dGFjaG1lbnQpIFRqIEVUCmVuZHN0cmVhbQplbmRvYmoKeHJlZgowIDUKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDE1IDAwMDAwIG4gCjAwMDAwMDAwNjQgMDAwMDAgbiAKMDAwMDAwMDE0NSAwMDAwMCBuIAowMDAwMDAwMjk2IDAwMDAwIG4gCnRyYWlsZXIKPDwgL1NpemUgNSAvUm9vdCAxIDAgUiA+PgpzdGFydHhyZWYKMzk5CiUlRU9GCg==';
+
+    public static function tableHtml(): string
+    {
+        return <<<'HTML'
+            <!DOCTYPE html>
+            <html lang="en">
+            <body style="font-family: Arial, sans-serif; color: #222; margin: 0; padding: 24px; background: #f5f5f7;">
+              <h2 style="margin: 0 0 12px 0;">Weekly traffic report</h2>
+              <p style="margin: 0 0 16px 0; color: #555;">Aggregated metrics for the last 7 days.</p>
+              <table cellpadding="8" cellspacing="0" style="border-collapse: collapse; width: 100%; max-width: 520px; background: #fff; border: 1px solid #e2e2e4;">
+                <thead>
+                  <tr style="background: #111; color: #fff;">
+                    <th align="left">Metric</th>
+                    <th align="right">Value</th>
+                    <th align="right">Δ vs prev.</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr><td>Requests</td><td align="right">1 240</td><td align="right" style="color:#22863a;">+12%</td></tr>
+                  <tr style="background:#fafafa;"><td>Errors</td><td align="right">12</td><td align="right" style="color:#b31d28;">+3%</td></tr>
+                  <tr><td>Avg response</td><td align="right">84 ms</td><td align="right" style="color:#22863a;">-8%</td></tr>
+                  <tr style="background:#fafafa;"><td>P95 response</td><td align="right">220 ms</td><td align="right" style="color:#22863a;">-5%</td></tr>
+                </tbody>
+              </table>
+            </body>
+            </html>
+            HTML;
+    }
+
+    public static function newsletterHtml(): string
+    {
+        return <<<'HTML'
+            <!DOCTYPE html>
+            <html lang="en">
+            <body style="margin:0; padding:0; background:#eef0f3; font-family:'Segoe UI', Arial, sans-serif; color:#1c1e21;">
+              <table width="100%" cellpadding="0" cellspacing="0" style="background:#eef0f3;">
+                <tr><td align="center" style="padding: 32px 16px;">
+                  <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff; border-radius:8px; overflow:hidden; box-shadow:0 4px 12px rgba(0,0,0,0.06);">
+                    <tr><td style="background:linear-gradient(90deg,#4f46e5,#06b6d4); padding:28px; color:#fff;">
+                      <h1 style="margin:0; font-size:22px;">ADP Release 2.4</h1>
+                      <p style="margin:6px 0 0 0; opacity:0.9;">April 2026 · Product newsletter</p>
+                    </td></tr>
+                    <tr><td style="padding:24px 28px;">
+                      <h2 style="margin:0 0 12px 0; font-size:18px;">What's new</h2>
+                      <ul style="margin:0 0 16px 0; padding-left:20px; line-height:1.6;">
+                        <li>New <strong>Mailer</strong> collector across all adapters</li>
+                        <li>Faster storage driver (SQLite backend)</li>
+                        <li>MCP server with stdio + HTTP transports</li>
+                      </ul>
+                      <p style="margin:0 0 12px 0;">See attached files for release notes and a printable summary.</p>
+                      <p style="margin:16px 0;">
+                        <a href="https://example.com/changelog" style="background:#4f46e5; color:#fff; padding:10px 18px; text-decoration:none; border-radius:6px; display:inline-block;">Read full changelog</a>
+                      </p>
+                    </td></tr>
+                    <tr><td style="background:#f6f7f9; padding:14px 28px; color:#6b7280; font-size:12px;">
+                      You received this email as a fixture for ADP debugging. No real user action required.
+                    </td></tr>
+                  </table>
+                </td></tr>
+              </table>
+            </body>
+            </html>
+            HTML;
+    }
+
+    public static function textAttachment(): string
+    {
+        return "ADP Release Notes\n=================\n\n- Added MailerCollector across Yii3, Symfony, Laravel and Yii2 adapters.\n- Normalized mail payload: from, to, subject, text/html, attachments.\n- Storage persists each sent message for inspection in the debug panel.\n";
+    }
+
+    public static function pdfAttachment(): string
+    {
+        return (string) base64_decode(self::PDF_BASE64, true);
+    }
+}

--- a/playground/yii2-basic-app/src/actions/testFixtures/MailerAction.php
+++ b/playground/yii2-basic-app/src/actions/testFixtures/MailerAction.php
@@ -10,19 +10,43 @@ final class MailerAction extends Action
 {
     public function run(): array
     {
-        // Send a real email via Yii's mailer — the Module hooks into
-        // BaseMailer::EVENT_AFTER_SEND and feeds email metadata to MailerCollector.
         $mailer = \Yii::$app->mailer;
-        $message = $mailer
+
+        $plain = $mailer
             ->compose()
             ->setFrom('noreply@example.com')
             ->setTo('user@example.com')
-            ->setSubject('ADP Test Fixture Email')
-            ->setTextBody('This is a test email from the ADP mailer fixture.')
-            ->setHtmlBody('<p>This is a test email from the ADP mailer fixture.</p>');
+            ->setSubject('ADP fixture — plain text')
+            ->setTextBody("Hello!\n\nThis is a plain-text email sent from the ADP Yii 2 fixture.\n\nCheers,\nADP");
 
-        $message->send();
+        $table = $mailer
+            ->compose()
+            ->setFrom('noreply@example.com')
+            ->setTo('user@example.com')
+            ->setSubject('ADP fixture — HTML table report')
+            ->setTextBody("Weekly report:\n- Requests: 1240\n- Errors: 12\n- Avg response: 84ms")
+            ->setHtmlBody(MailerFixtureContent::tableHtml());
 
-        return ['fixture' => 'mailer:basic', 'status' => 'ok'];
+        $rich = $mailer
+            ->compose()
+            ->setFrom('noreply@example.com')
+            ->setTo('user@example.com')
+            ->setSubject('ADP fixture — newsletter with attachments')
+            ->setTextBody('Please see the attached TXT and PDF files.')
+            ->setHtmlBody(MailerFixtureContent::newsletterHtml())
+            ->attachContent(
+                MailerFixtureContent::textAttachment(),
+                ['fileName' => 'release-notes.txt', 'contentType' => 'text/plain'],
+            )
+            ->attachContent(
+                MailerFixtureContent::pdfAttachment(),
+                ['fileName' => 'adp-fixture.pdf', 'contentType' => 'application/pdf'],
+            );
+
+        $plain->send();
+        $table->send();
+        $rich->send();
+
+        return ['fixture' => 'mailer:basic', 'status' => 'ok', 'sent' => 3];
     }
 }

--- a/playground/yii2-basic-app/src/actions/testFixtures/MailerFixtureContent.php
+++ b/playground/yii2-basic-app/src/actions/testFixtures/MailerFixtureContent.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\actions\testFixtures;
+
+final class MailerFixtureContent
+{
+    private const PDF_BASE64 = 'JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgL01lZGlhQm94IFswIDAgNDAwIDIwMF0gPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA8PCAvVHlwZSAvRm9udCAvU3VidHlwZSAvVHlwZTEgL0Jhc2VGb250IC9IZWx2ZXRpY2EgPj4gPj4gPj4gL0NvbnRlbnRzIDQgMCBSID4+CmVuZG9iago0IDAgb2JqCjw8IC9MZW5ndGggNTMgPj4Kc3RyZWFtCkJUIC9GMSAxOCBUZiA0MCAxMjAgVGQgKEFEUCBmaXh0dXJlIGF0dGFjaG1lbnQpIFRqIEVUCmVuZHN0cmVhbQplbmRvYmoKeHJlZgowIDUKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDE1IDAwMDAwIG4gCjAwMDAwMDAwNjQgMDAwMDAgbiAKMDAwMDAwMDE0NSAwMDAwMCBuIAowMDAwMDAwMjk2IDAwMDAwIG4gCnRyYWlsZXIKPDwgL1NpemUgNSAvUm9vdCAxIDAgUiA+PgpzdGFydHhyZWYKMzk5CiUlRU9GCg==';
+
+    public static function tableHtml(): string
+    {
+        return <<<'HTML'
+            <!DOCTYPE html>
+            <html lang="en">
+            <body style="font-family: Arial, sans-serif; color: #222; margin: 0; padding: 24px; background: #f5f5f7;">
+              <h2 style="margin: 0 0 12px 0;">Weekly traffic report</h2>
+              <p style="margin: 0 0 16px 0; color: #555;">Aggregated metrics for the last 7 days.</p>
+              <table cellpadding="8" cellspacing="0" style="border-collapse: collapse; width: 100%; max-width: 520px; background: #fff; border: 1px solid #e2e2e4;">
+                <thead>
+                  <tr style="background: #111; color: #fff;">
+                    <th align="left">Metric</th>
+                    <th align="right">Value</th>
+                    <th align="right">Δ vs prev.</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr><td>Requests</td><td align="right">1 240</td><td align="right" style="color:#22863a;">+12%</td></tr>
+                  <tr style="background:#fafafa;"><td>Errors</td><td align="right">12</td><td align="right" style="color:#b31d28;">+3%</td></tr>
+                  <tr><td>Avg response</td><td align="right">84 ms</td><td align="right" style="color:#22863a;">-8%</td></tr>
+                  <tr style="background:#fafafa;"><td>P95 response</td><td align="right">220 ms</td><td align="right" style="color:#22863a;">-5%</td></tr>
+                </tbody>
+              </table>
+            </body>
+            </html>
+            HTML;
+    }
+
+    public static function newsletterHtml(): string
+    {
+        return <<<'HTML'
+            <!DOCTYPE html>
+            <html lang="en">
+            <body style="margin:0; padding:0; background:#eef0f3; font-family:'Segoe UI', Arial, sans-serif; color:#1c1e21;">
+              <table width="100%" cellpadding="0" cellspacing="0" style="background:#eef0f3;">
+                <tr><td align="center" style="padding: 32px 16px;">
+                  <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff; border-radius:8px; overflow:hidden; box-shadow:0 4px 12px rgba(0,0,0,0.06);">
+                    <tr><td style="background:linear-gradient(90deg,#4f46e5,#06b6d4); padding:28px; color:#fff;">
+                      <h1 style="margin:0; font-size:22px;">ADP Release 2.4</h1>
+                      <p style="margin:6px 0 0 0; opacity:0.9;">April 2026 · Product newsletter</p>
+                    </td></tr>
+                    <tr><td style="padding:24px 28px;">
+                      <h2 style="margin:0 0 12px 0; font-size:18px;">What's new</h2>
+                      <ul style="margin:0 0 16px 0; padding-left:20px; line-height:1.6;">
+                        <li>New <strong>Mailer</strong> collector across all adapters</li>
+                        <li>Faster storage driver (SQLite backend)</li>
+                        <li>MCP server with stdio + HTTP transports</li>
+                      </ul>
+                      <p style="margin:0 0 12px 0;">See attached files for release notes and a printable summary.</p>
+                      <p style="margin:16px 0;">
+                        <a href="https://example.com/changelog" style="background:#4f46e5; color:#fff; padding:10px 18px; text-decoration:none; border-radius:6px; display:inline-block;">Read full changelog</a>
+                      </p>
+                    </td></tr>
+                    <tr><td style="background:#f6f7f9; padding:14px 28px; color:#6b7280; font-size:12px;">
+                      You received this email as a fixture for ADP debugging. No real user action required.
+                    </td></tr>
+                  </table>
+                </td></tr>
+              </table>
+            </body>
+            </html>
+            HTML;
+    }
+
+    public static function textAttachment(): string
+    {
+        return "ADP Release Notes\n=================\n\n- Added MailerCollector across Yii3, Symfony, Laravel and Yii2 adapters.\n- Normalized mail payload: from, to, subject, text/html, attachments.\n- Storage persists each sent message for inspection in the debug panel.\n";
+    }
+
+    public static function pdfAttachment(): string
+    {
+        return (string) base64_decode(self::PDF_BASE64, true);
+    }
+}

--- a/playground/yii3-app/src/Web/TestFixtures/MailerAction.php
+++ b/playground/yii3-app/src/Web/TestFixtures/MailerAction.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Yiisoft\DataResponse\DataResponseFactoryInterface;
+use Yiisoft\Mailer\File;
 use Yiisoft\Mailer\MailerInterface;
 use Yiisoft\Mailer\Message;
 
@@ -20,17 +21,34 @@ final readonly class MailerAction implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        // Send a real email via yiisoft/mailer — the MailerInterfaceProxy intercepts
-        // send() calls and feeds email metadata to MailerCollector.
-        $message = new Message()
+        $plain = new Message()
             ->withFrom('noreply@example.com')
             ->withTo('user@example.com')
-            ->withSubject('ADP Test Fixture Email')
-            ->withTextBody('This is a test email from the ADP mailer fixture.')
-            ->withHtmlBody('<p>This is a test email from the ADP mailer fixture.</p>');
+            ->withSubject('ADP fixture — plain text')
+            ->withTextBody("Hello!\n\nThis is a plain-text email sent from the ADP Yii 3 fixture.\n\nCheers,\nADP");
 
-        $this->mailer->send($message);
+        $table = new Message()
+            ->withFrom('noreply@example.com')
+            ->withTo('user@example.com')
+            ->withSubject('ADP fixture — HTML table report')
+            ->withTextBody("Weekly report:\n- Requests: 1240\n- Errors: 12\n- Avg response: 84ms")
+            ->withHtmlBody(MailerFixtureContent::tableHtml());
 
-        return $this->responseFactory->createResponse(['fixture' => 'mailer:basic', 'status' => 'ok']);
+        $rich = new Message()
+            ->withFrom('noreply@example.com')
+            ->withTo('user@example.com')
+            ->withSubject('ADP fixture — newsletter with attachments')
+            ->withTextBody('Please see the attached TXT and PDF files.')
+            ->withHtmlBody(MailerFixtureContent::newsletterHtml())
+            ->withAttachments(
+                File::fromContent(MailerFixtureContent::textAttachment(), 'release-notes.txt', 'text/plain'),
+                File::fromContent(MailerFixtureContent::pdfAttachment(), 'adp-fixture.pdf', 'application/pdf'),
+            );
+
+        $this->mailer->send($plain);
+        $this->mailer->send($table);
+        $this->mailer->send($rich);
+
+        return $this->responseFactory->createResponse(['fixture' => 'mailer:basic', 'status' => 'ok', 'sent' => 3]);
     }
 }

--- a/playground/yii3-app/src/Web/TestFixtures/MailerFixtureContent.php
+++ b/playground/yii3-app/src/Web/TestFixtures/MailerFixtureContent.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Web\TestFixtures;
+
+final class MailerFixtureContent
+{
+    private const PDF_BASE64 = 'JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgL01lZGlhQm94IFswIDAgNDAwIDIwMF0gPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA8PCAvVHlwZSAvRm9udCAvU3VidHlwZSAvVHlwZTEgL0Jhc2VGb250IC9IZWx2ZXRpY2EgPj4gPj4gPj4gL0NvbnRlbnRzIDQgMCBSID4+CmVuZG9iago0IDAgb2JqCjw8IC9MZW5ndGggNTMgPj4Kc3RyZWFtCkJUIC9GMSAxOCBUZiA0MCAxMjAgVGQgKEFEUCBmaXh0dXJlIGF0dGFjaG1lbnQpIFRqIEVUCmVuZHN0cmVhbQplbmRvYmoKeHJlZgowIDUKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDE1IDAwMDAwIG4gCjAwMDAwMDAwNjQgMDAwMDAgbiAKMDAwMDAwMDE0NSAwMDAwMCBuIAowMDAwMDAwMjk2IDAwMDAwIG4gCnRyYWlsZXIKPDwgL1NpemUgNSAvUm9vdCAxIDAgUiA+PgpzdGFydHhyZWYKMzk5CiUlRU9GCg==';
+
+    public static function tableHtml(): string
+    {
+        return <<<'HTML'
+            <!DOCTYPE html>
+            <html lang="en">
+            <body style="font-family: Arial, sans-serif; color: #222; margin: 0; padding: 24px; background: #f5f5f7;">
+              <h2 style="margin: 0 0 12px 0;">Weekly traffic report</h2>
+              <p style="margin: 0 0 16px 0; color: #555;">Aggregated metrics for the last 7 days.</p>
+              <table cellpadding="8" cellspacing="0" style="border-collapse: collapse; width: 100%; max-width: 520px; background: #fff; border: 1px solid #e2e2e4;">
+                <thead>
+                  <tr style="background: #111; color: #fff;">
+                    <th align="left">Metric</th>
+                    <th align="right">Value</th>
+                    <th align="right">Δ vs prev.</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr><td>Requests</td><td align="right">1 240</td><td align="right" style="color:#22863a;">+12%</td></tr>
+                  <tr style="background:#fafafa;"><td>Errors</td><td align="right">12</td><td align="right" style="color:#b31d28;">+3%</td></tr>
+                  <tr><td>Avg response</td><td align="right">84 ms</td><td align="right" style="color:#22863a;">-8%</td></tr>
+                  <tr style="background:#fafafa;"><td>P95 response</td><td align="right">220 ms</td><td align="right" style="color:#22863a;">-5%</td></tr>
+                </tbody>
+              </table>
+            </body>
+            </html>
+            HTML;
+    }
+
+    public static function newsletterHtml(): string
+    {
+        return <<<'HTML'
+            <!DOCTYPE html>
+            <html lang="en">
+            <body style="margin:0; padding:0; background:#eef0f3; font-family:'Segoe UI', Arial, sans-serif; color:#1c1e21;">
+              <table width="100%" cellpadding="0" cellspacing="0" style="background:#eef0f3;">
+                <tr><td align="center" style="padding: 32px 16px;">
+                  <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff; border-radius:8px; overflow:hidden; box-shadow:0 4px 12px rgba(0,0,0,0.06);">
+                    <tr><td style="background:linear-gradient(90deg,#4f46e5,#06b6d4); padding:28px; color:#fff;">
+                      <h1 style="margin:0; font-size:22px;">ADP Release 2.4</h1>
+                      <p style="margin:6px 0 0 0; opacity:0.9;">April 2026 · Product newsletter</p>
+                    </td></tr>
+                    <tr><td style="padding:24px 28px;">
+                      <h2 style="margin:0 0 12px 0; font-size:18px;">What's new</h2>
+                      <ul style="margin:0 0 16px 0; padding-left:20px; line-height:1.6;">
+                        <li>New <strong>Mailer</strong> collector across all adapters</li>
+                        <li>Faster storage driver (SQLite backend)</li>
+                        <li>MCP server with stdio + HTTP transports</li>
+                      </ul>
+                      <p style="margin:0 0 12px 0;">See attached files for release notes and a printable summary.</p>
+                      <p style="margin:16px 0;">
+                        <a href="https://example.com/changelog" style="background:#4f46e5; color:#fff; padding:10px 18px; text-decoration:none; border-radius:6px; display:inline-block;">Read full changelog</a>
+                      </p>
+                    </td></tr>
+                    <tr><td style="background:#f6f7f9; padding:14px 28px; color:#6b7280; font-size:12px;">
+                      You received this email as a fixture for ADP debugging. No real user action required.
+                    </td></tr>
+                  </table>
+                </td></tr>
+              </table>
+            </body>
+            </html>
+            HTML;
+    }
+
+    public static function textAttachment(): string
+    {
+        return "ADP Release Notes\n=================\n\n- Added MailerCollector across Yii3, Symfony, Laravel and Yii2 adapters.\n- Normalized mail payload: from, to, subject, text/html, attachments.\n- Storage persists each sent message for inspection in the debug panel.\n";
+    }
+
+    public static function pdfAttachment(): string
+    {
+        return (string) base64_decode(self::PDF_BASE64, true);
+    }
+}


### PR DESCRIPTION
## Summary
This PR enhances the mailer test fixtures across all playground applications (Laravel, Symfony, Yii2, Yii3) by introducing reusable email content templates and expanding the test scenarios from a single basic email to three distinct email types with attachments.

## Key Changes

- **New `MailerFixtureContent` classes**: Added to each playground app with static methods providing:
  - `tableHtml()`: A styled HTML table showing weekly traffic metrics
  - `newsletterHtml()`: A formatted newsletter template for ADP Release 2.4
  - `textAttachment()`: Release notes as plain text
  - `pdfAttachment()`: A minimal valid PDF file (base64-encoded)

- **Expanded `MailerAction` implementations**: Updated across all frameworks to send three emails instead of one:
  1. Plain text email with simple message
  2. HTML email with a styled table report
  3. Rich HTML email with newsletter content and two file attachments (TXT + PDF)

- **Response updates**: Modified all `MailerAction` responses to include `'sent' => 3` to reflect the number of emails sent

## Implementation Details

- The PDF content is stored as a base64-encoded constant to avoid binary file dependencies
- Each framework's implementation uses its native mailer API:
  - **Laravel**: `Mail::raw()` and `Mail::html()` with `attachData()`
  - **Symfony**: `Email` objects with `attach()` method
  - **Yii2**: Mailer composition with `attachContent()`
  - **Yii3**: `Message` objects with `File::fromContent()` for attachments
- All fixture content is identical across frameworks to ensure consistent testing behavior
- The HTML templates use inline styles for email client compatibility

https://claude.ai/code/session_01Nnvfap9Vs2XR6Quuisrg4d