### PR TITLE
Enhance Mailer panel with attachments, headers, and improved preview UI

### DIFF
--- a/libs/Adapter/Symfony/src/EventSubscriber/MailerSubscriber.php
+++ b/libs/Adapter/Symfony/src/EventSubscriber/MailerSubscriber.php
@@ -9,13 +9,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
 
 /**
  * Listens to Symfony Mailer events and feeds MailerCollector.
  *
- * Captures email metadata (from, to, subject, body) when Symfony Mailer sends a message.
- * Requires symfony/mailer. When not installed, the subscriber is not registered
- * (guarded by class_exists check in AppDevPanelExtension).
+ * Captures email metadata (from, to, subject, body, attachments, headers) when
+ * Symfony Mailer sends a message. Requires symfony/mailer. When not installed,
+ * the subscriber is not registered (guarded by class_exists check in AppDevPanelExtension).
  */
 final class MailerSubscriber implements EventSubscriberInterface
 {
@@ -38,6 +39,20 @@ final class MailerSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $raw = $message->toString();
+        $headers = [];
+        foreach ($message->getHeaders()->all() as $header) {
+            $headers[$header->getName()] = $header->getBodyAsString();
+        }
+
+        $attachments = [];
+        foreach ($message->getAttachments() as $part) {
+            $attachments[] = $this->normalizePart($part);
+        }
+
+        $messageIdHeader = $message->getHeaders()->get('Message-ID');
+        $messageId = $messageIdHeader !== null ? $messageIdHeader->getBodyAsString() : null;
+
         $this->collector->collectMessage([
             'from' => $this->formatAddresses($message->getFrom()),
             'to' => $this->formatAddresses($message->getTo()),
@@ -47,9 +62,13 @@ final class MailerSubscriber implements EventSubscriberInterface
             'subject' => $message->getSubject() ?? '',
             'textBody' => $message->getTextBody(),
             'htmlBody' => $message->getHtmlBody(),
-            'raw' => '',
+            'raw' => $raw,
             'charset' => $message->getTextCharset() ?? 'utf-8',
             'date' => $message->getDate()?->format('r'),
+            'messageId' => $messageId,
+            'headers' => $headers,
+            'size' => \strlen($raw),
+            'attachments' => $attachments,
         ]);
     }
 
@@ -65,5 +84,33 @@ final class MailerSubscriber implements EventSubscriberInterface
         }
 
         return $result;
+    }
+
+    /**
+     * @return array{
+     *     filename: string,
+     *     contentType: string,
+     *     size: int,
+     *     contentId: ?string,
+     *     inline: bool,
+     *     contentBase64: string,
+     * }
+     */
+    private function normalizePart(DataPart $part): array
+    {
+        $body = $part->getBody();
+        $contentType = $part->getMediaType() . '/' . $part->getMediaSubtype();
+        $inline = $part->hasContentId() || $part->getDisposition() === 'inline';
+
+        return [
+            'filename' => $part->getFilename() ?? 'attachment',
+            'contentType' => $contentType,
+            'size' => \strlen($body),
+            // `embed()` lazily generates the content id on first access — calling
+            // getContentId() is the idiomatic way to read it for inline parts.
+            'contentId' => $inline ? $part->getContentId() : null,
+            'inline' => $inline,
+            'contentBase64' => base64_encode($body),
+        ];
     }
 }

--- a/libs/Adapter/Symfony/tests/Unit/EventSubscriber/MailerSubscriberTest.php
+++ b/libs/Adapter/Symfony/tests/Unit/EventSubscriber/MailerSubscriberTest.php
@@ -67,6 +67,49 @@ final class MailerSubscriberTest extends TestCase
         $this->assertCount(0, $collected['messages']);
     }
 
+    public function testOnMessageCollectsAttachmentsAndHeaders(): void
+    {
+        $subscriber = new MailerSubscriber($this->collector);
+
+        $email = new Email()
+            ->from('sender@example.com')
+            ->to('recipient@example.com')
+            ->subject('With attachment')
+            ->text('Text body')
+            ->html('<p>See logo <img src="cid:logo-id"></p>')
+            ->attach('release-notes', 'release.txt', 'text/plain')
+            ->embed('logo-bytes', 'logo.png', 'image/png');
+
+        $envelope = Envelope::create($email);
+        $event = new MessageEvent($email, $envelope, 'null://null');
+
+        $subscriber->onMessage($event);
+
+        $collected = $this->collector->getCollected();
+        $message = $collected['messages'][0];
+
+        $this->assertIsInt($message['size']);
+        $this->assertGreaterThan(0, $message['size']);
+        $this->assertIsArray($message['headers']);
+        $this->assertArrayHasKey('From', $message['headers']);
+        $this->assertArrayHasKey('To', $message['headers']);
+
+        $this->assertCount(2, $message['attachments']);
+        $byFilename = [];
+        foreach ($message['attachments'] as $attachment) {
+            $byFilename[$attachment['filename']] = $attachment;
+        }
+
+        $this->assertArrayHasKey('release.txt', $byFilename);
+        $this->assertFalse($byFilename['release.txt']['inline']);
+        $this->assertSame('release-notes', base64_decode($byFilename['release.txt']['contentBase64'], true));
+
+        $this->assertArrayHasKey('logo.png', $byFilename);
+        $this->assertTrue($byFilename['logo.png']['inline']);
+        $this->assertNotNull($byFilename['logo.png']['contentId']);
+        $this->assertSame('logo-bytes', base64_decode($byFilename['logo.png']['contentBase64'], true));
+    }
+
     public function testSubscribedEvents(): void
     {
         $events = MailerSubscriber::getSubscribedEvents();

--- a/libs/Adapter/Yii3/src/Collector/Db/CommandInterfaceProxy.php
+++ b/libs/Adapter/Yii3/src/Collector/Db/CommandInterfaceProxy.php
@@ -359,11 +359,8 @@ final class CommandInterfaceProxy implements CommandInterface
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
 
-    public function upsert(
-        string $table,
-        array|QueryInterface $insertColumns,
-        array|bool $updateColumns = true,
-    ): static {
+    public function upsert(string $table, array|QueryInterface $insertColumns, array|bool $updateColumns = true): static
+    {
         return new self($this->decorated->{__FUNCTION__}(...func_get_args()), $this->collector);
     }
 

--- a/libs/Adapter/Yii3/src/Collector/Mailer/MailerInterfaceProxy.php
+++ b/libs/Adapter/Yii3/src/Collector/Mailer/MailerInterfaceProxy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AppDevPanel\Adapter\Yii3\Collector\Mailer;
 
 use AppDevPanel\Kernel\Collector\MailerCollector;
+use Yiisoft\Mailer\File;
 use Yiisoft\Mailer\MailerInterface;
 use Yiisoft\Mailer\MessageInterface;
 use Yiisoft\Mailer\SendResults;
@@ -28,22 +29,93 @@ final class MailerInterfaceProxy implements MailerInterface
         return $this->decorated->sendMultiple($messages);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function normalizeMessage(MessageInterface $message): array
     {
+        $raw = (string) $message;
+        $htmlBody = $message->getCharset() === 'quoted-printable'
+            ? quoted_printable_decode($message->getHtmlBody() ?? '')
+            : $message->getHtmlBody();
+
         return [
             'from' => (array) $message->getFrom(),
             'to' => (array) $message->getTo(),
-            'subject' => $message->getSubject(),
+            'subject' => $message->getSubject() ?? '',
             'textBody' => $message->getTextBody(),
-            'htmlBody' => $message->getCharset() === 'quoted-printable'
-                ? quoted_printable_decode($message->getHtmlBody() ?? '')
-                : $message->getHtmlBody(),
+            'htmlBody' => $htmlBody,
             'replyTo' => (array) $message->getReplyTo(),
             'cc' => (array) $message->getCc(),
             'bcc' => (array) $message->getBcc(),
-            'charset' => $message->getCharset(),
+            'charset' => $message->getCharset() ?? 'utf-8',
             'date' => $message->getDate()?->format('Y-m-d H:i:s'),
-            'raw' => (string) $message,
+            'raw' => $raw,
+            'messageId' => null,
+            'headers' => [],
+            'size' => \strlen($raw),
+            'attachments' => self::collectAttachments($message),
         ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function collectAttachments(MessageInterface $message): array
+    {
+        // Attachments and embeddings live on the concrete Message class, not the interface.
+        $attachments = [];
+        if (method_exists($message, 'getAttachments')) {
+            /** @var array<int, File>|null $list */
+            $list = $message->getAttachments();
+            foreach ($list ?? [] as $file) {
+                $attachments[] = self::normalizeFile($file, false);
+            }
+        }
+        if (method_exists($message, 'getEmbeddings')) {
+            /** @var array<int, File>|null $list */
+            $list = $message->getEmbeddings();
+            foreach ($list ?? [] as $file) {
+                $attachments[] = self::normalizeFile($file, true);
+            }
+        }
+        return $attachments;
+    }
+
+    /**
+     * @return array{
+     *     filename: string,
+     *     contentType: string,
+     *     size: int,
+     *     contentId: ?string,
+     *     inline: bool,
+     *     contentBase64: string,
+     * }
+     */
+    private static function normalizeFile(File $file, bool $inline): array
+    {
+        $content = self::resolveFileContent($file);
+        return [
+            'filename' => $file->name() ?? 'attachment',
+            'contentType' => $file->contentType() ?? 'application/octet-stream',
+            'size' => \strlen($content),
+            'contentId' => $inline ? $file->id() : null,
+            'inline' => $inline,
+            'contentBase64' => base64_encode($content),
+        ];
+    }
+
+    private static function resolveFileContent(File $file): string
+    {
+        $content = $file->content();
+        if ($content !== null) {
+            return $content;
+        }
+        $path = $file->path();
+        if ($path === null || !is_readable($path)) {
+            return '';
+        }
+        $bytes = file_get_contents($path);
+        return $bytes === false ? '' : $bytes;
     }
 }

--- a/libs/Adapter/Yii3/tests/Unit/Collector/Mailer/MailerInterfaceProxyTest.php
+++ b/libs/Adapter/Yii3/tests/Unit/Collector/Mailer/MailerInterfaceProxyTest.php
@@ -107,6 +107,54 @@ final class MailerInterfaceProxyTest extends TestCase
         $this->assertSame('<p>Hello World</p>', $collected['messages'][0]['htmlBody']);
     }
 
+    public function testSendNormalizesAttachmentsAndEmbeddings(): void
+    {
+        $attachment = \Yiisoft\Mailer\File::fromContent('release-notes', 'release.txt', 'text/plain');
+        $embedding = \Yiisoft\Mailer\File::fromContent('logo-bytes', 'logo.png', 'image/png');
+
+        $message = $this->createMessageMock();
+        // Attach both files via real Message methods on the mock's __call - use actual Message instead.
+        $realMessage = new \Yiisoft\Mailer\Message()
+            ->withFrom('sender@example.com')
+            ->withTo('recipient@example.com')
+            ->withSubject('With attachments')
+            ->withAttachments($attachment)
+            ->withEmbeddings($embedding);
+
+        $mailer = $this->createMock(\Yiisoft\Mailer\MailerInterface::class);
+        $mailer->expects($this->once())->method('send')->with($realMessage);
+
+        $timeline = new TimelineCollector();
+        $timeline->startup();
+        $collector = new MailerCollector($timeline);
+        $collector->startup();
+
+        $proxy = new MailerInterfaceProxy($mailer, $collector);
+        $proxy->send($realMessage);
+
+        $collected = $collector->getCollected();
+        $this->assertCount(1, $collected['messages']);
+
+        $attachments = $collected['messages'][0]['attachments'];
+        $this->assertCount(2, $attachments);
+
+        $regular = $attachments[0];
+        $this->assertSame('release.txt', $regular['filename']);
+        $this->assertSame('text/plain', $regular['contentType']);
+        $this->assertFalse($regular['inline']);
+        $this->assertNull($regular['contentId']);
+        $this->assertSame('release-notes', base64_decode($regular['contentBase64'], true));
+
+        $inline = $attachments[1];
+        $this->assertSame('logo.png', $inline['filename']);
+        $this->assertTrue($inline['inline']);
+        $this->assertNotNull($inline['contentId']);
+        $this->assertSame('logo-bytes', base64_decode($inline['contentBase64'], true));
+
+        $this->assertIsInt($collected['messages'][0]['size']);
+        unset($message);
+    }
+
     public function testSendUpdatesSummary(): void
     {
         $message = $this->createMessageMock();

--- a/libs/Kernel/src/Collector/MailerCollector.php
+++ b/libs/Kernel/src/Collector/MailerCollector.php
@@ -9,13 +9,42 @@ namespace AppDevPanel\Kernel\Collector;
  *
  * Framework adapters normalize their message objects into arrays and call collectMessage().
  * Each message is an associative array with keys: from, to, cc, bcc, replyTo, subject,
- * textBody, htmlBody, raw, charset, date.
+ * textBody, htmlBody, raw, charset, date, messageId, headers, size, attachments.
+ *
+ * Attachment entries: {filename, contentType, size, contentId?, inline, contentBase64}.
+ * `inline` entries participate in `cid:` resolution in the HTML preview; non-inline
+ * entries surface as downloadable attachments in the UI.
  */
 final class MailerCollector implements SummaryCollectorInterface
 {
     use CollectorTrait;
 
-    /** @var array<int, array{from: array, to: array, cc: array, bcc: array, replyTo: array, subject: string, textBody: ?string, htmlBody: ?string, raw: string, charset: string, date: ?string}> */
+    /**
+     * @var array<int, array{
+     *     from: array,
+     *     to: array,
+     *     cc: array,
+     *     bcc: array,
+     *     replyTo: array,
+     *     subject: string,
+     *     textBody: ?string,
+     *     htmlBody: ?string,
+     *     raw: string,
+     *     charset: string,
+     *     date: ?string,
+     *     messageId: ?string,
+     *     headers: array<string, string>,
+     *     size: int,
+     *     attachments: array<int, array{
+     *         filename: string,
+     *         contentType: string,
+     *         size: int,
+     *         contentId: ?string,
+     *         inline: bool,
+     *         contentBase64: string,
+     *     }>,
+     * }>
+     */
     private array $messages = [];
 
     public function __construct(
@@ -25,7 +54,10 @@ final class MailerCollector implements SummaryCollectorInterface
     /**
      * Collect a single normalized mail message.
      *
-     * @param array{from: array, to: array, cc: array, bcc: array, replyTo: array, subject: string, textBody: ?string, htmlBody: ?string, raw: string, charset: string, date: ?string} $message
+     * Adapters may omit new fields (messageId, headers, size, attachments);
+     * defaults are filled in here to keep older integrations backwards-compatible.
+     *
+     * @param array<string, mixed> $message
      */
     public function collectMessage(array $message): void
     {
@@ -33,14 +65,14 @@ final class MailerCollector implements SummaryCollectorInterface
             return;
         }
 
-        $this->messages[] = $message;
+        $this->messages[] = $this->normalize($message);
         $this->timelineCollector->collect($this, count($this->messages));
     }
 
     /**
      * Collect multiple normalized messages at once.
      *
-     * @param array<int, array{from: array, to: array, cc: array, bcc: array, replyTo: array, subject: string, textBody: ?string, htmlBody: ?string, raw: string, charset: string, date: ?string}> $messages
+     * @param array<int, array<string, mixed>> $messages
      */
     public function collectMessages(array $messages): void
     {
@@ -49,7 +81,7 @@ final class MailerCollector implements SummaryCollectorInterface
         }
 
         foreach ($messages as $message) {
-            $this->messages[] = $message;
+            $this->messages[] = $this->normalize($message);
         }
 
         $this->timelineCollector->collect($this, count($this->messages));
@@ -82,5 +114,114 @@ final class MailerCollector implements SummaryCollectorInterface
     protected function reset(): void
     {
         $this->messages = [];
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     * @return array{
+     *     from: array,
+     *     to: array,
+     *     cc: array,
+     *     bcc: array,
+     *     replyTo: array,
+     *     subject: string,
+     *     textBody: ?string,
+     *     htmlBody: ?string,
+     *     raw: string,
+     *     charset: string,
+     *     date: ?string,
+     *     messageId: ?string,
+     *     headers: array<string, string>,
+     *     size: int,
+     *     attachments: array<int, array{
+     *         filename: string,
+     *         contentType: string,
+     *         size: int,
+     *         contentId: ?string,
+     *         inline: bool,
+     *         contentBase64: string,
+     *     }>,
+     * }
+     */
+    private function normalize(array $message): array
+    {
+        $raw = (string) ($message['raw'] ?? '');
+        $declaredSize = $message['size'] ?? null;
+
+        /** @var array<string, string> $headers */
+        $headers = \is_array($message['headers'] ?? null) ? $message['headers'] : [];
+
+        return [
+            'from' => (array) ($message['from'] ?? []),
+            'to' => (array) ($message['to'] ?? []),
+            'cc' => (array) ($message['cc'] ?? []),
+            'bcc' => (array) ($message['bcc'] ?? []),
+            'replyTo' => (array) ($message['replyTo'] ?? []),
+            'subject' => (string) ($message['subject'] ?? ''),
+            'textBody' => self::nullableString($message['textBody'] ?? null),
+            'htmlBody' => self::nullableString($message['htmlBody'] ?? null),
+            'raw' => $raw,
+            'charset' => (string) ($message['charset'] ?? 'utf-8'),
+            'date' => self::nullableString($message['date'] ?? null),
+            'messageId' => self::nullableString($message['messageId'] ?? null),
+            'headers' => $headers,
+            'size' => \is_int($declaredSize) ? $declaredSize : \strlen($raw),
+            'attachments' => self::normalizeAttachments($message['attachments'] ?? null),
+        ];
+    }
+
+    private static function nullableString(mixed $value): ?string
+    {
+        return $value === null ? null : (string) $value;
+    }
+
+    /**
+     * @return array<int, array{
+     *     filename: string,
+     *     contentType: string,
+     *     size: int,
+     *     contentId: ?string,
+     *     inline: bool,
+     *     contentBase64: string,
+     * }>
+     */
+    private static function normalizeAttachments(mixed $rawAttachments): array
+    {
+        if (!\is_array($rawAttachments)) {
+            return [];
+        }
+        $attachments = [];
+        foreach ($rawAttachments as $attachment) {
+            if (!\is_array($attachment)) {
+                continue;
+            }
+            $attachments[] = self::normalizeAttachment($attachment);
+        }
+        return $attachments;
+    }
+
+    /**
+     * @param array<string, mixed> $attachment
+     * @return array{
+     *     filename: string,
+     *     contentType: string,
+     *     size: int,
+     *     contentId: ?string,
+     *     inline: bool,
+     *     contentBase64: string,
+     * }
+     */
+    private static function normalizeAttachment(array $attachment): array
+    {
+        $contentBase64 = (string) ($attachment['contentBase64'] ?? '');
+        $declaredSize = $attachment['size'] ?? null;
+        return [
+            'filename' => (string) ($attachment['filename'] ?? ''),
+            'contentType' => (string) ($attachment['contentType'] ?? 'application/octet-stream'),
+            'size' => \is_int($declaredSize) ? $declaredSize : \strlen(base64_decode($contentBase64, true) ?: ''),
+            'contentId' => self::nullableString($attachment['contentId'] ?? null),
+            'inline' => (bool) ($attachment['inline'] ?? false),
+            'contentBase64' => $contentBase64,
+        ];
     }
 }

--- a/libs/Kernel/tests/Unit/Collector/MailerCollectorTest.php
+++ b/libs/Kernel/tests/Unit/Collector/MailerCollectorTest.php
@@ -46,6 +46,11 @@ final class MailerCollectorTest extends AbstractCollectorTestCase
         $this->assertSame('Hello World', $msg['textBody']);
         $this->assertSame('<p>Hello World</p>', $msg['htmlBody']);
         $this->assertSame('utf-8', $msg['charset']);
+        // New fields default to empty when adapter omits them.
+        $this->assertNull($msg['messageId']);
+        $this->assertSame([], $msg['headers']);
+        $this->assertSame([], $msg['attachments']);
+        $this->assertIsInt($msg['size']);
     }
 
     protected function checkSummaryData(array $data): void
@@ -79,6 +84,59 @@ final class MailerCollectorTest extends AbstractCollectorTestCase
 
         $this->assertSame([], $collector->getCollected());
         $this->assertSame([], $collector->getSummary());
+    }
+
+    public function testCollectMessageNormalizesAttachmentsAndSize(): void
+    {
+        $collector = new MailerCollector(new TimelineCollector());
+        $collector->startup();
+
+        $content = 'hello';
+        $contentBase64 = base64_encode($content);
+
+        $collector->collectMessage([
+            'from' => ['sender@example.com' => 'Sender'],
+            'to' => ['recipient@example.com' => 'Recipient'],
+            'subject' => 'With attachment',
+            'raw' => 'RAW',
+            'messageId' => '<abc@example.com>',
+            'headers' => ['X-Custom' => 'yes'],
+            'attachments' => [
+                [
+                    'filename' => 'release-notes.txt',
+                    'contentType' => 'text/plain',
+                    'size' => \strlen($content),
+                    'contentId' => null,
+                    'inline' => false,
+                    'contentBase64' => $contentBase64,
+                ],
+                [
+                    'filename' => 'logo.png',
+                    'contentType' => 'image/png',
+                    'contentId' => 'cid-123',
+                    'inline' => true,
+                    'contentBase64' => $contentBase64,
+                ],
+            ],
+        ]);
+
+        $data = $collector->getCollected();
+        $msg = $data['messages'][0];
+
+        $this->assertSame('<abc@example.com>', $msg['messageId']);
+        $this->assertSame(['X-Custom' => 'yes'], $msg['headers']);
+        $this->assertSame(3, $msg['size']); // strlen('RAW')
+        $this->assertCount(2, $msg['attachments']);
+
+        $this->assertSame('release-notes.txt', $msg['attachments'][0]['filename']);
+        $this->assertFalse($msg['attachments'][0]['inline']);
+        $this->assertNull($msg['attachments'][0]['contentId']);
+        $this->assertSame(\strlen($content), $msg['attachments'][0]['size']);
+
+        $this->assertTrue($msg['attachments'][1]['inline']);
+        $this->assertSame('cid-123', $msg['attachments'][1]['contentId']);
+        // Size computed from base64 when not provided.
+        $this->assertSame(\strlen($content), $msg['attachments'][1]['size']);
     }
 
     public function testResetClearsData(): void

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/MailerPanel.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/MailerPanel.test.tsx
@@ -1,10 +1,12 @@
 import {renderWithProviders} from '@app-dev-panel/sdk/test-utils';
-import {screen} from '@testing-library/react';
+import {screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {describe, expect, it} from 'vitest';
 import {MailerPanel} from './MailerPanel';
 
-const makeMessage = (overrides: Partial<Parameters<typeof MailerPanel>[0]['data']['messages'][0]> = {}) => ({
+type Message = Parameters<typeof MailerPanel>[0]['data']['messages'][0];
+
+const makeMessage = (overrides: Partial<Message> = {}): Message => ({
     from: {'sender@example.com': 'Sender'},
     to: {'admin@example.com': 'Admin'},
     subject: 'Test Email Subject',
@@ -16,11 +18,15 @@ const makeMessage = (overrides: Partial<Parameters<typeof MailerPanel>[0]['data'
     replyTo: {},
     cc: {},
     bcc: {},
+    messageId: null,
+    headers: {},
+    size: 128,
+    attachments: [],
     ...overrides,
 });
 
-describe('MailerPanel', () => {
-    it('shows empty message when no messages', () => {
+describe('MailerPanel — list view', () => {
+    it('shows empty state when no messages', () => {
         renderWithProviders(<MailerPanel data={{messages: []}} />);
         expect(screen.getByText(/No dumped mails/)).toBeInTheDocument();
     });
@@ -35,28 +41,104 @@ describe('MailerPanel', () => {
         expect(screen.getByText('2 messages')).toBeInTheDocument();
     });
 
-    it('renders email subject', () => {
+    it('renders subject and To summary on each row', () => {
         renderWithProviders(<MailerPanel data={{messages: [makeMessage({subject: 'Welcome aboard'})]}} />);
         expect(screen.getByText('Welcome aboard')).toBeInTheDocument();
+        expect(screen.getByText(/admin@example\.com/)).toBeInTheDocument();
     });
 
-    it('renders To field in row', () => {
-        renderWithProviders(<MailerPanel data={{messages: [makeMessage()]}} />);
-        expect(screen.getAllByText(/admin@example\.com/).length).toBeGreaterThan(0);
-    });
-
-    it('renders date in row', () => {
-        renderWithProviders(<MailerPanel data={{messages: [makeMessage({date: '2024-03-20'})]}} />);
-        expect(screen.getByText('2024-03-20')).toBeInTheDocument();
-    });
-
-    it('renders index badges', () => {
+    it('renders index badges per row', () => {
         renderWithProviders(<MailerPanel data={{messages: [makeMessage(), makeMessage({subject: 'Second'})]}} />);
         expect(screen.getByText('1')).toBeInTheDocument();
         expect(screen.getByText('2')).toBeInTheDocument();
     });
 
-    it('expands detail on click showing From/To/Charset', async () => {
+    it('renders attachment count badge when there are non-inline attachments', () => {
+        const message = makeMessage({
+            attachments: [
+                {
+                    filename: 'a.txt',
+                    contentType: 'text/plain',
+                    size: 8,
+                    contentId: null,
+                    inline: false,
+                    contentBase64: '',
+                },
+                {
+                    filename: 'b.pdf',
+                    contentType: 'application/pdf',
+                    size: 8,
+                    contentId: null,
+                    inline: false,
+                    contentBase64: '',
+                },
+            ],
+        });
+        renderWithProviders(<MailerPanel data={{messages: [message]}} />);
+        expect(screen.getByText('2 files')).toBeInTheDocument();
+    });
+
+    it('renders an HTML thumbnail iframe for each message that has HTML body', () => {
+        const {container} = renderWithProviders(<MailerPanel data={{messages: [makeMessage()]}} />);
+        const iframe = container.querySelector('iframe[title="preview"]');
+        expect(iframe).not.toBeNull();
+    });
+
+    it('renders a text snippet when message has no HTML body', () => {
+        renderWithProviders(
+            <MailerPanel data={{messages: [makeMessage({htmlBody: null, textBody: 'Plain only body'})]}} />,
+        );
+        expect(screen.getByText(/Plain only body/)).toBeInTheDocument();
+    });
+});
+
+describe('MailerPanel — detail view', () => {
+    it('opens the detail view when a row is clicked', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<MailerPanel data={{messages: [makeMessage({subject: 'Click me'})]}} />);
+        await user.click(screen.getByText('Click me'));
+        expect(screen.getByText(/Message 1 of 1/)).toBeInTheDocument();
+        expect(screen.getByText('Recipients')).toBeInTheDocument();
+    });
+
+    it('returns to the list when Back is clicked', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<MailerPanel data={{messages: [makeMessage({subject: 'Click me'})]}} />);
+        await user.click(screen.getByText('Click me'));
+        await user.click(screen.getByRole('button', {name: /back/i}));
+        expect(screen.getByText('1 message')).toBeInTheDocument();
+    });
+
+    it('renders preview tabs and viewport toggle', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<MailerPanel data={{messages: [makeMessage()]}} />);
+        await user.click(screen.getByText('Test Email Subject'));
+        expect(screen.getByRole('tab', {name: /HTML Preview/i})).toBeInTheDocument();
+        expect(screen.getByRole('tab', {name: /HTML Source/i})).toBeInTheDocument();
+        expect(screen.getByRole('tab', {name: /^Text$/i})).toBeInTheDocument();
+        expect(screen.getByRole('tab', {name: /^Raw$/i})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: /desktop/i})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: /tablet/i})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: /mobile/i})).toBeInTheDocument();
+    });
+
+    it('switches to text tab and shows the text body', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<MailerPanel data={{messages: [makeMessage({textBody: 'Plain content here'})]}} />);
+        await user.click(screen.getByText('Test Email Subject'));
+        await user.click(screen.getByRole('tab', {name: /^Text$/i}));
+        expect(screen.getByText('Plain content here')).toBeInTheDocument();
+    });
+
+    it('shows the raw content under the Raw tab', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<MailerPanel data={{messages: [makeMessage({raw: 'RAW-MESSAGE-CONTENT-Z'})]}} />);
+        await user.click(screen.getByText('Test Email Subject'));
+        await user.click(screen.getByRole('tab', {name: /^Raw$/i}));
+        expect(screen.getByText(/RAW-MESSAGE-CONTENT-Z/)).toBeInTheDocument();
+    });
+
+    it('renders From, To and Charset fields in the recipients and info sections', async () => {
         const user = userEvent.setup();
         renderWithProviders(<MailerPanel data={{messages: [makeMessage()]}} />);
         await user.click(screen.getByText('Test Email Subject'));
@@ -65,26 +147,57 @@ describe('MailerPanel', () => {
         expect(screen.getByText('utf-8')).toBeInTheDocument();
     });
 
-    it('shows CC when present', async () => {
+    it('shows CC row only when CC is populated', async () => {
         const user = userEvent.setup();
-        const msg = makeMessage({cc: {'cc@example.com': 'CC User'}});
-        renderWithProviders(<MailerPanel data={{messages: [msg]}} />);
+        const cc = makeMessage({cc: {'cc@example.com': 'CC User'}});
+        renderWithProviders(<MailerPanel data={{messages: [cc]}} />);
         await user.click(screen.getByText('Test Email Subject'));
         expect(screen.getByText('CC')).toBeInTheDocument();
     });
 
-    it('hides CC when empty', async () => {
+    it('renders attachments with download buttons', async () => {
         const user = userEvent.setup();
-        renderWithProviders(<MailerPanel data={{messages: [makeMessage()]}} />);
+        const message = makeMessage({
+            attachments: [
+                {
+                    filename: 'release.txt',
+                    contentType: 'text/plain',
+                    size: 5,
+                    contentId: null,
+                    inline: false,
+                    contentBase64: 'aGVsbG8=',
+                },
+            ],
+        });
+        renderWithProviders(<MailerPanel data={{messages: [message]}} />);
         await user.click(screen.getByText('Test Email Subject'));
-        expect(screen.queryByText('CC')).not.toBeInTheDocument();
+        expect(screen.getByText('release.txt')).toBeInTheDocument();
+        const downloadButton = screen.getByRole('link', {name: /Download release\.txt/i});
+        expect(downloadButton).toHaveAttribute('href', 'data:text/plain;base64,aGVsbG8=');
+        expect(downloadButton).toHaveAttribute('download', 'release.txt');
     });
 
-    it('shows Preview HTML and View Raw chips', async () => {
+    it('extracts links from the HTML body', async () => {
         const user = userEvent.setup();
-        renderWithProviders(<MailerPanel data={{messages: [makeMessage()]}} />);
+        const message = makeMessage({
+            htmlBody: '<a href="https://example.com/a">A</a><a href="https://example.com/b">B</a>',
+        });
+        renderWithProviders(<MailerPanel data={{messages: [message]}} />);
         await user.click(screen.getByText('Test Email Subject'));
-        expect(screen.getByText('Preview HTML')).toBeInTheDocument();
-        expect(screen.getByText('View Raw')).toBeInTheDocument();
+        const linksHeading = screen.getByText(/^Links · 2$/);
+        expect(linksHeading).toBeInTheDocument();
+        const section = linksHeading.parentElement!.parentElement!;
+        expect(within(section).getByText('https://example.com/a')).toBeInTheDocument();
+        expect(within(section).getByText('https://example.com/b')).toBeInTheDocument();
+    });
+
+    it('renders Message-ID and headers only when present', async () => {
+        const user = userEvent.setup();
+        const message = makeMessage({messageId: '<abc@example.com>', headers: {'X-Custom': 'yes'}});
+        renderWithProviders(<MailerPanel data={{messages: [message]}} />);
+        await user.click(screen.getByText('Test Email Subject'));
+        expect(screen.getByText('<abc@example.com>')).toBeInTheDocument();
+        expect(screen.getByText('X-Custom')).toBeInTheDocument();
+        expect(screen.getByText('yes')).toBeInTheDocument();
     });
 });

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/MailerPanel.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/MailerPanel.test.tsx
@@ -98,7 +98,22 @@ describe('MailerPanel — detail view', () => {
         renderWithProviders(<MailerPanel data={{messages: [makeMessage({subject: 'Click me'})]}} />);
         await user.click(screen.getByText('Click me'));
         expect(screen.getByText(/Message 1 of 1/)).toBeInTheDocument();
-        expect(screen.getByText('Recipients')).toBeInTheDocument();
+        // Recipients block shows a "From" label row
+        expect(screen.getByText('From')).toBeInTheDocument();
+    });
+
+    it('pre-selects message from ?message query param (simulates page refresh)', () => {
+        renderWithProviders(
+            <MailerPanel data={{messages: [makeMessage({subject: 'Second'}), makeMessage({subject: 'Third'})]}} />,
+            {route: '/?message=1'},
+        );
+        expect(screen.getByText(/Message 2 of 2/)).toBeInTheDocument();
+        expect(screen.getByText('Third')).toBeInTheDocument();
+    });
+
+    it('ignores out-of-range ?message values and falls back to list', () => {
+        renderWithProviders(<MailerPanel data={{messages: [makeMessage()]}} />, {route: '/?message=99'});
+        expect(screen.getByText('1 message')).toBeInTheDocument();
     });
 
     it('returns to the list when Back is clicked', async () => {
@@ -138,13 +153,14 @@ describe('MailerPanel — detail view', () => {
         expect(screen.getByText(/RAW-MESSAGE-CONTENT-Z/)).toBeInTheDocument();
     });
 
-    it('renders From, To and Charset fields in the recipients and info sections', async () => {
+    it('renders From/To rows only for populated address maps', async () => {
         const user = userEvent.setup();
         renderWithProviders(<MailerPanel data={{messages: [makeMessage()]}} />);
         await user.click(screen.getByText('Test Email Subject'));
         expect(screen.getByText('From')).toBeInTheDocument();
-        expect(screen.getByText('Charset')).toBeInTheDocument();
-        expect(screen.getByText('utf-8')).toBeInTheDocument();
+        expect(screen.getByText('To')).toBeInTheDocument();
+        expect(screen.queryByText('CC')).not.toBeInTheDocument();
+        expect(screen.queryByText('BCC')).not.toBeInTheDocument();
     });
 
     it('shows CC row only when CC is populated', async () => {
@@ -155,7 +171,7 @@ describe('MailerPanel — detail view', () => {
         expect(screen.getByText('CC')).toBeInTheDocument();
     });
 
-    it('renders attachments with download buttons', async () => {
+    it('renders attachments with download links', async () => {
         const user = userEvent.setup();
         const message = makeMessage({
             attachments: [
@@ -171,10 +187,9 @@ describe('MailerPanel — detail view', () => {
         });
         renderWithProviders(<MailerPanel data={{messages: [message]}} />);
         await user.click(screen.getByText('Test Email Subject'));
-        expect(screen.getByText('release.txt')).toBeInTheDocument();
-        const downloadButton = screen.getByRole('link', {name: /Download release\.txt/i});
-        expect(downloadButton).toHaveAttribute('href', 'data:text/plain;base64,aGVsbG8=');
-        expect(downloadButton).toHaveAttribute('download', 'release.txt');
+        const downloadLink = screen.getByRole('link', {name: /Download release\.txt/i});
+        expect(downloadLink).toHaveAttribute('href', 'data:text/plain;base64,aGVsbG8=');
+        expect(downloadLink).toHaveAttribute('download', 'release.txt');
     });
 
     it('extracts links from the HTML body', async () => {
@@ -184,20 +199,55 @@ describe('MailerPanel — detail view', () => {
         });
         renderWithProviders(<MailerPanel data={{messages: [message]}} />);
         await user.click(screen.getByText('Test Email Subject'));
-        const linksHeading = screen.getByText(/^Links · 2$/);
-        expect(linksHeading).toBeInTheDocument();
-        const section = linksHeading.parentElement!.parentElement!;
-        expect(within(section).getByText('https://example.com/a')).toBeInTheDocument();
-        expect(within(section).getByText('https://example.com/b')).toBeInTheDocument();
+        expect(screen.getByText('Links: 2')).toBeInTheDocument();
+        expect(screen.getByText('https://example.com/a')).toBeInTheDocument();
+        expect(screen.getByText('https://example.com/b')).toBeInTheDocument();
     });
 
-    it('renders Message-ID and headers only when present', async () => {
+    it('headers chip expands a collapsible headers block', async () => {
         const user = userEvent.setup();
         const message = makeMessage({messageId: '<abc@example.com>', headers: {'X-Custom': 'yes'}});
         renderWithProviders(<MailerPanel data={{messages: [message]}} />);
         await user.click(screen.getByText('Test Email Subject'));
-        expect(screen.getByText('<abc@example.com>')).toBeInTheDocument();
+        const headersChip = screen.getByText(/^Headers · 1$/);
+        expect(headersChip).toBeInTheDocument();
+        // Initially collapsed
+        expect(screen.queryByText('X-Custom')).not.toBeInTheDocument();
+        await user.click(headersChip);
         expect(screen.getByText('X-Custom')).toBeInTheDocument();
         expect(screen.getByText('yes')).toBeInTheDocument();
+    });
+
+    it('opens a fullscreen preview dialog when the fullscreen button is clicked', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<MailerPanel data={{messages: [makeMessage()]}} />);
+        await user.click(screen.getByText('Test Email Subject'));
+        const fullscreenButton = screen.getByRole('button', {name: /open preview fullscreen/i});
+        await user.click(fullscreenButton);
+        const dialog = await screen.findByRole('dialog');
+        expect(within(dialog).getByRole('button', {name: /close fullscreen preview/i})).toBeInTheDocument();
+    });
+
+    it('does not crash when optional fields are missing (legacy payloads)', async () => {
+        const user = userEvent.setup();
+        const minimal = {
+            from: {'a@a.com': ''},
+            to: {'b@b.com': ''},
+            subject: 'Legacy',
+            textBody: 'plain',
+            htmlBody: null,
+            raw: 'legacy raw',
+            charset: 'utf-8',
+            replyTo: {},
+            cc: {},
+            bcc: {},
+            date: null,
+            // deliberately no messageId/headers/size/attachments — simulates old entries on disk
+        } as unknown as Message;
+        renderWithProviders(<MailerPanel data={{messages: [minimal]}} />);
+        await user.click(screen.getByText('Legacy'));
+        expect(screen.getByText(/Message 1 of 1/)).toBeInTheDocument();
+        // Headers chip should not appear
+        expect(screen.queryByText(/^Headers · /)).not.toBeInTheDocument();
     });
 });

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/MailerPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/MailerPanel.tsx
@@ -1,58 +1,82 @@
+import {CodeHighlight} from '@app-dev-panel/sdk/Component/CodeHighlight';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
-import {nl2br} from '@app-dev-panel/sdk/Helper/nl2br';
+import {formatBytes} from '@app-dev-panel/sdk/Helper/formatBytes';
+import {
+    attachmentDataUrl,
+    countImages,
+    extractLinks,
+    type MailAttachment,
+    rewriteCidReferences,
+} from '@app-dev-panel/sdk/Helper/mailPreview';
 import {
     Box,
     Button,
     Chip,
-    Collapse,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogContentText,
-    DialogTitle,
     Icon,
     IconButton,
+    Link,
+    Tab,
+    Tabs,
+    ToggleButton,
+    ToggleButtonGroup,
     Typography,
 } from '@mui/material';
 import {styled} from '@mui/material/styles';
-import {useCallback, useState} from 'react';
+import {type SyntheticEvent, useCallback, useMemo, useState} from 'react';
 
-type PreviewType = 'html' | 'raw';
-type MailMessageType = {
-    from: Record<string, string>;
-    to: Record<string, string>;
+type AddressMap = Record<string, string>;
+
+type MailMessage = {
+    from: AddressMap;
+    to: AddressMap;
+    cc: AddressMap;
+    bcc: AddressMap;
+    replyTo: AddressMap;
     subject: string;
-    date: string;
-    textBody: string;
-    htmlBody: string;
+    textBody: string | null;
+    htmlBody: string | null;
     raw: string;
     charset: string;
-    replyTo: Record<string, string>;
-    cc: Record<string, string>;
-    bcc: Record<string, string>;
+    date: string | null;
+    messageId: string | null;
+    headers: Record<string, string>;
+    size: number;
+    attachments: MailAttachment[];
 };
-type MailerPanelProps = {data: {messages: MailMessageType[]}};
 
-function serializeSender(sender: Record<string, string>): string {
-    return Object.entries(sender)
-        .map(([key, value]) => `${key} <${value}>`)
+type MailerPanelProps = {data: {messages: MailMessage[]}};
+
+type PreviewTab = 'html' | 'text' | 'source' | 'raw';
+type Viewport = 'desktop' | 'tablet' | 'mobile';
+
+const VIEWPORT_WIDTHS: Record<Viewport, number | '100%'> = {desktop: '100%', tablet: 768, mobile: 375};
+
+const serializeAddresses = (addresses: AddressMap): string =>
+    Object.entries(addresses)
+        .map(([email, name]) => (name && name !== email ? `${name} <${email}>` : email))
         .join(', ');
-}
 
-const MailRow = styled(Box, {shouldForwardProp: (p) => p !== 'expanded'})<{expanded?: boolean}>(
-    ({theme, expanded}) => ({
-        display: 'flex',
-        alignItems: 'flex-start',
-        gap: theme.spacing(1.5),
-        padding: theme.spacing(1.5, 2),
-        borderBottom: `1px solid ${theme.palette.divider}`,
-        cursor: 'pointer',
-        transition: 'background-color 0.1s ease',
-        backgroundColor: expanded ? theme.palette.action.hover : 'transparent',
-        '&:hover': {backgroundColor: theme.palette.action.hover},
-    }),
-);
+const formatSummaryRecipients = (addresses: AddressMap): string => Object.keys(addresses).join(', ') || '—';
+
+const attachmentIconName = (contentType: string): string => {
+    if (contentType.startsWith('image/')) return 'image';
+    if (contentType === 'application/pdf') return 'picture_as_pdf';
+    if (contentType.startsWith('text/')) return 'description';
+    if (contentType.includes('zip') || contentType.includes('compressed')) return 'folder_zip';
+    return 'attach_file';
+};
+
+const ListRow = styled(Box)(({theme}) => ({
+    display: 'flex',
+    alignItems: 'stretch',
+    gap: theme.spacing(2),
+    padding: theme.spacing(1.5, 2),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    cursor: 'pointer',
+    transition: 'background-color 0.1s ease',
+    '&:hover': {backgroundColor: theme.palette.action.hover},
+}));
 
 const IndexBadge = styled(Box)(({theme}) => ({
     width: 24,
@@ -69,178 +93,519 @@ const IndexBadge = styled(Box)(({theme}) => ({
     marginTop: 2,
 }));
 
-const DetailBox = styled(Box)(({theme}) => ({
-    padding: theme.spacing(2),
-    backgroundColor: theme.palette.action.hover,
-    borderBottom: `1px solid ${theme.palette.divider}`,
+const ThumbFrame = styled(Box)(({theme}) => ({
+    width: 220,
+    height: 72,
+    flexShrink: 0,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    overflow: 'hidden',
+    position: 'relative',
+    backgroundColor: theme.palette.common.white,
+    '& iframe': {
+        width: 640,
+        height: 220,
+        border: 0,
+        transform: 'scale(0.34)',
+        transformOrigin: 'top left',
+        pointerEvents: 'none',
+    },
+}));
+
+const TextThumb = styled(Box)(({theme}) => ({
+    width: 220,
+    height: 72,
+    flexShrink: 0,
+    border: `1px dashed ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(0.75, 1),
+    overflow: 'hidden',
+    fontFamily: theme.adp.fontFamilyMono,
+    fontSize: '10px',
+    lineHeight: 1.3,
+    color: theme.palette.text.disabled,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+}));
+
+const MetaLabel = styled(Typography)(({theme}) => ({
+    fontSize: theme.typography.overline.fontSize,
+    fontWeight: theme.typography.overline.fontWeight,
+    letterSpacing: '0.05em',
+    textTransform: 'uppercase',
+    color: theme.palette.text.disabled,
 }));
 
 const FieldRow = styled(Box)(({theme}) => ({
     display: 'flex',
     gap: theme.spacing(1),
-    marginBottom: theme.spacing(0.5),
+    padding: theme.spacing(0.75, 0),
     fontSize: '12px',
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    '&:last-of-type': {borderBottom: 'none'},
 }));
 
-const FieldLabel = styled(Typography)(({theme}) => ({
-    fontSize: '12px',
+const FieldKey = styled(Typography)(({theme}) => ({
+    fontSize: '11px',
     fontWeight: 600,
     color: theme.palette.text.disabled,
-    width: 60,
+    width: 80,
     flexShrink: 0,
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
 }));
 
-const FieldValue = styled(Typography)({fontSize: '12px', wordBreak: 'break-word'});
+const FieldValue = styled(Typography)({fontSize: '12px', wordBreak: 'break-word', flex: 1});
 
-type PreviewDialogProps = {onClose: () => void; open: boolean; previewType: PreviewType; message: MailMessageType};
-const PreviewDialog = ({message, open, onClose, previewType}: PreviewDialogProps) => {
-    if (!message) return null;
+const MessageListThumbnail = ({message}: {message: MailMessage}) => {
+    const srcDoc = useMemo(() => {
+        if (!message.htmlBody) return '';
+        return rewriteCidReferences(message.htmlBody, message.attachments);
+    }, [message.htmlBody, message.attachments]);
+
+    if (message.htmlBody) {
+        return (
+            <ThumbFrame>
+                <iframe title="preview" sandbox="" srcDoc={srcDoc} />
+            </ThumbFrame>
+        );
+    }
+    const snippet = (message.textBody ?? '').slice(0, 240);
+    return <TextThumb>{snippet || '(no body)'}</TextThumb>;
+};
+
+const ListView = ({messages, onSelect}: {messages: MailMessage[]; onSelect: (index: number) => void}) => (
+    <Box>
+        <Box sx={{display: 'flex', alignItems: 'center', gap: 2, mb: 2}}>
+            <SectionTitle>{`${messages.length} message${messages.length !== 1 ? 's' : ''}`}</SectionTitle>
+        </Box>
+        {messages.map((message, index) => {
+            const attachments = message.attachments.filter((a) => !a.inline);
+            return (
+                <ListRow
+                    key={index}
+                    role="button"
+                    aria-label={`Open message ${index + 1}`}
+                    onClick={() => onSelect(index)}
+                >
+                    <IndexBadge>{index + 1}</IndexBadge>
+                    <Box sx={{flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 0.25}}>
+                        <Typography sx={{fontSize: '13px', fontWeight: 500}}>
+                            {message.subject || '(no subject)'}
+                        </Typography>
+                        <Typography sx={{fontSize: '11px', color: 'text.disabled'}}>
+                            To: {formatSummaryRecipients(message.to)}
+                        </Typography>
+                        <Box sx={{display: 'flex', gap: 0.75, mt: 0.5, flexWrap: 'wrap'}}>
+                            {attachments.length > 0 && (
+                                <Chip
+                                    size="small"
+                                    variant="outlined"
+                                    icon={<Icon sx={{fontSize: '14px !important'}}>attach_file</Icon>}
+                                    label={`${attachments.length} file${attachments.length !== 1 ? 's' : ''}`}
+                                    sx={{fontSize: '11px', height: 22}}
+                                />
+                            )}
+                            {message.htmlBody && (
+                                <Chip
+                                    size="small"
+                                    variant="outlined"
+                                    label="HTML"
+                                    sx={{fontSize: '11px', height: 22}}
+                                />
+                            )}
+                            {message.size > 0 && (
+                                <Chip
+                                    size="small"
+                                    variant="outlined"
+                                    label={formatBytes(message.size)}
+                                    sx={{fontSize: '11px', height: 22, color: 'text.disabled'}}
+                                />
+                            )}
+                        </Box>
+                    </Box>
+                    <MessageListThumbnail message={message} />
+                    <Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'flex-end', flexShrink: 0}}>
+                        <Typography sx={{fontSize: '11px', color: 'text.disabled'}}>{message.date ?? ''}</Typography>
+                        <Icon sx={{fontSize: 16, color: 'text.disabled', mt: 'auto'}}>chevron_right</Icon>
+                    </Box>
+                </ListRow>
+            );
+        })}
+    </Box>
+);
+
+type DetailProps = {message: MailMessage; index: number; total: number; onBack: () => void};
+
+const LeftColumn = ({message}: {message: MailMessage}) => {
+    const attachments = message.attachments.filter((a) => !a.inline);
+    const inlineAttachments = message.attachments.filter((a) => a.inline);
+    const links = useMemo(() => extractLinks(message.htmlBody ?? ''), [message.htmlBody]);
+    const headerEntries = Object.entries(message.headers);
 
     return (
-        <Dialog open={open} onClose={onClose} fullScreen>
-            <DialogTitle sx={{fontWeight: 600, fontSize: '16px'}}>{message.subject}</DialogTitle>
-            <DialogContent>
-                {previewType === 'html' ? (
-                    <DialogContentText dangerouslySetInnerHTML={{__html: message.htmlBody}} />
-                ) : (
-                    <DialogContentText
+        <Box sx={{width: {xs: '100%', md: 340}, flexShrink: 0, display: 'flex', flexDirection: 'column'}}>
+            <SectionTitle>Recipients</SectionTitle>
+            <Box sx={{display: 'flex', flexDirection: 'column'}}>
+                <FieldRow>
+                    <FieldKey>From</FieldKey>
+                    <FieldValue>{serializeAddresses(message.from) || '—'}</FieldValue>
+                </FieldRow>
+                <FieldRow>
+                    <FieldKey>To</FieldKey>
+                    <FieldValue>{serializeAddresses(message.to) || '—'}</FieldValue>
+                </FieldRow>
+                {Object.keys(message.cc).length > 0 && (
+                    <FieldRow>
+                        <FieldKey>CC</FieldKey>
+                        <FieldValue>{serializeAddresses(message.cc)}</FieldValue>
+                    </FieldRow>
+                )}
+                {Object.keys(message.bcc).length > 0 && (
+                    <FieldRow>
+                        <FieldKey>BCC</FieldKey>
+                        <FieldValue>{serializeAddresses(message.bcc)}</FieldValue>
+                    </FieldRow>
+                )}
+                {Object.keys(message.replyTo).length > 0 && (
+                    <FieldRow>
+                        <FieldKey>Reply-To</FieldKey>
+                        <FieldValue>{serializeAddresses(message.replyTo)}</FieldValue>
+                    </FieldRow>
+                )}
+            </Box>
+
+            <SectionTitle>Message info</SectionTitle>
+            <Box sx={{display: 'flex', flexDirection: 'column'}}>
+                {message.messageId && (
+                    <FieldRow>
+                        <FieldKey>Message-ID</FieldKey>
+                        <FieldValue sx={{fontFamily: 'monospace'}}>{message.messageId}</FieldValue>
+                    </FieldRow>
+                )}
+                {message.date && (
+                    <FieldRow>
+                        <FieldKey>Date</FieldKey>
+                        <FieldValue>{message.date}</FieldValue>
+                    </FieldRow>
+                )}
+                <FieldRow>
+                    <FieldKey>Charset</FieldKey>
+                    <FieldValue>{message.charset}</FieldValue>
+                </FieldRow>
+                <FieldRow>
+                    <FieldKey>Size</FieldKey>
+                    <FieldValue>{formatBytes(message.size)}</FieldValue>
+                </FieldRow>
+            </Box>
+
+            {attachments.length > 0 && (
+                <>
+                    <SectionTitle>Attachments · {attachments.length}</SectionTitle>
+                    <Box sx={{display: 'flex', flexDirection: 'column', gap: 0.5}}>
+                        {attachments.map((attachment, idx) => (
+                            <Box
+                                key={`${attachment.filename}-${idx}`}
+                                sx={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 1,
+                                    padding: 1,
+                                    border: '1px solid',
+                                    borderColor: 'divider',
+                                    borderRadius: 1,
+                                }}
+                            >
+                                <Icon sx={{fontSize: 20, color: 'text.disabled'}}>
+                                    {attachmentIconName(attachment.contentType)}
+                                </Icon>
+                                <Box sx={{flex: 1, minWidth: 0}}>
+                                    <Typography sx={{fontSize: '12px', fontWeight: 500, wordBreak: 'break-all'}}>
+                                        {attachment.filename}
+                                    </Typography>
+                                    <Typography sx={{fontSize: '11px', color: 'text.disabled'}}>
+                                        {formatBytes(attachment.size)} · {attachment.contentType}
+                                    </Typography>
+                                </Box>
+                                <IconButton
+                                    size="small"
+                                    component="a"
+                                    href={attachmentDataUrl(attachment)}
+                                    download={attachment.filename}
+                                    aria-label={`Download ${attachment.filename}`}
+                                >
+                                    <Icon sx={{fontSize: 18}}>download</Icon>
+                                </IconButton>
+                            </Box>
+                        ))}
+                    </Box>
+                </>
+            )}
+
+            {inlineAttachments.length > 0 && (
+                <>
+                    <SectionTitle>Inline images · {inlineAttachments.length}</SectionTitle>
+                    <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 1}}>
+                        {inlineAttachments.map((attachment, idx) => (
+                            <Chip
+                                key={`${attachment.filename}-${idx}`}
+                                size="small"
+                                variant="outlined"
+                                icon={<Icon sx={{fontSize: '14px !important'}}>image</Icon>}
+                                label={`${attachment.filename} · ${formatBytes(attachment.size)}`}
+                                sx={{fontSize: '11px', height: 22}}
+                            />
+                        ))}
+                    </Box>
+                </>
+            )}
+
+            {links.length > 0 && (
+                <>
+                    <SectionTitle>Links · {links.length}</SectionTitle>
+                    <Box sx={{display: 'flex', flexDirection: 'column', gap: 0.5}}>
+                        {links.map((href) => (
+                            <Link
+                                key={href}
+                                href={href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                sx={{fontSize: '12px', wordBreak: 'break-all'}}
+                            >
+                                {href}
+                            </Link>
+                        ))}
+                    </Box>
+                </>
+            )}
+
+            {headerEntries.length > 0 && (
+                <>
+                    <SectionTitle>Headers · {headerEntries.length}</SectionTitle>
+                    <Box sx={{display: 'flex', flexDirection: 'column'}}>
+                        {headerEntries.map(([name, value]) => (
+                            <FieldRow key={name}>
+                                <FieldKey>{name}</FieldKey>
+                                <FieldValue sx={{fontFamily: 'monospace', fontSize: '11px'}}>{value}</FieldValue>
+                            </FieldRow>
+                        ))}
+                    </Box>
+                </>
+            )}
+        </Box>
+    );
+};
+
+const PreviewPane = ({message}: {message: MailMessage}) => {
+    const [tab, setTab] = useState<PreviewTab>(message.htmlBody ? 'html' : message.textBody ? 'text' : 'raw');
+    const [viewport, setViewport] = useState<Viewport>('desktop');
+
+    const handleTab = useCallback((_: SyntheticEvent, next: PreviewTab) => setTab(next), []);
+    const handleViewport = useCallback((_: unknown, next: Viewport | null) => {
+        if (next) setViewport(next);
+    }, []);
+
+    const htmlSrcDoc = useMemo(
+        () => rewriteCidReferences(message.htmlBody ?? '', message.attachments),
+        [message.htmlBody, message.attachments],
+    );
+
+    const viewportWidth = VIEWPORT_WIDTHS[viewport];
+
+    return (
+        <Box sx={{flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column'}}>
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    borderBottom: '1px solid',
+                    borderColor: 'divider',
+                    gap: 2,
+                    flexWrap: 'wrap',
+                }}
+            >
+                <Tabs
+                    value={tab}
+                    onChange={handleTab}
+                    sx={{minHeight: 36, '& .MuiTab-root': {minHeight: 36, fontSize: '12px', textTransform: 'none'}}}
+                >
+                    <Tab value="html" label="HTML Preview" disabled={!message.htmlBody} />
+                    <Tab value="text" label="Text" disabled={!message.textBody} />
+                    <Tab value="source" label="HTML Source" disabled={!message.htmlBody} />
+                    <Tab value="raw" label="Raw" />
+                </Tabs>
+                {tab === 'html' && (
+                    <ToggleButtonGroup
+                        value={viewport}
+                        exclusive
+                        size="small"
+                        onChange={handleViewport}
+                        sx={{'& .MuiToggleButton-root': {padding: '4px 10px', fontSize: '11px'}}}
+                    >
+                        <ToggleButton value="desktop" aria-label="Desktop">
+                            <Icon sx={{fontSize: 16, mr: 0.5}}>desktop_windows</Icon>
+                            Desktop
+                        </ToggleButton>
+                        <ToggleButton value="tablet" aria-label="Tablet">
+                            <Icon sx={{fontSize: 16, mr: 0.5}}>tablet_mac</Icon>
+                            Tablet
+                        </ToggleButton>
+                        <ToggleButton value="mobile" aria-label="Mobile">
+                            <Icon sx={{fontSize: 16, mr: 0.5}}>smartphone</Icon>
+                            Mobile
+                        </ToggleButton>
+                    </ToggleButtonGroup>
+                )}
+            </Box>
+
+            <Box sx={{p: 2, flex: 1, minHeight: 320, overflow: 'auto', backgroundColor: 'background.default'}}>
+                {tab === 'html' && message.htmlBody && (
+                    <Box sx={{display: 'flex', justifyContent: 'center'}}>
+                        <Box
+                            sx={{
+                                width: viewportWidth,
+                                minHeight: 480,
+                                backgroundColor: 'common.white',
+                                border: '1px solid',
+                                borderColor: 'divider',
+                                borderRadius: 1,
+                                overflow: 'hidden',
+                            }}
+                        >
+                            <iframe
+                                title="html-preview"
+                                sandbox=""
+                                srcDoc={htmlSrcDoc}
+                                style={{width: '100%', height: 600, border: 0, display: 'block'}}
+                            />
+                        </Box>
+                    </Box>
+                )}
+                {tab === 'text' && (
+                    <Box
+                        component="pre"
                         sx={(theme) => ({
+                            margin: 0,
                             fontFamily: theme.adp.fontFamilyMono,
                             fontSize: '12px',
                             whiteSpace: 'pre-wrap',
+                            wordBreak: 'break-word',
                         })}
                     >
-                        {nl2br(message.raw)}
-                    </DialogContentText>
+                        {message.textBody ?? ''}
+                    </Box>
                 )}
-            </DialogContent>
-            <DialogActions>
-                <Button onClick={onClose}>Close</Button>
-            </DialogActions>
-        </Dialog>
+                {tab === 'source' && message.htmlBody && <CodeHighlight language="html" code={message.htmlBody} />}
+                {tab === 'raw' && (
+                    <Box
+                        component="pre"
+                        sx={(theme) => ({
+                            margin: 0,
+                            fontFamily: theme.adp.fontFamilyMono,
+                            fontSize: '12px',
+                            whiteSpace: 'pre-wrap',
+                            wordBreak: 'break-word',
+                        })}
+                    >
+                        {message.raw}
+                    </Box>
+                )}
+            </Box>
+        </Box>
+    );
+};
+
+const DetailView = ({message, index, total, onBack}: DetailProps) => {
+    const attachments = message.attachments.filter((a) => !a.inline);
+    const images = useMemo(() => countImages(message.htmlBody ?? ''), [message.htmlBody]);
+    const links = useMemo(() => extractLinks(message.htmlBody ?? ''), [message.htmlBody]);
+    const contentType =
+        message.htmlBody && message.textBody ? 'multipart/alternative' : message.htmlBody ? 'text/html' : 'text/plain';
+
+    return (
+        <Box>
+            <Box sx={{display: 'flex', alignItems: 'center', gap: 1.5, mb: 2, flexWrap: 'wrap'}}>
+                <Button
+                    onClick={onBack}
+                    size="small"
+                    startIcon={<Icon sx={{fontSize: '16px !important'}}>arrow_back</Icon>}
+                    sx={{textTransform: 'none'}}
+                >
+                    Back
+                </Button>
+                <Typography sx={{fontSize: '12px', color: 'text.disabled'}}>
+                    Message {index + 1} of {total}
+                </Typography>
+                <Box sx={{flex: 1}} />
+                {message.htmlBody && (
+                    <Chip size="small" variant="outlined" label="multipart" sx={{fontSize: '11px', height: 22}} />
+                )}
+                {attachments.length > 0 && (
+                    <Chip
+                        size="small"
+                        variant="outlined"
+                        icon={<Icon sx={{fontSize: '14px !important'}}>attach_file</Icon>}
+                        label={`${attachments.length} file${attachments.length !== 1 ? 's' : ''}`}
+                        sx={{fontSize: '11px', height: 22}}
+                    />
+                )}
+            </Box>
+
+            <Typography sx={{fontSize: '18px', fontWeight: 600, mb: 0.5}}>
+                {message.subject || '(no subject)'}
+            </Typography>
+            <Typography sx={{fontSize: '12px', color: 'text.disabled', mb: 1.5}}>
+                {serializeAddresses(message.from) || '—'}
+                {' → '}
+                {serializeAddresses(message.to) || '—'}
+                {message.date ? ` · ${message.date}` : ''}
+            </Typography>
+
+            <Box
+                sx={{
+                    display: 'flex',
+                    gap: 2,
+                    mb: 2,
+                    flexWrap: 'wrap',
+                    pb: 1.5,
+                    borderBottom: '1px solid',
+                    borderColor: 'divider',
+                }}
+            >
+                <MetaLabel>Size: {formatBytes(message.size)}</MetaLabel>
+                <MetaLabel>Links: {links.length}</MetaLabel>
+                <MetaLabel>Images: {images}</MetaLabel>
+                <MetaLabel>Type: {contentType}</MetaLabel>
+                <MetaLabel>Charset: {message.charset}</MetaLabel>
+            </Box>
+
+            <Box sx={{display: 'flex', gap: 3, alignItems: 'flex-start', flexDirection: {xs: 'column', md: 'row'}}}>
+                <LeftColumn message={message} />
+                <PreviewPane message={message} />
+            </Box>
+        </Box>
     );
 };
 
 export const MailerPanel = ({data}: MailerPanelProps) => {
-    const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
-    const [dialogOpen, setDialogOpen] = useState(false);
-    const [previewType, setPreviewType] = useState<PreviewType>('html');
-    const [selectedMessage, setSelectedMessage] = useState<MailMessageType | null>(null);
+    const messages = data?.messages ?? [];
+    const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 
-    const handleDialogClose = useCallback(() => {
-        setDialogOpen(false);
-        setSelectedMessage(null);
-    }, []);
-
-    const openPreview = (message: MailMessageType, type: PreviewType) => {
-        setSelectedMessage(message);
-        setPreviewType(type);
-        setDialogOpen(true);
-    };
-
-    if (!data || data.messages.length === 0) {
+    if (messages.length === 0) {
         return <EmptyState icon="mail" title="No dumped mails found" />;
     }
 
-    return (
-        <Box>
-            <Box sx={{display: 'flex', alignItems: 'center', gap: 2, mb: 2}}>
-                <SectionTitle>{`${data.messages.length} message${data.messages.length !== 1 ? 's' : ''}`}</SectionTitle>
-            </Box>
-
-            {data.messages.map((entry, index) => {
-                const expanded = expandedIndex === index;
-
-                return (
-                    <Box key={index}>
-                        <MailRow expanded={expanded} onClick={() => setExpandedIndex(expanded ? null : index)}>
-                            <IndexBadge>{index + 1}</IndexBadge>
-                            <Box sx={{flex: 1, minWidth: 0}}>
-                                <Typography sx={{fontSize: '13px', fontWeight: 500}}>{entry.subject}</Typography>
-                                <Typography sx={{fontSize: '11px', color: 'text.disabled'}}>
-                                    To: {serializeSender(entry.to)}
-                                </Typography>
-                            </Box>
-                            <Typography sx={{fontSize: '11px', color: 'text.disabled', flexShrink: 0}}>
-                                {entry.date}
-                            </Typography>
-                            <IconButton size="small" sx={{flexShrink: 0}}>
-                                <Icon sx={{fontSize: 16}}>{expanded ? 'expand_less' : 'expand_more'}</Icon>
-                            </IconButton>
-                        </MailRow>
-                        <Collapse in={expanded}>
-                            <DetailBox>
-                                <FieldRow>
-                                    <FieldLabel>From</FieldLabel>
-                                    <FieldValue>{serializeSender(entry.from)}</FieldValue>
-                                </FieldRow>
-                                <FieldRow>
-                                    <FieldLabel>To</FieldLabel>
-                                    <FieldValue>{serializeSender(entry.to)}</FieldValue>
-                                </FieldRow>
-                                {Object.keys(entry.cc).length > 0 && (
-                                    <FieldRow>
-                                        <FieldLabel>CC</FieldLabel>
-                                        <FieldValue>{serializeSender(entry.cc)}</FieldValue>
-                                    </FieldRow>
-                                )}
-                                {Object.keys(entry.bcc).length > 0 && (
-                                    <FieldRow>
-                                        <FieldLabel>BCC</FieldLabel>
-                                        <FieldValue>{serializeSender(entry.bcc)}</FieldValue>
-                                    </FieldRow>
-                                )}
-                                {Object.keys(entry.replyTo).length > 0 && (
-                                    <FieldRow>
-                                        <FieldLabel>Reply-To</FieldLabel>
-                                        <FieldValue>{serializeSender(entry.replyTo)}</FieldValue>
-                                    </FieldRow>
-                                )}
-                                <FieldRow>
-                                    <FieldLabel>Charset</FieldLabel>
-                                    <FieldValue>{entry.charset}</FieldValue>
-                                </FieldRow>
-
-                                <Box sx={{display: 'flex', gap: 1, mt: 1.5}}>
-                                    {entry.htmlBody && (
-                                        <Chip
-                                            clickable
-                                            onClick={(e) => {
-                                                e.stopPropagation();
-                                                openPreview(entry, 'html');
-                                            }}
-                                            label="Preview HTML"
-                                            size="small"
-                                            icon={<Icon sx={{fontSize: '14px !important'}}>html</Icon>}
-                                            sx={{fontSize: '11px', height: 24}}
-                                            variant="outlined"
-                                        />
-                                    )}
-                                    <Chip
-                                        clickable
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            openPreview(entry, 'raw');
-                                        }}
-                                        label="View Raw"
-                                        size="small"
-                                        icon={<Icon sx={{fontSize: '14px !important'}}>raw_on</Icon>}
-                                        sx={{fontSize: '11px', height: 24}}
-                                        variant="outlined"
-                                    />
-                                </Box>
-                            </DetailBox>
-                        </Collapse>
-                    </Box>
-                );
-            })}
-
-            <PreviewDialog
-                open={dialogOpen}
-                onClose={handleDialogClose}
-                message={selectedMessage!}
-                previewType={previewType}
+    if (selectedIndex !== null && messages[selectedIndex]) {
+        return (
+            <DetailView
+                message={messages[selectedIndex]}
+                index={selectedIndex}
+                total={messages.length}
+                onBack={() => setSelectedIndex(null)}
             />
-        </Box>
-    );
+        );
+    }
+
+    return <ListView messages={messages} onSelect={setSelectedIndex} />;
 };

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/MailerPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/MailerPanel.tsx
@@ -4,7 +4,6 @@ import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
 import {formatBytes} from '@app-dev-panel/sdk/Helper/formatBytes';
 import {
     attachmentDataUrl,
-    countImages,
     extractLinks,
     type MailAttachment,
     rewriteCidReferences,
@@ -13,6 +12,8 @@ import {
     Box,
     Button,
     Chip,
+    Dialog,
+    DialogContent,
     Icon,
     IconButton,
     Link,
@@ -20,29 +21,31 @@ import {
     Tabs,
     ToggleButton,
     ToggleButtonGroup,
+    Tooltip,
     Typography,
 } from '@mui/material';
 import {styled} from '@mui/material/styles';
 import {type SyntheticEvent, useCallback, useMemo, useState} from 'react';
+import {useSearchParams} from 'react-router';
 
 type AddressMap = Record<string, string>;
 
 type MailMessage = {
-    from: AddressMap;
-    to: AddressMap;
-    cc: AddressMap;
-    bcc: AddressMap;
-    replyTo: AddressMap;
-    subject: string;
-    textBody: string | null;
-    htmlBody: string | null;
-    raw: string;
-    charset: string;
-    date: string | null;
-    messageId: string | null;
-    headers: Record<string, string>;
-    size: number;
-    attachments: MailAttachment[];
+    from?: AddressMap;
+    to?: AddressMap;
+    cc?: AddressMap;
+    bcc?: AddressMap;
+    replyTo?: AddressMap;
+    subject?: string;
+    textBody?: string | null;
+    htmlBody?: string | null;
+    raw?: string;
+    charset?: string;
+    date?: string | null;
+    messageId?: string | null;
+    headers?: Record<string, string>;
+    size?: number;
+    attachments?: MailAttachment[];
 };
 
 type MailerPanelProps = {data: {messages: MailMessage[]}};
@@ -52,12 +55,15 @@ type Viewport = 'desktop' | 'tablet' | 'mobile';
 
 const VIEWPORT_WIDTHS: Record<Viewport, number | '100%'> = {desktop: '100%', tablet: 768, mobile: 375};
 
-const serializeAddresses = (addresses: AddressMap): string =>
-    Object.entries(addresses)
+const serializeAddresses = (addresses: AddressMap | undefined): string =>
+    Object.entries(addresses ?? {})
         .map(([email, name]) => (name && name !== email ? `${name} <${email}>` : email))
         .join(', ');
 
-const formatSummaryRecipients = (addresses: AddressMap): string => Object.keys(addresses).join(', ') || '—';
+const hasAddresses = (addresses: AddressMap | undefined): boolean => !!addresses && Object.keys(addresses).length > 0;
+
+const formatSummaryRecipients = (addresses: AddressMap | undefined): string =>
+    Object.keys(addresses ?? {}).join(', ') || '—';
 
 const attachmentIconName = (contentType: string): string => {
     if (contentType.startsWith('image/')) return 'image';
@@ -136,31 +142,10 @@ const MetaLabel = styled(Typography)(({theme}) => ({
     color: theme.palette.text.disabled,
 }));
 
-const FieldRow = styled(Box)(({theme}) => ({
-    display: 'flex',
-    gap: theme.spacing(1),
-    padding: theme.spacing(0.75, 0),
-    fontSize: '12px',
-    borderBottom: `1px solid ${theme.palette.divider}`,
-    '&:last-of-type': {borderBottom: 'none'},
-}));
-
-const FieldKey = styled(Typography)(({theme}) => ({
-    fontSize: '11px',
-    fontWeight: 600,
-    color: theme.palette.text.disabled,
-    width: 80,
-    flexShrink: 0,
-    textTransform: 'uppercase',
-    letterSpacing: '0.04em',
-}));
-
-const FieldValue = styled(Typography)({fontSize: '12px', wordBreak: 'break-word', flex: 1});
-
 const MessageListThumbnail = ({message}: {message: MailMessage}) => {
     const srcDoc = useMemo(() => {
         if (!message.htmlBody) return '';
-        return rewriteCidReferences(message.htmlBody, message.attachments);
+        return rewriteCidReferences(message.htmlBody, message.attachments ?? []);
     }, [message.htmlBody, message.attachments]);
 
     if (message.htmlBody) {
@@ -170,8 +155,10 @@ const MessageListThumbnail = ({message}: {message: MailMessage}) => {
             </ThumbFrame>
         );
     }
-    const snippet = (message.textBody ?? '').slice(0, 240);
-    return <TextThumb>{snippet || '(no body)'}</TextThumb>;
+    if (message.textBody) {
+        return <TextThumb>{message.textBody.slice(0, 240)}</TextThumb>;
+    }
+    return null;
 };
 
 const ListView = ({messages, onSelect}: {messages: MailMessage[]; onSelect: (index: number) => void}) => (
@@ -180,7 +167,7 @@ const ListView = ({messages, onSelect}: {messages: MailMessage[]; onSelect: (ind
             <SectionTitle>{`${messages.length} message${messages.length !== 1 ? 's' : ''}`}</SectionTitle>
         </Box>
         {messages.map((message, index) => {
-            const attachments = message.attachments.filter((a) => !a.inline);
+            const attachments = (message.attachments ?? []).filter((a) => !a.inline);
             return (
                 <ListRow
                     key={index}
@@ -193,9 +180,11 @@ const ListView = ({messages, onSelect}: {messages: MailMessage[]; onSelect: (ind
                         <Typography sx={{fontSize: '13px', fontWeight: 500}}>
                             {message.subject || '(no subject)'}
                         </Typography>
-                        <Typography sx={{fontSize: '11px', color: 'text.disabled'}}>
-                            To: {formatSummaryRecipients(message.to)}
-                        </Typography>
+                        {hasAddresses(message.to) && (
+                            <Typography sx={{fontSize: '11px', color: 'text.disabled'}}>
+                                To: {formatSummaryRecipients(message.to)}
+                            </Typography>
+                        )}
                         <Box sx={{display: 'flex', gap: 0.75, mt: 0.5, flexWrap: 'wrap'}}>
                             {attachments.length > 0 && (
                                 <Chip
@@ -214,7 +203,7 @@ const ListView = ({messages, onSelect}: {messages: MailMessage[]; onSelect: (ind
                                     sx={{fontSize: '11px', height: 22}}
                                 />
                             )}
-                            {message.size > 0 && (
+                            {typeof message.size === 'number' && message.size > 0 && (
                                 <Chip
                                     size="small"
                                     variant="outlined"
@@ -226,7 +215,9 @@ const ListView = ({messages, onSelect}: {messages: MailMessage[]; onSelect: (ind
                     </Box>
                     <MessageListThumbnail message={message} />
                     <Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'flex-end', flexShrink: 0}}>
-                        <Typography sx={{fontSize: '11px', color: 'text.disabled'}}>{message.date ?? ''}</Typography>
+                        {message.date && (
+                            <Typography sx={{fontSize: '11px', color: 'text.disabled'}}>{message.date}</Typography>
+                        )}
                         <Icon sx={{fontSize: 16, color: 'text.disabled', mt: 'auto'}}>chevron_right</Icon>
                     </Box>
                 </ListRow>
@@ -237,166 +228,178 @@ const ListView = ({messages, onSelect}: {messages: MailMessage[]; onSelect: (ind
 
 type DetailProps = {message: MailMessage; index: number; total: number; onBack: () => void};
 
-const LeftColumn = ({message}: {message: MailMessage}) => {
-    const attachments = message.attachments.filter((a) => !a.inline);
-    const inlineAttachments = message.attachments.filter((a) => a.inline);
+// ---------------------------------------------------------------------------
+// Meta sections — displayed ABOVE the full-width preview.
+// Each section is shown only when it has content.
+// ---------------------------------------------------------------------------
+
+const AddressLine = ({label, addresses}: {label: string; addresses: AddressMap | undefined}) => {
+    if (!hasAddresses(addresses)) return null;
+    return (
+        <Box sx={{display: 'flex', gap: 1, fontSize: '12px', lineHeight: 1.5}}>
+            <Box
+                sx={{
+                    width: 64,
+                    flexShrink: 0,
+                    color: 'text.disabled',
+                    fontWeight: 600,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.04em',
+                    fontSize: '11px',
+                }}
+            >
+                {label}
+            </Box>
+            <Box sx={{flex: 1, wordBreak: 'break-word'}}>{serializeAddresses(addresses)}</Box>
+        </Box>
+    );
+};
+
+const AttachmentChip = ({attachment}: {attachment: MailAttachment}) => (
+    <Box
+        component="a"
+        href={attachmentDataUrl(attachment)}
+        download={attachment.filename}
+        aria-label={`Download ${attachment.filename}`}
+        sx={(theme) => ({
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 1,
+            padding: theme.spacing(0.5, 1),
+            border: `1px solid ${theme.palette.divider}`,
+            borderRadius: 1,
+            textDecoration: 'none',
+            color: theme.palette.text.primary,
+            fontSize: '12px',
+            maxWidth: 280,
+            transition: 'background-color 0.1s ease',
+            '&:hover': {backgroundColor: theme.palette.action.hover},
+        })}
+    >
+        <Icon sx={{fontSize: 16, color: 'text.disabled', flexShrink: 0}}>
+            {attachmentIconName(attachment.contentType)}
+        </Icon>
+        <Box sx={{minWidth: 0, display: 'flex', flexDirection: 'column'}}>
+            <Box sx={{fontWeight: 500, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'}}>
+                {attachment.filename}
+            </Box>
+            <Box sx={{fontSize: '10px', color: 'text.disabled'}}>
+                {formatBytes(attachment.size)} · {attachment.contentType}
+            </Box>
+        </Box>
+        <Icon sx={{fontSize: 16, color: 'text.disabled', ml: 'auto', flexShrink: 0}}>download</Icon>
+    </Box>
+);
+
+const MetaHeader = ({message}: {message: MailMessage}) => {
+    const allAttachments = message.attachments ?? [];
+    const attachments = allAttachments.filter((a) => !a.inline);
+    const inlineAttachments = allAttachments.filter((a) => a.inline);
     const links = useMemo(() => extractLinks(message.htmlBody ?? ''), [message.htmlBody]);
-    const headerEntries = Object.entries(message.headers);
+    const headerEntries = Object.entries(message.headers ?? {});
+    const [headersOpen, setHeadersOpen] = useState(false);
 
     return (
-        <Box sx={{width: {xs: '100%', md: 340}, flexShrink: 0, display: 'flex', flexDirection: 'column'}}>
-            <SectionTitle>Recipients</SectionTitle>
-            <Box sx={{display: 'flex', flexDirection: 'column'}}>
-                <FieldRow>
-                    <FieldKey>From</FieldKey>
-                    <FieldValue>{serializeAddresses(message.from) || '—'}</FieldValue>
-                </FieldRow>
-                <FieldRow>
-                    <FieldKey>To</FieldKey>
-                    <FieldValue>{serializeAddresses(message.to) || '—'}</FieldValue>
-                </FieldRow>
-                {Object.keys(message.cc).length > 0 && (
-                    <FieldRow>
-                        <FieldKey>CC</FieldKey>
-                        <FieldValue>{serializeAddresses(message.cc)}</FieldValue>
-                    </FieldRow>
-                )}
-                {Object.keys(message.bcc).length > 0 && (
-                    <FieldRow>
-                        <FieldKey>BCC</FieldKey>
-                        <FieldValue>{serializeAddresses(message.bcc)}</FieldValue>
-                    </FieldRow>
-                )}
-                {Object.keys(message.replyTo).length > 0 && (
-                    <FieldRow>
-                        <FieldKey>Reply-To</FieldKey>
-                        <FieldValue>{serializeAddresses(message.replyTo)}</FieldValue>
-                    </FieldRow>
-                )}
+        <Box sx={{display: 'flex', flexDirection: 'column', gap: 1.25, mb: 2}}>
+            {/* Recipients block */}
+            <Box sx={{display: 'flex', flexDirection: 'column', gap: 0.5}}>
+                <AddressLine label="From" addresses={message.from} />
+                <AddressLine label="To" addresses={message.to} />
+                <AddressLine label="CC" addresses={message.cc} />
+                <AddressLine label="BCC" addresses={message.bcc} />
+                <AddressLine label="Reply-To" addresses={message.replyTo} />
             </Box>
 
-            <SectionTitle>Message info</SectionTitle>
-            <Box sx={{display: 'flex', flexDirection: 'column'}}>
-                {message.messageId && (
-                    <FieldRow>
-                        <FieldKey>Message-ID</FieldKey>
-                        <FieldValue sx={{fontFamily: 'monospace'}}>{message.messageId}</FieldValue>
-                    </FieldRow>
-                )}
-                {message.date && (
-                    <FieldRow>
-                        <FieldKey>Date</FieldKey>
-                        <FieldValue>{message.date}</FieldValue>
-                    </FieldRow>
-                )}
-                <FieldRow>
-                    <FieldKey>Charset</FieldKey>
-                    <FieldValue>{message.charset}</FieldValue>
-                </FieldRow>
-                <FieldRow>
-                    <FieldKey>Size</FieldKey>
-                    <FieldValue>{formatBytes(message.size)}</FieldValue>
-                </FieldRow>
-            </Box>
-
+            {/* Attachments strip — filename chips with download */}
             {attachments.length > 0 && (
-                <>
-                    <SectionTitle>Attachments · {attachments.length}</SectionTitle>
-                    <Box sx={{display: 'flex', flexDirection: 'column', gap: 0.5}}>
-                        {attachments.map((attachment, idx) => (
-                            <Box
-                                key={`${attachment.filename}-${idx}`}
-                                sx={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    gap: 1,
-                                    padding: 1,
-                                    border: '1px solid',
-                                    borderColor: 'divider',
-                                    borderRadius: 1,
-                                }}
-                            >
-                                <Icon sx={{fontSize: 20, color: 'text.disabled'}}>
-                                    {attachmentIconName(attachment.contentType)}
-                                </Icon>
-                                <Box sx={{flex: 1, minWidth: 0}}>
-                                    <Typography sx={{fontSize: '12px', fontWeight: 500, wordBreak: 'break-all'}}>
-                                        {attachment.filename}
-                                    </Typography>
-                                    <Typography sx={{fontSize: '11px', color: 'text.disabled'}}>
-                                        {formatBytes(attachment.size)} · {attachment.contentType}
-                                    </Typography>
-                                </Box>
-                                <IconButton
-                                    size="small"
-                                    component="a"
-                                    href={attachmentDataUrl(attachment)}
-                                    download={attachment.filename}
-                                    aria-label={`Download ${attachment.filename}`}
-                                >
-                                    <Icon sx={{fontSize: 18}}>download</Icon>
-                                </IconButton>
-                            </Box>
-                        ))}
-                    </Box>
-                </>
+                <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75}}>
+                    {attachments.map((attachment, idx) => (
+                        <AttachmentChip key={`${attachment.filename}-${idx}`} attachment={attachment} />
+                    ))}
+                </Box>
             )}
 
-            {inlineAttachments.length > 0 && (
-                <>
-                    <SectionTitle>Inline images · {inlineAttachments.length}</SectionTitle>
-                    <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 1}}>
-                        {inlineAttachments.map((attachment, idx) => (
-                            <Chip
-                                key={`${attachment.filename}-${idx}`}
-                                size="small"
-                                variant="outlined"
-                                icon={<Icon sx={{fontSize: '14px !important'}}>image</Icon>}
-                                label={`${attachment.filename} · ${formatBytes(attachment.size)}`}
-                                sx={{fontSize: '11px', height: 22}}
-                            />
-                        ))}
-                    </Box>
-                </>
-            )}
+            {/* Compact meta row — inline stats, links, inline-images, headers toggle */}
+            <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 1.25, alignItems: 'center', rowGap: 0.5}}>
+                {message.messageId && (
+                    <Tooltip title={message.messageId} placement="top">
+                        <Chip
+                            size="small"
+                            variant="outlined"
+                            label={`ID: ${message.messageId.replace(/^<|>$/g, '').slice(0, 32)}${message.messageId.length > 34 ? '…' : ''}`}
+                            sx={{fontSize: '11px', height: 22, fontFamily: 'monospace'}}
+                        />
+                    </Tooltip>
+                )}
+                {typeof message.size === 'number' && message.size > 0 && (
+                    <MetaLabel>Size: {formatBytes(message.size)}</MetaLabel>
+                )}
+                {message.charset && <MetaLabel>Charset: {message.charset}</MetaLabel>}
+                {links.length > 0 && <MetaLabel>Links: {links.length}</MetaLabel>}
+                {inlineAttachments.length > 0 && <MetaLabel>Inline images: {inlineAttachments.length}</MetaLabel>}
+                {headerEntries.length > 0 && (
+                    <Chip
+                        size="small"
+                        clickable
+                        variant={headersOpen ? 'filled' : 'outlined'}
+                        label={`Headers · ${headerEntries.length}`}
+                        onClick={() => setHeadersOpen((v) => !v)}
+                        sx={{fontSize: '11px', height: 22}}
+                    />
+                )}
+            </Box>
 
+            {/* Links list — only when there are links */}
             {links.length > 0 && (
-                <>
-                    <SectionTitle>Links · {links.length}</SectionTitle>
-                    <Box sx={{display: 'flex', flexDirection: 'column', gap: 0.5}}>
-                        {links.map((href) => (
-                            <Link
-                                key={href}
-                                href={href}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                sx={{fontSize: '12px', wordBreak: 'break-all'}}
-                            >
-                                {href}
-                            </Link>
-                        ))}
-                    </Box>
-                </>
+                <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75, rowGap: 0.25}}>
+                    {links.map((href) => (
+                        <Link
+                            key={href}
+                            href={href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            sx={{fontSize: '11px', wordBreak: 'break-all'}}
+                        >
+                            {href}
+                        </Link>
+                    ))}
+                </Box>
             )}
 
-            {headerEntries.length > 0 && (
-                <>
-                    <SectionTitle>Headers · {headerEntries.length}</SectionTitle>
-                    <Box sx={{display: 'flex', flexDirection: 'column'}}>
-                        {headerEntries.map(([name, value]) => (
-                            <FieldRow key={name}>
-                                <FieldKey>{name}</FieldKey>
-                                <FieldValue sx={{fontFamily: 'monospace', fontSize: '11px'}}>{value}</FieldValue>
-                            </FieldRow>
-                        ))}
-                    </Box>
-                </>
+            {/* Headers — collapsible */}
+            {headersOpen && headerEntries.length > 0 && (
+                <Box
+                    sx={(theme) => ({
+                        border: `1px solid ${theme.palette.divider}`,
+                        borderRadius: 1,
+                        padding: theme.spacing(1, 1.5),
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 0.25,
+                        maxHeight: 220,
+                        overflow: 'auto',
+                    })}
+                >
+                    {headerEntries.map(([name, value]) => (
+                        <Box key={name} sx={{display: 'flex', gap: 1, fontSize: '11px', fontFamily: 'monospace'}}>
+                            <Box sx={{minWidth: 140, color: 'text.disabled'}}>{name}</Box>
+                            <Box sx={{flex: 1, wordBreak: 'break-word'}}>{value}</Box>
+                        </Box>
+                    ))}
+                </Box>
             )}
         </Box>
     );
 };
 
-const PreviewPane = ({message}: {message: MailMessage}) => {
+// ---------------------------------------------------------------------------
+// Preview pane — tabs + viewport toggle. Used both inline and inside the
+// fullscreen Dialog.
+// ---------------------------------------------------------------------------
+
+type PreviewPaneProps = {message: MailMessage; onFullscreen?: () => void; onExitFullscreen?: () => void};
+
+const PreviewPane = ({message, onFullscreen, onExitFullscreen}: PreviewPaneProps) => {
     const [tab, setTab] = useState<PreviewTab>(message.htmlBody ? 'html' : message.textBody ? 'text' : 'raw');
     const [viewport, setViewport] = useState<Viewport>('desktop');
 
@@ -406,14 +409,26 @@ const PreviewPane = ({message}: {message: MailMessage}) => {
     }, []);
 
     const htmlSrcDoc = useMemo(
-        () => rewriteCidReferences(message.htmlBody ?? '', message.attachments),
+        () => rewriteCidReferences(message.htmlBody ?? '', message.attachments ?? []),
         [message.htmlBody, message.attachments],
     );
 
     const viewportWidth = VIEWPORT_WIDTHS[viewport];
+    const fullscreen = Boolean(onExitFullscreen);
 
     return (
-        <Box sx={{flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column'}}>
+        <Box
+            sx={(theme) => ({
+                flex: 1,
+                minWidth: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                border: fullscreen ? 'none' : `1px solid ${theme.palette.divider}`,
+                borderRadius: fullscreen ? 0 : 1,
+                overflow: 'hidden',
+                backgroundColor: theme.palette.background.paper,
+            })}
+        >
             <Box
                 sx={{
                     display: 'flex',
@@ -422,6 +437,7 @@ const PreviewPane = ({message}: {message: MailMessage}) => {
                     borderBottom: '1px solid',
                     borderColor: 'divider',
                     gap: 2,
+                    px: 1,
                     flexWrap: 'wrap',
                 }}
             >
@@ -433,39 +449,63 @@ const PreviewPane = ({message}: {message: MailMessage}) => {
                     <Tab value="html" label="HTML Preview" disabled={!message.htmlBody} />
                     <Tab value="text" label="Text" disabled={!message.textBody} />
                     <Tab value="source" label="HTML Source" disabled={!message.htmlBody} />
-                    <Tab value="raw" label="Raw" />
+                    <Tab value="raw" label="Raw" disabled={!message.raw} />
                 </Tabs>
-                {tab === 'html' && (
-                    <ToggleButtonGroup
-                        value={viewport}
-                        exclusive
-                        size="small"
-                        onChange={handleViewport}
-                        sx={{'& .MuiToggleButton-root': {padding: '4px 10px', fontSize: '11px'}}}
-                    >
-                        <ToggleButton value="desktop" aria-label="Desktop">
-                            <Icon sx={{fontSize: 16, mr: 0.5}}>desktop_windows</Icon>
-                            Desktop
-                        </ToggleButton>
-                        <ToggleButton value="tablet" aria-label="Tablet">
-                            <Icon sx={{fontSize: 16, mr: 0.5}}>tablet_mac</Icon>
-                            Tablet
-                        </ToggleButton>
-                        <ToggleButton value="mobile" aria-label="Mobile">
-                            <Icon sx={{fontSize: 16, mr: 0.5}}>smartphone</Icon>
-                            Mobile
-                        </ToggleButton>
-                    </ToggleButtonGroup>
-                )}
+                <Box sx={{display: 'flex', alignItems: 'center', gap: 1, mr: 0.5}}>
+                    {tab === 'html' && message.htmlBody && (
+                        <ToggleButtonGroup
+                            value={viewport}
+                            exclusive
+                            size="small"
+                            onChange={handleViewport}
+                            sx={{'& .MuiToggleButton-root': {padding: '4px 10px', fontSize: '11px'}}}
+                        >
+                            <ToggleButton value="desktop" aria-label="Desktop">
+                                <Icon sx={{fontSize: 16, mr: 0.5}}>desktop_windows</Icon>
+                                Desktop
+                            </ToggleButton>
+                            <ToggleButton value="tablet" aria-label="Tablet">
+                                <Icon sx={{fontSize: 16, mr: 0.5}}>tablet_mac</Icon>
+                                Tablet
+                            </ToggleButton>
+                            <ToggleButton value="mobile" aria-label="Mobile">
+                                <Icon sx={{fontSize: 16, mr: 0.5}}>smartphone</Icon>
+                                Mobile
+                            </ToggleButton>
+                        </ToggleButtonGroup>
+                    )}
+                    {onFullscreen && (
+                        <Tooltip title="Open fullscreen" placement="top">
+                            <IconButton size="small" onClick={onFullscreen} aria-label="Open preview fullscreen">
+                                <Icon sx={{fontSize: 18}}>fullscreen</Icon>
+                            </IconButton>
+                        </Tooltip>
+                    )}
+                    {onExitFullscreen && (
+                        <Tooltip title="Exit fullscreen" placement="top">
+                            <IconButton size="small" onClick={onExitFullscreen} aria-label="Close fullscreen preview">
+                                <Icon sx={{fontSize: 18}}>close</Icon>
+                            </IconButton>
+                        </Tooltip>
+                    )}
+                </Box>
             </Box>
 
-            <Box sx={{p: 2, flex: 1, minHeight: 320, overflow: 'auto', backgroundColor: 'background.default'}}>
+            <Box
+                sx={{
+                    p: 2,
+                    flex: 1,
+                    minHeight: fullscreen ? 0 : 480,
+                    overflow: 'auto',
+                    backgroundColor: 'background.default',
+                }}
+            >
                 {tab === 'html' && message.htmlBody && (
                     <Box sx={{display: 'flex', justifyContent: 'center'}}>
                         <Box
                             sx={{
                                 width: viewportWidth,
-                                minHeight: 480,
+                                minHeight: fullscreen ? '80vh' : 560,
                                 backgroundColor: 'common.white',
                                 border: '1px solid',
                                 borderColor: 'divider',
@@ -477,7 +517,12 @@ const PreviewPane = ({message}: {message: MailMessage}) => {
                                 title="html-preview"
                                 sandbox=""
                                 srcDoc={htmlSrcDoc}
-                                style={{width: '100%', height: 600, border: 0, display: 'block'}}
+                                style={{
+                                    width: '100%',
+                                    height: fullscreen ? 'calc(100vh - 120px)' : 680,
+                                    border: 0,
+                                    display: 'block',
+                                }}
                             />
                         </Box>
                     </Box>
@@ -508,7 +553,7 @@ const PreviewPane = ({message}: {message: MailMessage}) => {
                             wordBreak: 'break-word',
                         })}
                     >
-                        {message.raw}
+                        {message.raw ?? ''}
                     </Box>
                 )}
             </Box>
@@ -517,15 +562,12 @@ const PreviewPane = ({message}: {message: MailMessage}) => {
 };
 
 const DetailView = ({message, index, total, onBack}: DetailProps) => {
-    const attachments = message.attachments.filter((a) => !a.inline);
-    const images = useMemo(() => countImages(message.htmlBody ?? ''), [message.htmlBody]);
-    const links = useMemo(() => extractLinks(message.htmlBody ?? ''), [message.htmlBody]);
-    const contentType =
-        message.htmlBody && message.textBody ? 'multipart/alternative' : message.htmlBody ? 'text/html' : 'text/plain';
+    const attachments = (message.attachments ?? []).filter((a) => !a.inline);
+    const [fullscreen, setFullscreen] = useState(false);
 
     return (
         <Box>
-            <Box sx={{display: 'flex', alignItems: 'center', gap: 1.5, mb: 2, flexWrap: 'wrap'}}>
+            <Box sx={{display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5, flexWrap: 'wrap'}}>
                 <Button
                     onClick={onBack}
                     size="small"
@@ -538,7 +580,7 @@ const DetailView = ({message, index, total, onBack}: DetailProps) => {
                     Message {index + 1} of {total}
                 </Typography>
                 <Box sx={{flex: 1}} />
-                {message.htmlBody && (
+                {message.htmlBody && message.textBody && (
                     <Chip size="small" variant="outlined" label="multipart" sx={{fontSize: '11px', height: 22}} />
                 )}
                 {attachments.length > 0 && (
@@ -555,42 +597,55 @@ const DetailView = ({message, index, total, onBack}: DetailProps) => {
             <Typography sx={{fontSize: '18px', fontWeight: 600, mb: 0.5}}>
                 {message.subject || '(no subject)'}
             </Typography>
-            <Typography sx={{fontSize: '12px', color: 'text.disabled', mb: 1.5}}>
-                {serializeAddresses(message.from) || '—'}
-                {' → '}
-                {serializeAddresses(message.to) || '—'}
-                {message.date ? ` · ${message.date}` : ''}
-            </Typography>
+            {message.date && (
+                <Typography sx={{fontSize: '12px', color: 'text.disabled', mb: 1.5}}>{message.date}</Typography>
+            )}
 
-            <Box
-                sx={{
-                    display: 'flex',
-                    gap: 2,
-                    mb: 2,
-                    flexWrap: 'wrap',
-                    pb: 1.5,
-                    borderBottom: '1px solid',
-                    borderColor: 'divider',
-                }}
+            <MetaHeader message={message} />
+
+            <PreviewPane message={message} onFullscreen={() => setFullscreen(true)} />
+
+            <Dialog
+                fullScreen
+                open={fullscreen}
+                onClose={() => setFullscreen(false)}
+                aria-label="Fullscreen email preview"
             >
-                <MetaLabel>Size: {formatBytes(message.size)}</MetaLabel>
-                <MetaLabel>Links: {links.length}</MetaLabel>
-                <MetaLabel>Images: {images}</MetaLabel>
-                <MetaLabel>Type: {contentType}</MetaLabel>
-                <MetaLabel>Charset: {message.charset}</MetaLabel>
-            </Box>
-
-            <Box sx={{display: 'flex', gap: 3, alignItems: 'flex-start', flexDirection: {xs: 'column', md: 'row'}}}>
-                <LeftColumn message={message} />
-                <PreviewPane message={message} />
-            </Box>
+                <DialogContent sx={{padding: 0, display: 'flex', flexDirection: 'column', height: '100%'}}>
+                    <PreviewPane message={message} onExitFullscreen={() => setFullscreen(false)} />
+                </DialogContent>
+            </Dialog>
         </Box>
     );
 };
 
+const MESSAGE_QUERY_PARAM = 'message';
+
 export const MailerPanel = ({data}: MailerPanelProps) => {
     const messages = data?.messages ?? [];
-    const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const selectedIndex = useMemo(() => {
+        const raw = searchParams.get(MESSAGE_QUERY_PARAM);
+        if (raw === null) return null;
+        const idx = Number.parseInt(raw, 10);
+        return Number.isInteger(idx) && idx >= 0 && idx < messages.length ? idx : null;
+    }, [searchParams, messages.length]);
+
+    const selectMessage = useCallback(
+        (index: number | null) => {
+            setSearchParams(
+                (prev) => {
+                    const next = new URLSearchParams(prev);
+                    if (index === null) next.delete(MESSAGE_QUERY_PARAM);
+                    else next.set(MESSAGE_QUERY_PARAM, String(index));
+                    return next;
+                },
+                {replace: false},
+            );
+        },
+        [setSearchParams],
+    );
 
     if (messages.length === 0) {
         return <EmptyState icon="mail" title="No dumped mails found" />;
@@ -602,10 +657,10 @@ export const MailerPanel = ({data}: MailerPanelProps) => {
                 message={messages[selectedIndex]}
                 index={selectedIndex}
                 total={messages.length}
-                onBack={() => setSelectedIndex(null)}
+                onBack={() => selectMessage(null)}
             />
         );
     }
 
-    return <ListView messages={messages} onSelect={setSelectedIndex} />;
+    return <ListView messages={messages} onSelect={selectMessage} />;
 };

--- a/libs/frontend/packages/sdk/src/Helper/mailPreview.test.ts
+++ b/libs/frontend/packages/sdk/src/Helper/mailPreview.test.ts
@@ -1,0 +1,82 @@
+import {describe, expect, it} from 'vitest';
+import {attachmentDataUrl, countImages, extractLinks, type MailAttachment, rewriteCidReferences} from './mailPreview';
+
+const makeAttachment = (overrides: Partial<MailAttachment> = {}): MailAttachment => ({
+    filename: 'logo.png',
+    contentType: 'image/png',
+    size: 100,
+    contentId: 'logo-id',
+    inline: true,
+    contentBase64: 'aGVsbG8=',
+    ...overrides,
+});
+
+describe('rewriteCidReferences', () => {
+    it('replaces cid: references in <img src> with data URLs', () => {
+        const html = '<img src="cid:logo-id">';
+        const out = rewriteCidReferences(html, [makeAttachment()]);
+        expect(out).toContain('data:image/png;base64,aGVsbG8=');
+        expect(out).not.toContain('cid:logo-id');
+    });
+
+    it('handles angle-bracketed content ids', () => {
+        const html = '<img src="cid:logo-id">';
+        const out = rewriteCidReferences(html, [makeAttachment({contentId: '<logo-id>'})]);
+        expect(out).toContain('data:image/png;base64,');
+    });
+
+    it('returns HTML unchanged when no matching content id', () => {
+        const html = '<img src="cid:nope">';
+        const out = rewriteCidReferences(html, [makeAttachment()]);
+        expect(out).toBe(html);
+    });
+
+    it('skips attachments without contentId or payload', () => {
+        const html = '<img src="cid:logo-id">';
+        const out = rewriteCidReferences(html, [makeAttachment({contentId: null})]);
+        expect(out).toBe(html);
+    });
+
+    it('returns the input for empty html', () => {
+        expect(rewriteCidReferences('', [makeAttachment()])).toBe('');
+    });
+});
+
+describe('extractLinks', () => {
+    it('returns the unique href list from <a> tags', () => {
+        const html = '<a href="https://a.test">A</a><a href="https://b.test">B</a><a href="https://a.test">A again</a>';
+        expect(extractLinks(html)).toEqual(['https://a.test', 'https://b.test']);
+    });
+
+    it('ignores javascript: and data: hrefs', () => {
+        const html =
+            '<a href="javascript:alert(1)">bad</a><a href="data:text/plain,hi">also bad</a><a href="https://ok.test">ok</a>';
+        expect(extractLinks(html)).toEqual(['https://ok.test']);
+    });
+
+    it('returns [] for empty html', () => {
+        expect(extractLinks('')).toEqual([]);
+    });
+});
+
+describe('countImages', () => {
+    it('counts <img> tags', () => {
+        expect(countImages('<img src="a"><img src="b"><p>no</p>')).toBe(2);
+    });
+
+    it('returns 0 for empty html', () => {
+        expect(countImages('')).toBe(0);
+    });
+});
+
+describe('attachmentDataUrl', () => {
+    it('builds a data URL with the content type and payload', () => {
+        const url = attachmentDataUrl({contentType: 'text/plain', contentBase64: 'aGk='});
+        expect(url).toBe('data:text/plain;base64,aGk=');
+    });
+
+    it('defaults to application/octet-stream when contentType is empty', () => {
+        const url = attachmentDataUrl({contentType: '', contentBase64: 'aGk='});
+        expect(url).toBe('data:application/octet-stream;base64,aGk=');
+    });
+});

--- a/libs/frontend/packages/sdk/src/Helper/mailPreview.ts
+++ b/libs/frontend/packages/sdk/src/Helper/mailPreview.ts
@@ -1,0 +1,80 @@
+/**
+ * Helpers for rendering collected email messages in the Mailer debug panel.
+ *
+ * - `rewriteCidReferences` replaces `cid:<id>` occurrences in an HTML body with
+ *   data URLs, using the inline attachments' contentId → base64 payload map.
+ * - `extractLinks` returns the unique `<a href>` set from an HTML body.
+ * - `attachmentDataUrl` builds a data: URL for downloading an attachment.
+ */
+
+export type MailAttachment = {
+    filename: string;
+    contentType: string;
+    size: number;
+    contentId: string | null;
+    inline: boolean;
+    contentBase64: string;
+};
+
+const stripAngles = (id: string): string => id.replace(/^<|>$/g, '');
+
+export const attachmentDataUrl = (attachment: Pick<MailAttachment, 'contentType' | 'contentBase64'>): string =>
+    `data:${attachment.contentType || 'application/octet-stream'};base64,${attachment.contentBase64}`;
+
+/**
+ * Replace every `cid:<id>` reference in the HTML with a `data:` URL.
+ * Matches against both the raw `contentId` and its angle-stripped form.
+ */
+export const rewriteCidReferences = (html: string, attachments: readonly MailAttachment[]): string => {
+    if (!html) return html;
+    const cidMap = new Map<string, string>();
+    for (const attachment of attachments) {
+        if (!attachment.contentId || !attachment.contentBase64) continue;
+        const url = attachmentDataUrl(attachment);
+        cidMap.set(attachment.contentId, url);
+        cidMap.set(stripAngles(attachment.contentId), url);
+    }
+    if (cidMap.size === 0) return html;
+
+    return html.replace(/cid:([^"'\s)>]+)/gi, (match, rawId: string) => {
+        const id = stripAngles(rawId);
+        return cidMap.get(id) ?? cidMap.get(rawId) ?? match;
+    });
+};
+
+/**
+ * Extract the unique list of href values from `<a>` tags in the HTML body.
+ * Safe for SSR-free browsers (uses DOMParser). Returns [] on parse failure.
+ */
+export const extractLinks = (html: string): string[] => {
+    if (!html || typeof DOMParser === 'undefined') return [];
+    try {
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        const seen = new Set<string>();
+        const result: string[] = [];
+        doc.querySelectorAll('a[href]').forEach((node) => {
+            const href = node.getAttribute('href');
+            if (!href) return;
+            if (href.startsWith('javascript:') || href.startsWith('data:')) return;
+            if (seen.has(href)) return;
+            seen.add(href);
+            result.push(href);
+        });
+        return result;
+    } catch {
+        return [];
+    }
+};
+
+/**
+ * Count `<img>` tags in the HTML body (same-document, not fetched).
+ */
+export const countImages = (html: string): number => {
+    if (!html || typeof DOMParser === 'undefined') return 0;
+    try {
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        return doc.querySelectorAll('img').length;
+    } catch {
+        return 0;
+    }
+};

--- a/mago.toml
+++ b/mago.toml
@@ -280,6 +280,9 @@ cyclomatic-complexity = { level = "warning", threshold = 15, exclude = [
     "libs/Kernel/src/Storage/FileStorage.php",
     # Stream proxy — complexity from HTTP context extraction
     "libs/Kernel/src/Collector/Stream/HttpStreamProxy.php",
+    # Mailer — complexity from normalizing heterogeneous message + attachment payloads
+    "libs/Kernel/src/Collector/MailerCollector.php",
+    "libs/Adapter/Yii3/src/Collector/Mailer/MailerInterfaceProxy.php",
 ] }
 kan-defect = { level = "warning", exclude = [
     "libs/Testing/tests",


### PR DESCRIPTION
## Summary

This PR significantly enhances the Mailer debug panel with comprehensive email inspection capabilities, including attachment handling, message headers, improved HTML preview with viewport controls, and a redesigned list/detail view architecture.

## Key Changes

### Frontend (MailerPanel Component)
- **Redesigned UI architecture**: Split into list view (message summary) and detail view (full inspection)
  - List view shows message thumbnails (HTML iframe preview or text snippet), subject, recipients, attachment count, and size
  - Detail view provides full message inspection with tabs for HTML preview, text, HTML source, and raw content
  - Query parameter support (`?message=N`) for direct message access and page refresh persistence

- **Enhanced preview capabilities**:
  - Viewport toggle (desktop/tablet/mobile) for responsive email testing
  - Fullscreen preview mode for detailed inspection
  - CID reference rewriting to display inline images as data URLs
  - Link extraction and display from HTML body

- **Attachment handling**:
  - Downloadable attachment chips with file icons, size, and content type
  - Distinction between inline attachments (for CID resolution) and regular attachments
  - Inline image count display in metadata

- **Message metadata display**:
  - Collapsible headers section showing all email headers
  - Message ID, charset, and size information
  - Extracted links list with safe href filtering (blocks javascript: and data: URLs)
  - Address fields (From, To, CC, BCC, Reply-To) with proper serialization

### Backend (MailerCollector & Adapters)

- **MailerCollector normalization**:
  - New `normalize()` method ensures consistent message structure across all adapters
  - Supports new fields: `messageId`, `headers`, `size`, `attachments`
  - Backwards-compatible defaults for older adapters that don't provide new fields
  - Calculates message size from raw content when not provided

- **Symfony Mailer adapter**:
  - Collects all email headers from the message
  - Extracts attachments and embeddings with base64 encoding
  - Captures Message-ID header
  - Includes raw message string and size

- **Yii3 Mailer adapter**:
  - Handles both attachments and embeddings (inline images)
  - Decodes quoted-printable HTML bodies
  - Collects file metadata (filename, content type, size)
  - Generates base64-encoded content for all attachments

### Helper Utilities

- **New `mailPreview.ts` module**:
  - `rewriteCidReferences()`: Replaces `cid:` URLs in HTML with data URLs from inline attachments
  - `extractLinks()`: Safely extracts unique href values from HTML, filtering unsafe protocols
  - `attachmentDataUrl()`: Generates data URLs for attachment downloads
  - `countImages()`: Counts embedded images in HTML

### Testing

- Comprehensive test coverage for new UI components and interactions
- Tests for attachment handling, preview tabs, viewport switching
- Tests for query parameter persistence and fallback behavior
- Backend tests for attachment normalization and header collection

## Notable Implementation Details

- Attachment entries include an `inline` boolean to distinguish between downloadable attachments and CID-referenced embedded images
- HTML preview uses sandboxed iframes with CID rewriting for safe rendering
- Message list shows visual thumbnails (scaled iframe or text snippet) for quick scanning
- Metadata sections are conditionally rendered only when content exists
- All address serialization handles both email-only and name+email formats

https://claude.ai/code/session_01LYEjBGyNs4HQ4mToYxZ6jF