### PR TITLE
Add DockBottomIcon and dock-to-bottom button to debug toolbar

### DIFF
--- a/libs/frontend/packages/sdk/src/Component/SvgIcon/DockBottomIcon.tsx
+++ b/libs/frontend/packages/sdk/src/Component/SvgIcon/DockBottomIcon.tsx
@@ -1,0 +1,13 @@
+import {SvgIcon, type SvgIconProps} from '@mui/material';
+
+export function DockBottomIcon(props: SvgIconProps) {
+    return (
+        <SvgIcon viewBox="0 0 24 24" {...props}>
+            <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M4.5 4A1.5 1.5 0 0 0 3 5.5v13A1.5 1.5 0 0 0 4.5 20h15a1.5 1.5 0 0 0 1.5-1.5v-13A1.5 1.5 0 0 0 19.5 4h-15Zm0 1.5h15V15h-15V5.5Z"
+            />
+        </SvgIcon>
+    );
+}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
@@ -36,6 +36,7 @@ import DragHandleIcon from '@mui/icons-material/DragHandle';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
+import VerticalAlignBottomIcon from '@mui/icons-material/VerticalAlignBottom';
 import WebAssetIcon from '@mui/icons-material/WebAsset';
 import WebAssetOffIcon from '@mui/icons-material/WebAssetOff';
 import {Box, Chip, Divider, IconButton, Paper, Portal, Stack, Tooltip, useTheme} from '@mui/material';
@@ -703,6 +704,11 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
                 >
                     <DuckIcon sx={{fontSize: 20}} />
                     <Box sx={{fontSize: 12, fontWeight: 600, flex: 1}}>Debug</Box>
+                    <Tooltip title="Dock to bottom" arrow>
+                        <IconButton onClick={() => snapTo('bottom')} size="small" sx={actionButtonSx}>
+                            <VerticalAlignBottomIcon sx={{fontSize: 16}} />
+                        </IconButton>
+                    </Tooltip>
                     <IconButton onClick={() => setChatOpen((v) => !v)} size="small" sx={actionButtonSx}>
                         <SmartToyIcon sx={{fontSize: 16}} />
                     </IconButton>

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
@@ -7,6 +7,7 @@ import {
 } from '@app-dev-panel/sdk/API/Application/ApplicationContext';
 import {addCurrentPageRequestId, changeEntryAction, useDebugEntry} from '@app-dev-panel/sdk/API/Debug/Context';
 import {debugApi, DebugEntry, useGetDebugQuery} from '@app-dev-panel/sdk/API/Debug/Debug';
+import {DockBottomIcon} from '@app-dev-panel/sdk/Component/SvgIcon/DockBottomIcon';
 import {DuckIcon} from '@app-dev-panel/sdk/Component/SvgIcon/DuckIcon';
 import {isDebugEntryAboutConsole, isDebugEntryAboutWeb} from '@app-dev-panel/sdk/Helper/debugEntry';
 import {dispatchWindowEvent} from '@app-dev-panel/sdk/Helper/dispatchWindowEvent';
@@ -36,7 +37,6 @@ import DragHandleIcon from '@mui/icons-material/DragHandle';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
-import VerticalAlignBottomIcon from '@mui/icons-material/VerticalAlignBottom';
 import WebAssetIcon from '@mui/icons-material/WebAsset';
 import WebAssetOffIcon from '@mui/icons-material/WebAssetOff';
 import {Box, Chip, Divider, IconButton, Paper, Portal, Stack, Tooltip, useTheme} from '@mui/material';
@@ -706,7 +706,7 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
                     <Box sx={{fontSize: 12, fontWeight: 600, flex: 1}}>Debug</Box>
                     <Tooltip title="Dock to bottom" arrow>
                         <IconButton onClick={() => snapTo('bottom')} size="small" sx={actionButtonSx}>
-                            <VerticalAlignBottomIcon sx={{fontSize: 16}} />
+                            <DockBottomIcon sx={{fontSize: 16}} />
                         </IconButton>
                     </Tooltip>
                     <IconButton onClick={() => setChatOpen((v) => !v)} size="small" sx={actionButtonSx}>


### PR DESCRIPTION
## Summary
This PR adds a new `DockBottomIcon` SVG icon component and integrates it into the debug toolbar to provide a "dock to bottom" functionality.

## Key Changes
- **New Component**: Created `DockBottomIcon` in the SDK's SvgIcon library
  - Implements a Material-UI SvgIcon with a custom SVG path representing a dock-to-bottom icon
  - Accepts standard SvgIconProps for styling flexibility

- **Debug Toolbar Enhancement**: Added a dock-to-bottom button to the DebugToolbar component
  - New icon button with tooltip "Dock to bottom" positioned in the toolbar header
  - Button triggers `snapTo('bottom')` action when clicked
  - Uses consistent styling with other action buttons in the toolbar

## Implementation Details
- The DockBottomIcon uses a viewBox of "0 0 24 24" with proper fill and clip rules for rendering
- The button is integrated alongside existing debug controls (Duck icon and AI chat button)
- Maintains consistent UI/UX patterns with existing toolbar buttons (small size, tooltip, action button styling)

https://claude.ai/code/session_011HZQosMH47Pw34hHyP8kPr