### PR TITLE
Fix DebugToolbar positioning to use fixed layout

### DIFF
--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
@@ -525,7 +525,7 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
     if (isBottom) {
         return (
             <Portal>
-                <Box sx={{position: 'sticky', bottom: 0, zIndex: 1300}}>
+                <Box sx={{position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 1300}}>
                     {iframeEnabled && (
                         <Box
                             {...separatorProps}


### PR DESCRIPTION
## Summary
Changed the DebugToolbar positioning from `sticky` to `fixed` to ensure it remains visible and properly positioned at the bottom of the viewport.

## Key Changes
- Updated the Box component's `sx` prop positioning from `position: 'sticky'` to `position: 'fixed'`
- Added explicit `left: 0` and `right: 0` properties to ensure the toolbar spans the full width when using fixed positioning

## Implementation Details
The change ensures the debug toolbar stays fixed at the bottom of the screen (bottom: 0) and stretches across the full viewport width, rather than being sticky within its parent container. This provides better visibility and accessibility of the debug toolbar regardless of scroll position or parent container layout.

https://claude.ai/code/session_01EPijc1X53dL8a8zBpeQULX