### PR TITLE
Add close button to debug toolbar

### DIFF
--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DebugToolbar.tsx
@@ -33,6 +33,7 @@ import {useDrag} from '@app-dev-panel/toolbar/Module/Toolbar/Component/Toolbar/u
 import {ValidatorItem} from '@app-dev-panel/toolbar/Module/Toolbar/Component/Toolbar/ValidatorItem';
 import {RequestItem} from '@app-dev-panel/toolbar/Module/Toolbar/Component/Toolbar/Web/RequestItem';
 import {useSelector} from '@app-dev-panel/toolbar/store';
+import CloseIcon from '@mui/icons-material/Close';
 import DragHandleIcon from '@mui/icons-material/DragHandle';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
@@ -715,6 +716,11 @@ export const DebugToolbar = ({activeComponents}: DebugToolbarProps) => {
                     <IconButton onClick={handleDebugWindowOpen} size="small" sx={actionButtonSx}>
                         <OpenInNewIcon sx={{fontSize: 16}} />
                     </IconButton>
+                    <Tooltip title="Close" arrow>
+                        <IconButton onClick={onToolbarClickHandler} size="small" sx={actionButtonSx}>
+                            <CloseIcon sx={{fontSize: 16}} />
+                        </IconButton>
+                    </Tooltip>
                 </Box>
                 {selectedEntry && <RequestHeroBar entry={selectedEntry} />}
                 {selectedEntry && (


### PR DESCRIPTION
## Summary
Added a close button to the debug toolbar that allows users to dismiss the toolbar using the `onToolbarClickHandler` callback.

## Key Changes
- Imported `CloseIcon` from Material-UI icons
- Added a new IconButton with a Close icon in the toolbar's action buttons section
- Wrapped the button with a Tooltip displaying "Close" on hover
- The button triggers the existing `onToolbarClickHandler` to close the toolbar

## Implementation Details
- The close button is positioned alongside the existing "Open in New" button in the toolbar's action area
- Uses consistent styling with other action buttons (`actionButtonSx` and `size="small"`)
- Icon size matches other toolbar icons (16px)
- Reuses existing close handler rather than introducing new logic

https://claude.ai/code/session_01DLYfpnRUa5YhS6B6HL35Uu