### PR TITLE
Add mobile drawer for live feed panel

### DIFF
--- a/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
@@ -648,9 +648,22 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
                         {liveFeedOpen && !isMobile && <LiveFeedPanel onClose={handleLiveFeedClick} />}
                     </MainInner>
                 </MainArea>
+                {isMobile && (
+                    <Drawer
+                        anchor="bottom"
+                        open={liveFeedOpen}
+                        onClose={handleLiveFeedClick}
+                        ModalProps={{keepMounted: true}}
+                        PaperProps={{
+                            sx: {height: '85vh', borderTopLeftRadius: 16, borderTopRightRadius: 16, overflow: 'hidden'},
+                        }}
+                    >
+                        <LiveFeedPanel onClose={handleLiveFeedClick} />
+                    </Drawer>
+                )}
             </Box>
             {children}
-            {!aiChatOpen && (
+            {!aiChatOpen && !(isMobile && liveFeedOpen) && (
                 <Tooltip title="Duck AI" placement="left">
                     <Fab
                         aria-label="Duck AI"

--- a/libs/frontend/packages/panel/src/Application/Component/LiveFeedPanel.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/LiveFeedPanel.tsx
@@ -27,6 +27,7 @@ const PanelRoot = styled(Box)(({theme}) => ({
     backgroundColor: theme.palette.background.paper,
     border: `1px solid ${theme.palette.divider}`,
     overflow: 'hidden',
+    [theme.breakpoints.down('md')]: {width: '100%', height: '100%', borderRadius: 0, border: 'none'},
 }));
 
 const PanelHeader = styled(Box)(({theme}) => ({


### PR DESCRIPTION
## Summary
Implemented a mobile-responsive live feed panel by adding a bottom drawer component for mobile devices while maintaining the existing side panel layout for desktop.

## Key Changes
- Added a bottom `Drawer` component that displays the `LiveFeedPanel` on mobile devices with 85vh height and rounded top corners
- Updated the FAB (Floating Action Button) visibility logic to hide it when the live feed drawer is open on mobile
- Enhanced `LiveFeedPanel` styling to be fully responsive on mobile by setting width/height to 100%, removing borders and border radius on screens below `md` breakpoint

## Implementation Details
- The drawer uses `anchor="bottom"` for mobile-appropriate positioning
- `ModalProps={{keepMounted: true}}` ensures the component state is preserved when the drawer closes
- Mobile-specific styling in `PanelRoot` uses theme breakpoints to apply responsive styles only on smaller screens
- The FAB visibility condition now checks both `!aiChatOpen` and `!(isMobile && liveFeedOpen)` to prevent overlap with the drawer

https://claude.ai/code/session_01Svh2VUk2GkecMxuFNB4a9W