### PR TITLE
Add tooltips and website navigation to TopBar and IndexPage

### DIFF
--- a/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
@@ -388,6 +388,13 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
         [updateMcpSettings],
     );
 
+    const handleOpenWebsite = useCallback(() => {
+        if (!backendUrl) {
+            return;
+        }
+        window.open(backendUrl, '_blank', 'noopener,noreferrer');
+    }, [backendUrl]);
+
     // TopBar debug info — support both web requests and console commands
     const isWeb = debugEntry ? isDebugEntryAboutWeb(debugEntry) : false;
     const isConsole = debugEntry ? isDebugEntryAboutConsole(debugEntry) : false;
@@ -597,6 +604,8 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
                     onCopyAsImage={copyAsImage}
                     onDownloadAsImage={downloadAsPng}
                     isCopyingAsImage={isCapturing}
+                    websiteUrl={backendUrl}
+                    onOpenWebsite={handleOpenWebsite}
                 />
                 <EntrySelector
                     anchorEl={ui.entrySelectorAnchor}

--- a/libs/frontend/packages/panel/src/Application/Pages/IndexPage.tsx
+++ b/libs/frontend/packages/panel/src/Application/Pages/IndexPage.tsx
@@ -5,7 +5,7 @@ import {addFavoriteUrl, changeBaseUrl, removeFavoriteUrl} from '@app-dev-panel/s
 import {useGetDebugQuery} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {StatusCard} from '@app-dev-panel/sdk/Component/StatusCard';
-import {Chip, Icon, IconButton, InputBase, Typography} from '@mui/material';
+import {Chip, Icon, IconButton, InputBase, Tooltip, Typography} from '@mui/material';
 import {styled} from '@mui/material/styles';
 import {useEffect, useState} from 'react';
 import {useDispatch} from 'react-redux';
@@ -39,6 +39,12 @@ const FavoritesRow = styled('div')(({theme}) => ({
     flexWrap: 'wrap',
     gap: theme.spacing(0.75),
     marginBottom: theme.spacing(3),
+}));
+
+const FavoriteItem = styled('div')(({theme}) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.25),
 }));
 
 const CurrentUrl = styled('div')(({theme}) => ({
@@ -115,6 +121,13 @@ export function IndexPage() {
         handleChangeUrl(url);
     };
 
+    const openInNewTab = (target: string) => {
+        if (!target) {
+            return;
+        }
+        window.open(target, '_blank', 'noopener,noreferrer');
+    };
+
     useEffect(() => {
         checkStatus();
     }, [baseUrl]);
@@ -130,15 +143,30 @@ export function IndexPage() {
             <CurrentUrl>
                 <Icon sx={{fontSize: 18, color: 'text.disabled'}}>link</Icon>
                 <span style={{flex: 1}}>{baseUrl}</span>
-                <IconButton
-                    size="small"
-                    onClick={() => {
-                        checkStatus();
-                        debugRefetch();
-                    }}
-                >
-                    <Icon sx={{fontSize: 16}}>refresh</Icon>
-                </IconButton>
+                <Tooltip title={baseUrl ? `Open ${baseUrl} in a new tab` : 'No backend URL set'} arrow enterDelay={400}>
+                    <span style={{display: 'inline-flex'}}>
+                        <IconButton
+                            size="small"
+                            disabled={!baseUrl}
+                            onClick={() => openInNewTab(baseUrl ?? '')}
+                            aria-label="Open backend URL in a new tab"
+                        >
+                            <Icon sx={{fontSize: 16}}>open_in_new</Icon>
+                        </IconButton>
+                    </span>
+                </Tooltip>
+                <Tooltip title="Refresh status" arrow enterDelay={400}>
+                    <IconButton
+                        size="small"
+                        aria-label="Refresh status"
+                        onClick={() => {
+                            checkStatus();
+                            debugRefetch();
+                        }}
+                    >
+                        <Icon sx={{fontSize: 16}}>refresh</Icon>
+                    </IconButton>
+                </Tooltip>
             </CurrentUrl>
 
             <SectionLabel>API Status</SectionLabel>
@@ -174,28 +202,42 @@ export function IndexPage() {
                     <SectionLabel>Favorites</SectionLabel>
                     <FavoritesRow>
                         {favoriteUrls.map((favUrl) => (
-                            <Chip
-                                key={favUrl}
-                                icon={<Icon sx={{fontSize: '14px !important', color: 'warning.main'}}>star</Icon>}
-                                label={favUrl}
-                                size="small"
-                                variant={favUrl === baseUrl ? 'filled' : 'outlined'}
-                                onClick={() => handleChangeUrl(favUrl)}
-                                onDelete={() => dispatch(removeFavoriteUrl(favUrl))}
-                                deleteIcon={<Icon sx={{fontSize: '14px !important'}}>close</Icon>}
-                                sx={(theme) => ({
-                                    fontFamily: theme.adp.fontFamilyMono,
-                                    fontSize: '12px',
-                                    height: 28,
-                                    borderRadius: 1,
-                                    ...(favUrl === baseUrl && {
-                                        backgroundColor: 'primary.light',
-                                        borderColor: 'primary.main',
-                                        color: 'primary.main',
-                                        fontWeight: 600,
-                                    }),
-                                })}
-                            />
+                            <FavoriteItem key={favUrl}>
+                                <Chip
+                                    icon={<Icon sx={{fontSize: '14px !important', color: 'warning.main'}}>star</Icon>}
+                                    label={favUrl}
+                                    size="small"
+                                    variant={favUrl === baseUrl ? 'filled' : 'outlined'}
+                                    onClick={() => handleChangeUrl(favUrl)}
+                                    onDelete={() => dispatch(removeFavoriteUrl(favUrl))}
+                                    deleteIcon={<Icon sx={{fontSize: '14px !important'}}>close</Icon>}
+                                    sx={(theme) => ({
+                                        fontFamily: theme.adp.fontFamilyMono,
+                                        fontSize: '12px',
+                                        height: 28,
+                                        borderRadius: 1,
+                                        ...(favUrl === baseUrl && {
+                                            backgroundColor: 'primary.light',
+                                            borderColor: 'primary.main',
+                                            color: 'primary.main',
+                                            fontWeight: 600,
+                                        }),
+                                    })}
+                                />
+                                <Tooltip title={`Open ${favUrl} in a new tab`} arrow enterDelay={400}>
+                                    <IconButton
+                                        size="small"
+                                        onClick={(event) => {
+                                            event.stopPropagation();
+                                            openInNewTab(favUrl);
+                                        }}
+                                        aria-label={`Open ${favUrl} in a new tab`}
+                                        sx={{padding: 0.25}}
+                                    >
+                                        <Icon sx={{fontSize: 14}}>open_in_new</Icon>
+                                    </IconButton>
+                                </Tooltip>
+                            </FavoriteItem>
                         ))}
                     </FavoritesRow>
                 </>

--- a/libs/frontend/packages/sdk/src/Component/Layout/SearchTrigger.tsx
+++ b/libs/frontend/packages/sdk/src/Component/Layout/SearchTrigger.tsx
@@ -1,4 +1,4 @@
-import {Icon, IconButton} from '@mui/material';
+import {Icon, IconButton, Tooltip} from '@mui/material';
 import {styled, useTheme} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
@@ -34,17 +34,21 @@ export const SearchTrigger = ({onClick}: SearchTriggerProps) => {
 
     if (compact) {
         return (
-            <IconButton size="small" onClick={onClick} aria-label="Search">
-                <Icon sx={{fontSize: 18}}>search</Icon>
-            </IconButton>
+            <Tooltip title="Search (Ctrl+K)" arrow enterDelay={400}>
+                <IconButton size="small" onClick={onClick} aria-label="Search (Ctrl+K)">
+                    <Icon sx={{fontSize: 18}}>search</Icon>
+                </IconButton>
+            </Tooltip>
         );
     }
 
     return (
-        <TriggerRoot onClick={onClick} aria-label="Search">
-            <Icon sx={{fontSize: 16}}>search</Icon>
-            Search...
-            <Kbd>Ctrl+K</Kbd>
-        </TriggerRoot>
+        <Tooltip title="Search (Ctrl+K)" arrow enterDelay={400}>
+            <TriggerRoot onClick={onClick} aria-label="Search (Ctrl+K)">
+                <Icon sx={{fontSize: 16}}>search</Icon>
+                Search...
+                <Kbd>Ctrl+K</Kbd>
+            </TriggerRoot>
+        </Tooltip>
     );
 };

--- a/libs/frontend/packages/sdk/src/Component/Layout/TopBar.tsx
+++ b/libs/frontend/packages/sdk/src/Component/Layout/TopBar.tsx
@@ -228,6 +228,21 @@ export const TopBar = React.memo(
                     <span className="logo-text">App Dev Panel</span>
                 </Logo>
                 <CenterGroup>
+                    {onOpenWebsite && (
+                        <Tooltip title={openWebsiteLabel} arrow enterDelay={tooltipEnterDelay}>
+                            <span style={{display: 'inline-flex'}}>
+                                <IconButton
+                                    size="small"
+                                    onClick={onOpenWebsite}
+                                    disabled={!websiteUrl}
+                                    aria-label={openWebsiteLabel}
+                                    sx={{display: {xs: 'none', md: 'inline-flex'}}}
+                                >
+                                    <Icon sx={{fontSize: 18}}>open_in_new</Icon>
+                                </IconButton>
+                            </span>
+                        </Tooltip>
+                    )}
                     <Tooltip title="Previous entry" arrow enterDelay={tooltipEnterDelay}>
                         <span style={{display: 'inline-flex'}}>
                             <IconButton
@@ -254,19 +269,6 @@ export const TopBar = React.memo(
                             </IconButton>
                         </span>
                     </Tooltip>
-                    <PillContainer>
-                        {method && path != null && status != null ? (
-                            <RequestPill
-                                method={method}
-                                path={path}
-                                status={status}
-                                duration={duration ?? ''}
-                                onClick={onEntryClick}
-                            />
-                        ) : (
-                            <Box sx={{height: 32}} />
-                        )}
-                    </PillContainer>
                     <Tooltip
                         title={isRefreshing ? 'Refreshing…' : 'Refresh entries'}
                         arrow
@@ -283,6 +285,19 @@ export const TopBar = React.memo(
                             </IconButton>
                         </span>
                     </Tooltip>
+                    <PillContainer>
+                        {method && path != null && status != null ? (
+                            <RequestPill
+                                method={method}
+                                path={path}
+                                status={status}
+                                duration={duration ?? ''}
+                                onClick={onEntryClick}
+                            />
+                        ) : (
+                            <Box sx={{height: 32}} />
+                        )}
+                    </PillContainer>
                     <Tooltip title={autoLatestLabel} arrow enterDelay={tooltipEnterDelay}>
                         <IconButton size="small" onClick={onAutoRefreshToggle} aria-label={autoLatestLabel}>
                             <Icon sx={{fontSize: 18, color: autoRefresh ? 'success.main' : undefined}}>
@@ -331,20 +346,6 @@ export const TopBar = React.memo(
                             </IconButton>
                         </Tooltip>
                     </>
-                )}
-                {onOpenWebsite && (
-                    <Tooltip title={openWebsiteLabel} arrow enterDelay={tooltipEnterDelay}>
-                        <span style={{display: 'inline-flex'}}>
-                            <IconButton
-                                size="small"
-                                onClick={onOpenWebsite}
-                                disabled={!websiteUrl}
-                                aria-label={openWebsiteLabel}
-                            >
-                                <Icon sx={{fontSize: 18}}>open_in_new</Icon>
-                            </IconButton>
-                        </span>
-                    </Tooltip>
                 )}
                 <Tooltip title={liveFeedLabel} arrow enterDelay={tooltipEnterDelay}>
                     <IconButton
@@ -431,6 +432,20 @@ export const TopBar = React.memo(
                                 </Badge>
                             </ListItemIcon>
                             <ListItemText>Notifications</ListItemText>
+                        </MenuItem>
+                    )}
+                    {compact && onOpenWebsite && (
+                        <MenuItem
+                            disabled={!websiteUrl}
+                            onClick={() => {
+                                handleMenuClose();
+                                onOpenWebsite();
+                            }}
+                        >
+                            <ListItemIcon>
+                                <Icon sx={{fontSize: 20}}>open_in_new</Icon>
+                            </ListItemIcon>
+                            <ListItemText>Open website</ListItemText>
                         </MenuItem>
                     )}
                     {compact && <Divider />}

--- a/libs/frontend/packages/sdk/src/Component/Layout/TopBar.tsx
+++ b/libs/frontend/packages/sdk/src/Component/Layout/TopBar.tsx
@@ -26,6 +26,7 @@ import {
     MenuItem,
     Switch,
     TextField,
+    Tooltip,
     Typography,
     type PaletteMode,
 } from '@mui/material';
@@ -81,6 +82,8 @@ type TopBarProps = {
     onCopyAsImage?: () => void;
     onDownloadAsImage?: () => void;
     isCopyingAsImage?: boolean;
+    websiteUrl?: string;
+    onOpenWebsite?: () => void;
 };
 
 const BarRoot = styled('header')(({theme}) => ({
@@ -157,6 +160,8 @@ export const TopBar = React.memo(
         onCopyAsImage,
         onDownloadAsImage,
         isCopyingAsImage,
+        websiteUrl,
+        onOpenWebsite,
     }: TopBarProps) => {
         const theme = useTheme();
         const compact = useMediaQuery(theme.breakpoints.down('md'));
@@ -196,41 +201,59 @@ export const TopBar = React.memo(
             }
         }, [notificationCount]);
 
+        const tooltipEnterDelay = 400;
+        const autoLatestLabel = autoRefresh
+            ? 'Auto-latest: on (switch to newest entry automatically)'
+            : 'Auto-latest: off';
+        const themeLabel = resolvedMode === 'dark' ? 'Switch to light theme' : 'Switch to dark theme';
+        const liveFeedLabel = liveFeedActive ? 'Hide live feed' : 'Show live feed';
+        const openWebsiteLabel = websiteUrl ? `Open ${websiteUrl} in a new tab` : 'Open backend website in a new tab';
+
         return (
             <BarRoot>
                 {onMenuClick && (
-                    <IconButton
-                        size="small"
-                        onClick={onMenuClick}
-                        aria-label="Open menu"
-                        sx={{display: {xs: 'inline-flex', md: 'none'}}}
-                    >
-                        <Icon sx={{fontSize: 20}}>menu</Icon>
-                    </IconButton>
+                    <Tooltip title="Open menu" arrow enterDelay={tooltipEnterDelay}>
+                        <IconButton
+                            size="small"
+                            onClick={onMenuClick}
+                            aria-label="Open menu"
+                            sx={{display: {xs: 'inline-flex', md: 'none'}}}
+                        >
+                            <Icon sx={{fontSize: 20}}>menu</Icon>
+                        </IconButton>
+                    </Tooltip>
                 )}
                 <Logo onClick={onLogoClick}>
                     <DuckIcon sx={{fontSize: 22}} />
                     <span className="logo-text">App Dev Panel</span>
                 </Logo>
                 <CenterGroup>
-                    <IconButton
-                        size="small"
-                        onClick={onPrevEntry}
-                        disabled={!onPrevEntry}
-                        aria-label="Previous entry"
-                        sx={{display: {xs: 'none', sm: 'inline-flex'}}}
-                    >
-                        <Icon sx={{fontSize: 18}}>chevron_left</Icon>
-                    </IconButton>
-                    <IconButton
-                        size="small"
-                        onClick={onNextEntry}
-                        disabled={!onNextEntry}
-                        aria-label="Next entry"
-                        sx={{display: {xs: 'none', sm: 'inline-flex'}}}
-                    >
-                        <Icon sx={{fontSize: 18}}>chevron_right</Icon>
-                    </IconButton>
+                    <Tooltip title="Previous entry" arrow enterDelay={tooltipEnterDelay}>
+                        <span style={{display: 'inline-flex'}}>
+                            <IconButton
+                                size="small"
+                                onClick={onPrevEntry}
+                                disabled={!onPrevEntry}
+                                aria-label="Previous entry"
+                                sx={{display: {xs: 'none', sm: 'inline-flex'}}}
+                            >
+                                <Icon sx={{fontSize: 18}}>chevron_left</Icon>
+                            </IconButton>
+                        </span>
+                    </Tooltip>
+                    <Tooltip title="Next entry" arrow enterDelay={tooltipEnterDelay}>
+                        <span style={{display: 'inline-flex'}}>
+                            <IconButton
+                                size="small"
+                                onClick={onNextEntry}
+                                disabled={!onNextEntry}
+                                aria-label="Next entry"
+                                sx={{display: {xs: 'none', sm: 'inline-flex'}}}
+                            >
+                                <Icon sx={{fontSize: 18}}>chevron_right</Icon>
+                            </IconButton>
+                        </span>
+                    </Tooltip>
                     <PillContainer>
                         {method && path != null && status != null ? (
                             <RequestPill
@@ -244,37 +267,115 @@ export const TopBar = React.memo(
                             <Box sx={{height: 32}} />
                         )}
                     </PillContainer>
-                    <IconButton
-                        size="small"
-                        onClick={onRefresh}
-                        disabled={isRefreshing}
-                        aria-label="Refresh entries"
-                        title="Refresh entries"
+                    <Tooltip
+                        title={isRefreshing ? 'Refreshing…' : 'Refresh entries'}
+                        arrow
+                        enterDelay={tooltipEnterDelay}
                     >
-                        <Icon sx={{fontSize: 18}}>{isRefreshing ? 'hourglass_empty' : 'refresh'}</Icon>
-                    </IconButton>
-                    <IconButton
-                        size="small"
-                        onClick={onAutoRefreshToggle}
-                        aria-label={
-                            autoRefresh ? 'Auto-latest: on (switch to newest entry automatically)' : 'Auto-latest: off'
-                        }
-                        title={
-                            autoRefresh ? 'Auto-latest: on (switch to newest entry automatically)' : 'Auto-latest: off'
-                        }
-                    >
-                        <Icon sx={{fontSize: 18, color: autoRefresh ? 'success.main' : undefined}}>
-                            {autoRefresh ? 'sync' : 'sync_disabled'}
-                        </Icon>
-                    </IconButton>
+                        <span style={{display: 'inline-flex'}}>
+                            <IconButton
+                                size="small"
+                                onClick={onRefresh}
+                                disabled={isRefreshing}
+                                aria-label="Refresh entries"
+                            >
+                                <Icon sx={{fontSize: 18}}>{isRefreshing ? 'hourglass_empty' : 'refresh'}</Icon>
+                            </IconButton>
+                        </span>
+                    </Tooltip>
+                    <Tooltip title={autoLatestLabel} arrow enterDelay={tooltipEnterDelay}>
+                        <IconButton size="small" onClick={onAutoRefreshToggle} aria-label={autoLatestLabel}>
+                            <Icon sx={{fontSize: 18, color: autoRefresh ? 'success.main' : undefined}}>
+                                {autoRefresh ? 'sync' : 'sync_disabled'}
+                            </Icon>
+                        </IconButton>
+                    </Tooltip>
                 </CenterGroup>
                 <SearchTrigger onClick={onSearchClick} />
                 {!compact && (
                     <>
-                        <IconButton size="small" onClick={onThemeToggle} aria-label="Toggle theme">
-                            <Icon sx={{fontSize: 18}}>{resolvedMode === 'dark' ? 'dark_mode' : 'light_mode'}</Icon>
-                        </IconButton>
-                        <IconButton size="small" onClick={onNotificationsClick} aria-label="Notifications">
+                        <Tooltip title={themeLabel} arrow enterDelay={tooltipEnterDelay}>
+                            <IconButton size="small" onClick={onThemeToggle} aria-label={themeLabel}>
+                                <Icon sx={{fontSize: 18}}>{resolvedMode === 'dark' ? 'dark_mode' : 'light_mode'}</Icon>
+                            </IconButton>
+                        </Tooltip>
+                        <Tooltip
+                            title={notificationCount ? `Notifications (${notificationCount})` : 'Notifications'}
+                            arrow
+                            enterDelay={tooltipEnterDelay}
+                        >
+                            <IconButton size="small" onClick={onNotificationsClick} aria-label="Notifications">
+                                <Badge
+                                    badgeContent={notificationCount}
+                                    color="error"
+                                    max={99}
+                                    sx={{
+                                        '& .MuiBadge-badge': {
+                                            fontSize: 10,
+                                            height: 16,
+                                            minWidth: 16,
+                                            animation: bellAnimating ? `${badgePulse} 0.4s ease-out` : 'none',
+                                        },
+                                    }}
+                                >
+                                    <Icon
+                                        sx={{
+                                            fontSize: 18,
+                                            animation: bellAnimating ? `${bellShake} 0.5s ease-in-out` : 'none',
+                                            transformOrigin: 'top center',
+                                        }}
+                                    >
+                                        notifications
+                                    </Icon>
+                                </Badge>
+                            </IconButton>
+                        </Tooltip>
+                    </>
+                )}
+                {onOpenWebsite && (
+                    <Tooltip title={openWebsiteLabel} arrow enterDelay={tooltipEnterDelay}>
+                        <span style={{display: 'inline-flex'}}>
+                            <IconButton
+                                size="small"
+                                onClick={onOpenWebsite}
+                                disabled={!websiteUrl}
+                                aria-label={openWebsiteLabel}
+                            >
+                                <Icon sx={{fontSize: 18}}>open_in_new</Icon>
+                            </IconButton>
+                        </span>
+                    </Tooltip>
+                )}
+                <Tooltip title={liveFeedLabel} arrow enterDelay={tooltipEnterDelay}>
+                    <IconButton
+                        size="small"
+                        onClick={onLiveFeedClick}
+                        aria-label={liveFeedLabel}
+                        sx={{backgroundColor: liveFeedActive ? 'action.selected' : undefined, borderRadius: 1}}
+                    >
+                        <Badge
+                            badgeContent={liveFeedCount}
+                            color="warning"
+                            max={99}
+                            sx={{
+                                '& .MuiBadge-badge': {
+                                    fontSize: 10,
+                                    height: 16,
+                                    minWidth: 16,
+                                    animation:
+                                        liveFeedCount && liveFeedCount > 0 ? `${badgePulse} 0.4s ease-out` : 'none',
+                                },
+                            }}
+                        >
+                            <Icon sx={{fontSize: 18, color: liveFeedActive ? 'primary.main' : undefined}}>
+                                terminal
+                            </Icon>
+                        </Badge>
+                    </IconButton>
+                </Tooltip>
+                <Tooltip title="More options" arrow enterDelay={tooltipEnterDelay}>
+                    <IconButton size="small" onClick={handleMenuOpen} aria-label="More options">
+                        {compact && notificationCount ? (
                             <Badge
                                 badgeContent={notificationCount}
                                 color="error"
@@ -288,62 +389,13 @@ export const TopBar = React.memo(
                                     },
                                 }}
                             >
-                                <Icon
-                                    sx={{
-                                        fontSize: 18,
-                                        animation: bellAnimating ? `${bellShake} 0.5s ease-in-out` : 'none',
-                                        transformOrigin: 'top center',
-                                    }}
-                                >
-                                    notifications
-                                </Icon>
+                                <Icon sx={{fontSize: 18}}>more_vert</Icon>
                             </Badge>
-                        </IconButton>
-                    </>
-                )}
-                <IconButton
-                    size="small"
-                    onClick={onLiveFeedClick}
-                    aria-label="Live feed"
-                    sx={{backgroundColor: liveFeedActive ? 'action.selected' : undefined, borderRadius: 1}}
-                >
-                    <Badge
-                        badgeContent={liveFeedCount}
-                        color="warning"
-                        max={99}
-                        sx={{
-                            '& .MuiBadge-badge': {
-                                fontSize: 10,
-                                height: 16,
-                                minWidth: 16,
-                                animation: liveFeedCount && liveFeedCount > 0 ? `${badgePulse} 0.4s ease-out` : 'none',
-                            },
-                        }}
-                    >
-                        <Icon sx={{fontSize: 18, color: liveFeedActive ? 'primary.main' : undefined}}>terminal</Icon>
-                    </Badge>
-                </IconButton>
-                <IconButton size="small" onClick={handleMenuOpen} aria-label="More options">
-                    {compact && notificationCount ? (
-                        <Badge
-                            badgeContent={notificationCount}
-                            color="error"
-                            max={99}
-                            sx={{
-                                '& .MuiBadge-badge': {
-                                    fontSize: 10,
-                                    height: 16,
-                                    minWidth: 16,
-                                    animation: bellAnimating ? `${badgePulse} 0.4s ease-out` : 'none',
-                                },
-                            }}
-                        >
+                        ) : (
                             <Icon sx={{fontSize: 18}}>more_vert</Icon>
-                        </Badge>
-                    ) : (
-                        <Icon sx={{fontSize: 18}}>more_vert</Icon>
-                    )}
-                </IconButton>
+                        )}
+                    </IconButton>
+                </Tooltip>
 
                 <Menu
                     anchorEl={menuAnchor}
@@ -459,9 +511,16 @@ export const TopBar = React.memo(
                 <Dialog open={settingsOpen} onClose={handleSettingsClose} maxWidth="xs" fullWidth>
                     <DialogTitle sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', pb: 1}}>
                         Settings
-                        <IconButton size="small" onClick={handleSettingsClose} edge="end">
-                            <Icon sx={{fontSize: 20}}>close</Icon>
-                        </IconButton>
+                        <Tooltip title="Close settings" arrow enterDelay={400}>
+                            <IconButton
+                                size="small"
+                                onClick={handleSettingsClose}
+                                edge="end"
+                                aria-label="Close settings"
+                            >
+                                <Icon sx={{fontSize: 20}}>close</Icon>
+                            </IconButton>
+                        </Tooltip>
                     </DialogTitle>
                     <DialogContent>
                         <Box sx={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', py: 1}}>


### PR DESCRIPTION
## Summary
Enhanced user experience by adding helpful tooltips to interactive elements throughout the application and introducing website navigation functionality to the TopBar and IndexPage components.

## Key Changes

### TopBar Component (`TopBar.tsx`)
- Added `Tooltip` import from MUI and configured with 400ms enter delay for consistency
- Added new props: `websiteUrl` and `onOpenWebsite` to support opening backend website
- Wrapped all icon buttons with `Tooltip` components providing descriptive labels for:
  - Menu, navigation (prev/next entry), refresh, auto-latest toggle
  - Theme toggle, notifications, live feed, and more options buttons
  - Settings close button
- Added new "Open website" button in the center group (hidden on mobile, shown in menu on compact view)
- Extracted tooltip labels into variables for maintainability and consistency
- Updated refresh button to show dynamic tooltip ("Refreshing…" vs "Refresh entries")
- Updated notifications tooltip to show count when available

### IndexPage Component (`IndexPage.tsx`)
- Added `Tooltip` import and new `FavoriteItem` styled component for layout
- Implemented `openInNewTab` utility function to safely open URLs in new tabs
- Added "Open in new tab" button next to the current backend URL with tooltip
- Added "Refresh status" tooltip to the refresh button
- Enhanced favorite URLs section:
  - Wrapped each favorite in `FavoriteItem` container
  - Added individual "Open in new tab" button for each favorite URL with tooltip
  - Proper event handling to prevent unintended chip interactions

### SearchTrigger Component (`SearchTrigger.tsx`)
- Added `Tooltip` wrapper around search trigger with "Search (Ctrl+K)" label
- Applied consistent 400ms enter delay

### Layout Component (`Layout.tsx`)
- Added `handleOpenWebsite` callback to open backend URL in new tab
- Passed `websiteUrl` and `onOpenWebsite` props to TopBar component

## Implementation Details
- All tooltips use consistent 400ms `enterDelay` for a polished feel
- Website navigation uses `window.open()` with `'noopener,noreferrer'` for security
- Buttons are properly disabled when URLs are unavailable
- Tooltips wrapped disabled buttons in `<span>` elements to ensure proper display
- Maintained accessibility with appropriate `aria-label` attributes

https://claude.ai/code/session_01XMCwP1nZpfGb4Ww2EJjWRs