### PR TITLE
Add Elasticsearch inspector controller and provider support

### DIFF
--- a/libs/Adapter/Laravel/src/AppDevPanelServiceProvider.php
+++ b/libs/Adapter/Laravel/src/AppDevPanelServiceProvider.php
@@ -45,6 +45,7 @@ use AppDevPanel\Api\Inspector\Controller\CodeCoverageController;
 use AppDevPanel\Api\Inspector\Controller\CommandController;
 use AppDevPanel\Api\Inspector\Controller\ComposerController;
 use AppDevPanel\Api\Inspector\Controller\DatabaseController;
+use AppDevPanel\Api\Inspector\Controller\ElasticsearchController;
 use AppDevPanel\Api\Inspector\Controller\FileController;
 use AppDevPanel\Api\Inspector\Controller\GitController;
 use AppDevPanel\Api\Inspector\Controller\GitRepositoryProvider;
@@ -56,6 +57,8 @@ use AppDevPanel\Api\Inspector\Controller\RoutingController;
 use AppDevPanel\Api\Inspector\Controller\ServiceController;
 use AppDevPanel\Api\Inspector\Controller\TranslationController;
 use AppDevPanel\Api\Inspector\Database\SchemaProviderInterface;
+use AppDevPanel\Api\Inspector\Elasticsearch\ElasticsearchProviderInterface;
+use AppDevPanel\Api\Inspector\Elasticsearch\NullElasticsearchProvider;
 use AppDevPanel\Api\Inspector\HttpMock\HttpMockProviderInterface;
 use AppDevPanel\Api\Inspector\HttpMock\NullHttpMockProvider;
 use AppDevPanel\Api\Inspector\Middleware\InspectorProxyMiddleware;
@@ -789,6 +792,15 @@ final class AppDevPanelServiceProvider extends ServiceProvider
             fn() => new HttpMockController(
                 $this->app->make(JsonResponseFactoryInterface::class),
                 $this->app->make(HttpMockProviderInterface::class),
+            ),
+        );
+
+        $this->app->singleton(ElasticsearchProviderInterface::class, fn() => new NullElasticsearchProvider());
+        $this->app->singleton(
+            ElasticsearchController::class,
+            fn() => new ElasticsearchController(
+                $this->app->make(JsonResponseFactoryInterface::class),
+                $this->app->make(ElasticsearchProviderInterface::class),
             ),
         );
 

--- a/libs/Adapter/Symfony/src/DependencyInjection/AppDevPanelExtension.php
+++ b/libs/Adapter/Symfony/src/DependencyInjection/AppDevPanelExtension.php
@@ -36,6 +36,7 @@ use AppDevPanel\Api\Inspector\Controller\CodeCoverageController;
 use AppDevPanel\Api\Inspector\Controller\CommandController;
 use AppDevPanel\Api\Inspector\Controller\ComposerController;
 use AppDevPanel\Api\Inspector\Controller\DatabaseController;
+use AppDevPanel\Api\Inspector\Controller\ElasticsearchController;
 use AppDevPanel\Api\Inspector\Controller\FileController;
 use AppDevPanel\Api\Inspector\Controller\GitController;
 use AppDevPanel\Api\Inspector\Controller\GitRepositoryProvider;
@@ -47,6 +48,8 @@ use AppDevPanel\Api\Inspector\Controller\RoutingController;
 use AppDevPanel\Api\Inspector\Controller\ServiceController;
 use AppDevPanel\Api\Inspector\Controller\TranslationController;
 use AppDevPanel\Api\Inspector\Database\SchemaProviderInterface;
+use AppDevPanel\Api\Inspector\Elasticsearch\ElasticsearchProviderInterface;
+use AppDevPanel\Api\Inspector\Elasticsearch\NullElasticsearchProvider;
 use AppDevPanel\Api\Inspector\HttpMock\HttpMockProviderInterface;
 use AppDevPanel\Api\Inspector\HttpMock\NullHttpMockProvider;
 use AppDevPanel\Api\Inspector\Middleware\InspectorProxyMiddleware;
@@ -748,6 +751,21 @@ final class AppDevPanelExtension extends Extension
             ->setArguments([
                 new Reference(JsonResponseFactoryInterface::class),
                 new Reference(HttpMockProviderInterface::class),
+            ])
+            ->setPublic(true);
+
+        // Elasticsearch inspector: register NullElasticsearchProvider as default.
+        if (!$container->has(ElasticsearchProviderInterface::class)) {
+            $container
+                ->register(ElasticsearchProviderInterface::class, NullElasticsearchProvider::class)
+                ->setPublic(false);
+        }
+
+        $container
+            ->register(ElasticsearchController::class, ElasticsearchController::class)
+            ->setArguments([
+                new Reference(JsonResponseFactoryInterface::class),
+                new Reference(ElasticsearchProviderInterface::class),
             ])
             ->setPublic(true);
 

--- a/libs/Adapter/Yii2/src/Module.php
+++ b/libs/Adapter/Yii2/src/Module.php
@@ -43,6 +43,7 @@ use AppDevPanel\Api\Inspector\Controller\CacheController;
 use AppDevPanel\Api\Inspector\Controller\CommandController;
 use AppDevPanel\Api\Inspector\Controller\ComposerController;
 use AppDevPanel\Api\Inspector\Controller\DatabaseController;
+use AppDevPanel\Api\Inspector\Controller\ElasticsearchController;
 use AppDevPanel\Api\Inspector\Controller\FileController;
 use AppDevPanel\Api\Inspector\Controller\GitController;
 use AppDevPanel\Api\Inspector\Controller\GitRepositoryProvider;
@@ -54,6 +55,8 @@ use AppDevPanel\Api\Inspector\Controller\RoutingController;
 use AppDevPanel\Api\Inspector\Controller\ServiceController;
 use AppDevPanel\Api\Inspector\Controller\TranslationController;
 use AppDevPanel\Api\Inspector\Database\SchemaProviderInterface;
+use AppDevPanel\Api\Inspector\Elasticsearch\ElasticsearchProviderInterface;
+use AppDevPanel\Api\Inspector\Elasticsearch\NullElasticsearchProvider;
 use AppDevPanel\Api\Inspector\HttpMock\HttpMockProviderInterface;
 use AppDevPanel\Api\Inspector\HttpMock\NullHttpMockProvider;
 use AppDevPanel\Api\Inspector\Middleware\InspectorProxyMiddleware;
@@ -416,6 +419,16 @@ class Module extends \yii\base\Module implements BootstrapInterface
             static fn() => new HttpMockController(
                 \Yii::$container->get(JsonResponseFactoryInterface::class),
                 \Yii::$container->get(HttpMockProviderInterface::class),
+            ),
+        );
+
+        // Elasticsearch provider
+        \Yii::$container->setSingleton(ElasticsearchProviderInterface::class, NullElasticsearchProvider::class);
+        \Yii::$container->setSingleton(
+            ElasticsearchController::class,
+            static fn() => new ElasticsearchController(
+                \Yii::$container->get(JsonResponseFactoryInterface::class),
+                \Yii::$container->get(ElasticsearchProviderInterface::class),
             ),
         );
 

--- a/libs/Adapter/Yii3/config/di-api.php
+++ b/libs/Adapter/Yii3/config/di-api.php
@@ -30,6 +30,7 @@ use AppDevPanel\Api\Inspector\Controller\CacheController;
 use AppDevPanel\Api\Inspector\Controller\CommandController;
 use AppDevPanel\Api\Inspector\Controller\ComposerController;
 use AppDevPanel\Api\Inspector\Controller\DatabaseController;
+use AppDevPanel\Api\Inspector\Controller\ElasticsearchController;
 use AppDevPanel\Api\Inspector\Controller\FileController;
 use AppDevPanel\Api\Inspector\Controller\GitController;
 use AppDevPanel\Api\Inspector\Controller\GitRepositoryProvider;
@@ -42,6 +43,8 @@ use AppDevPanel\Api\Inspector\Controller\ServiceController;
 use AppDevPanel\Api\Inspector\Controller\TranslationController;
 use AppDevPanel\Api\Inspector\Database\NullSchemaProvider;
 use AppDevPanel\Api\Inspector\Database\SchemaProviderInterface;
+use AppDevPanel\Api\Inspector\Elasticsearch\ElasticsearchProviderInterface;
+use AppDevPanel\Api\Inspector\Elasticsearch\NullElasticsearchProvider;
 use AppDevPanel\Api\Inspector\HttpMock\HttpMockProviderInterface;
 use AppDevPanel\Api\Inspector\HttpMock\NullHttpMockProvider;
 use AppDevPanel\Api\Inspector\Middleware\InspectorProxyMiddleware;
@@ -180,6 +183,15 @@ return [
         JsonResponseFactoryInterface $jsonResponseFactory,
         HttpMockProviderInterface $httpMockProvider,
     ) => new HttpMockController($jsonResponseFactory, $httpMockProvider),
+
+    // Elasticsearch provider
+    ElasticsearchProviderInterface::class => static fn() => new NullElasticsearchProvider(),
+
+    // Elasticsearch controller
+    ElasticsearchController::class => static fn(
+        JsonResponseFactoryInterface $jsonResponseFactory,
+        ElasticsearchProviderInterface $elasticsearchProvider,
+    ) => new ElasticsearchController($jsonResponseFactory, $elasticsearchProvider),
 
     // Collector repository
     CollectorRepositoryInterface::class => static fn(StorageInterface $storage) => new CollectorRepository($storage),


### PR DESCRIPTION
## Summary
This PR adds Elasticsearch inspector functionality across all framework adapters (Symfony, Laravel, Yii2, and Yii3) by introducing the `ElasticsearchController` and establishing a provider pattern for Elasticsearch integration.

## Key Changes
- **Added Elasticsearch Controller Registration**: Registered `ElasticsearchController` in all four framework adapters (Symfony, Laravel, Yii2, Yii3)
- **Implemented Provider Pattern**: Introduced `ElasticsearchProviderInterface` with a `NullElasticsearchProvider` default implementation, following the existing pattern used for other inspectors (Database, HttpMock)
- **Consistent Dependency Injection**: The controller is configured with:
  - `JsonResponseFactoryInterface` for response formatting
  - `ElasticsearchProviderInterface` for Elasticsearch operations
- **Framework-Specific Integration**:
  - **Symfony**: Registered in DependencyInjection extension with conditional provider setup
  - **Laravel**: Registered as singletons in service provider
  - **Yii2**: Registered in container with factory functions
  - **Yii3**: Registered in DI configuration with static factory functions

## Implementation Details
- The `NullElasticsearchProvider` serves as the default implementation, allowing the inspector to function without an actual Elasticsearch connection
- The provider interface follows the established pattern used by `SchemaProviderInterface` and `HttpMockProviderInterface`
- All adapters maintain consistent registration patterns while respecting their framework-specific conventions

https://claude.ai/code/session_015c4hJTCE3B9wtNtGGNyj2V