### PR TITLE
Refactor configuration pages to use namespace grouping

### DIFF
--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/ComposerPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/ComposerPage.tsx
@@ -194,7 +194,7 @@ const PackageItem = React.memo(({pkg, onSwitch}: PackageItemProps) => {
 // Main component
 // ---------------------------------------------------------------------------
 
-export const ComposerPage = () => {
+export const ComposerPage = ({showHeader = true}: {showHeader?: boolean}) => {
     const theme = useTheme();
     const {data, isLoading, isError, error, refetch} = useGetComposerQuery();
     const [tab, setTab] = useState(0);
@@ -327,11 +327,13 @@ export const ComposerPage = () => {
     if (isError) {
         return (
             <>
-                <PageHeader
-                    title="Composer"
-                    icon="inventory_2"
-                    description="Manage project dependencies and packages"
-                />
+                {showHeader && (
+                    <PageHeader
+                        title="Composer"
+                        icon="inventory_2"
+                        description="Manage project dependencies and packages"
+                    />
+                )}
                 <QueryErrorState
                     error={error}
                     title="Failed to load Composer data"
@@ -344,7 +346,13 @@ export const ComposerPage = () => {
 
     return (
         <>
-            <PageHeader title="Composer" icon="inventory_2" description="Manage project dependencies and packages" />
+            {showHeader && (
+                <PageHeader
+                    title="Composer"
+                    icon="inventory_2"
+                    description="Manage project dependencies and packages"
+                />
+            )}
 
             <Box sx={{borderBottom: 1, borderColor: 'divider'}}>
                 <Tabs value={tab} onChange={(_: SyntheticEvent, v: number) => setTab(v)}>

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ConfigurationPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ConfigurationPage.tsx
@@ -1,22 +1,66 @@
+import {
+    useGetClassesQuery,
+    useGetConfigurationQuery,
+    useGetParametersQuery,
+} from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
 import {DataContextProvider} from '@app-dev-panel/panel/Module/Inspector/Context/DataContext';
 import * as Pages from '@app-dev-panel/panel/Module/Inspector/Pages';
 import {ContainerPage} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/ContainerPage';
+import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {TabContext, TabPanel} from '@mui/lab';
 import TabList from '@mui/lab/TabList';
-import {Box, Tab} from '@mui/material';
-import {SyntheticEvent, useState} from 'react';
-import {useNavigate, useParams} from 'react-router';
+import {Box, Tab, Typography} from '@mui/material';
+import {SyntheticEvent, useCallback, useMemo, useState} from 'react';
+import {useNavigate, useParams, useSearchParams} from 'react-router';
 
 type TabValue = 'container' | 'parameters' | 'definitions';
+
+function countParamLeaves(data: unknown): number {
+    if (!data || typeof data !== 'object') return 0;
+    let total = 0;
+    for (const value of Object.values(data as Record<string, unknown>)) {
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            total += Object.keys(value as Record<string, unknown>).length;
+        } else {
+            total += 1;
+        }
+    }
+    return total;
+}
+
 export const ConfigurationPage = () => {
     const {page} = useParams();
     const navigate = useNavigate();
     const [tabValue, setTabValue] = useState<TabValue>((page as TabValue | undefined) ?? 'parameters');
-    const handleChange = (event: SyntheticEvent, newValue: TabValue) => {
+
+    const [searchParams, setSearchParams] = useSearchParams();
+    const filter = searchParams.get('filter') || '';
+
+    const params = useGetParametersQuery();
+    const definitions = useGetConfigurationQuery('di');
+    const classes = useGetClassesQuery('');
+
+    const paramCount = useMemo(() => countParamLeaves(params.data), [params.data]);
+    const definitionCount = useMemo(
+        () => (definitions.data ? Object.keys(definitions.data).length : 0),
+        [definitions.data],
+    );
+    const classCount = classes.data?.length ?? 0;
+
+    const handleTabChange = (_event: SyntheticEvent, newValue: TabValue) => {
         setTabValue(newValue);
-        navigate(`/inspector/config/${newValue}`);
+        navigate(`/inspector/config/${newValue}${filter ? `?filter=${encodeURIComponent(filter)}` : ''}`);
     };
+
+    const onFilterChange = useCallback(
+        (value: string) => {
+            setSearchParams(value ? {filter: value} : {});
+        },
+        [setSearchParams],
+    );
+
+    const totalCount = paramCount + definitionCount + classCount;
 
     return (
         <>
@@ -26,12 +70,18 @@ export const ConfigurationPage = () => {
                 description="Application parameters, DI definitions and resolved container entries"
             />
             <TabContext value={tabValue}>
-                <Box sx={{borderBottom: 1, borderColor: 'divider'}}>
-                    <TabList onChange={handleChange}>
-                        <Tab value="parameters" label="Parameters" />
-                        <Tab value="definitions" label="Definitions" />
-                        <Tab value="container" label="Container" />
+                <Box sx={{display: 'flex', alignItems: 'center', borderBottom: 1, borderColor: 'divider', mb: 2}}>
+                    <TabList onChange={handleTabChange} sx={{flex: 1}}>
+                        <Tab value="parameters" label={`Parameters (${paramCount})`} />
+                        <Tab value="definitions" label={`Definitions (${definitionCount})`} />
+                        <Tab value="container" label={`Container (${classCount})`} />
                     </TabList>
+                    <Box sx={{display: 'flex', alignItems: 'center', gap: 1.5, pb: 0.5}}>
+                        <Typography sx={{fontSize: '12px', color: 'text.disabled', whiteSpace: 'nowrap'}}>
+                            {totalCount} entries
+                        </Typography>
+                        <FilterInput value={filter} onChange={onFilterChange} placeholder="Search configuration..." />
+                    </Box>
                 </Box>
                 <TabPanel value="container" sx={{px: 0, py: 0}}>
                     <DataContextProvider>

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ConfigurationPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ConfigurationPage.tsx
@@ -1,6 +1,7 @@
 import {DataContextProvider} from '@app-dev-panel/panel/Module/Inspector/Context/DataContext';
 import * as Pages from '@app-dev-panel/panel/Module/Inspector/Pages';
 import {ContainerPage} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/ContainerPage';
+import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {TabContext, TabPanel} from '@mui/lab';
 import TabList from '@mui/lab/TabList';
 import {Box, Tab} from '@mui/material';
@@ -19,6 +20,11 @@ export const ConfigurationPage = () => {
 
     return (
         <>
+            <PageHeader
+                title="Configuration"
+                icon="settings"
+                description="Application parameters, DI definitions and resolved container entries"
+            />
             <TabContext value={tabValue}>
                 <Box sx={{borderBottom: 1, borderColor: 'divider'}}>
                     <TabList onChange={handleChange}>

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.test.tsx
@@ -69,11 +69,6 @@ describe('ContainerPage', () => {
         expect(screen.getByText('LoggerInterface')).toBeInTheDocument();
     });
 
-    it('displays total entry count', () => {
-        renderPage();
-        expect(screen.getByText('5 entries')).toBeInTheDocument();
-    });
-
     it('groups entries by vendor namespace', () => {
         renderPage();
         expect(screen.getByText('App\\Controller')).toBeInTheDocument();
@@ -82,35 +77,16 @@ describe('ContainerPage', () => {
         expect(screen.getByText('Psr\\Log')).toBeInTheDocument();
     });
 
-    it('filters entries by class name', async () => {
-        const user = userEvent.setup();
-        renderPage();
-
-        const input = screen.getByPlaceholderText('Search container entries...');
-        await user.type(input, 'UserService');
+    it('filters entries by URL query param', () => {
+        renderPage('/inspector/config/container?filter=UserService');
 
         expect(screen.getByText('UserService')).toBeInTheDocument();
         expect(screen.queryByText('HomeController')).not.toBeInTheDocument();
         expect(screen.queryByText('LoggerInterface')).not.toBeInTheDocument();
     });
 
-    it('shows filtered count', async () => {
-        const user = userEvent.setup();
-        renderPage();
-
-        const input = screen.getByPlaceholderText('Search container entries...');
-        await user.type(input, 'Psr');
-
-        expect(screen.getByText('2 of 5 entries')).toBeInTheDocument();
-    });
-
-    it('shows empty state when filter matches nothing', async () => {
-        const user = userEvent.setup();
-        renderPage();
-
-        const input = screen.getByPlaceholderText('Search container entries...');
-        await user.type(input, 'zzzzzzzzz');
-
+    it('shows empty state when filter matches nothing', () => {
+        renderPage('/inspector/config/container?filter=zzzzzzzzz');
         expect(screen.getByText('No container entries found')).toBeInTheDocument();
     });
 

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.test.tsx
@@ -64,9 +64,9 @@ function renderPage(route = '/inspector/config/container') {
 describe('ContainerPage', () => {
     it('renders container entries after loading', () => {
         renderPage();
-        expect(screen.getByText('App\\Controller\\HomeController')).toBeInTheDocument();
-        expect(screen.getByText('App\\Service\\UserService')).toBeInTheDocument();
-        expect(screen.getByText('Psr\\Log\\LoggerInterface')).toBeInTheDocument();
+        expect(screen.getByText('HomeController')).toBeInTheDocument();
+        expect(screen.getByText('UserService')).toBeInTheDocument();
+        expect(screen.getByText('LoggerInterface')).toBeInTheDocument();
     });
 
     it('displays total entry count', () => {
@@ -74,11 +74,12 @@ describe('ContainerPage', () => {
         expect(screen.getByText('5 entries')).toBeInTheDocument();
     });
 
-    it('shows column headers', () => {
+    it('groups entries by vendor namespace', () => {
         renderPage();
-        expect(screen.getByText('Class')).toBeInTheDocument();
-        expect(screen.getByText('Value')).toBeInTheDocument();
-        expect(screen.getByText('Actions')).toBeInTheDocument();
+        expect(screen.getByText('App\\Controller')).toBeInTheDocument();
+        expect(screen.getByText('App\\Service')).toBeInTheDocument();
+        expect(screen.getByText('App\\Repository')).toBeInTheDocument();
+        expect(screen.getByText('Psr\\Log')).toBeInTheDocument();
     });
 
     it('filters entries by class name', async () => {
@@ -88,9 +89,9 @@ describe('ContainerPage', () => {
         const input = screen.getByPlaceholderText('Search container entries...');
         await user.type(input, 'UserService');
 
-        expect(screen.getByText('App\\Service\\UserService')).toBeInTheDocument();
-        expect(screen.queryByText('App\\Controller\\HomeController')).not.toBeInTheDocument();
-        expect(screen.queryByText('Psr\\Log\\LoggerInterface')).not.toBeInTheDocument();
+        expect(screen.getByText('UserService')).toBeInTheDocument();
+        expect(screen.queryByText('HomeController')).not.toBeInTheDocument();
+        expect(screen.queryByText('LoggerInterface')).not.toBeInTheDocument();
     });
 
     it('shows filtered count', async () => {

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.tsx
@@ -153,7 +153,7 @@ export const ContainerPage = () => {
     }
 
     return (
-        <Box sx={{px: 2, pb: 2}}>
+        <Box sx={{pb: 2}}>
             {filteredRows.length === 0 && (
                 <EmptyState
                     icon="widgets"

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.tsx
@@ -2,7 +2,6 @@ import {useGetClassesQuery, useLazyGetObjectQuery} from '@app-dev-panel/panel/Mo
 import {DataContext} from '@app-dev-panel/panel/Module/Inspector/Context/DataContext';
 import {groupByNamespace, stripNamespace} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/grouping';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
-import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
 import {GroupCard} from '@app-dev-panel/sdk/Component/GroupCard';
 import {JsonRenderer} from '@app-dev-panel/sdk/Component/JsonRenderer';
@@ -25,13 +24,6 @@ type ContainerEntry = {id: string; value: unknown};
 // ---------------------------------------------------------------------------
 // Styled components
 // ---------------------------------------------------------------------------
-
-const SearchRow = styled(Box)(({theme}) => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1.5),
-    padding: theme.spacing(2),
-}));
 
 const EntryRow = styled(Box)(({theme}) => ({
     display: 'flex',
@@ -113,7 +105,7 @@ const ContainerValue = ({entry, onLoad}: {entry: ContainerEntry; onLoad: (id: st
 export const ContainerPage = () => {
     const {data, isLoading, isError, error, refetch} = useGetClassesQuery('');
     const [lazyLoadObject] = useLazyGetObjectQuery();
-    const [searchParams, setSearchParams] = useSearchParams();
+    const [searchParams] = useSearchParams();
     const searchString = searchParams.get('filter') || '';
 
     const {objects, setObjects, insertObject} = useContext(DataContext);
@@ -145,13 +137,6 @@ export const ContainerPage = () => {
 
     const groups = useMemo(() => groupByNamespace(filteredRows), [filteredRows]);
 
-    const onChangeHandler = useCallback(
-        (value: string) => {
-            setSearchParams({filter: value});
-        },
-        [setSearchParams],
-    );
-
     if (isLoading) {
         return <FullScreenCircularProgress />;
     }
@@ -168,91 +153,78 @@ export const ContainerPage = () => {
     }
 
     return (
-        <Box>
-            <SearchRow>
-                <FilterInput
-                    value={searchString}
-                    onChange={onChangeHandler}
-                    placeholder="Search container entries..."
+        <Box sx={{px: 2, pb: 2}}>
+            {filteredRows.length === 0 && (
+                <EmptyState
+                    icon="widgets"
+                    title="No container entries found"
+                    description={searchString ? `No entries match "${searchString}"` : undefined}
                 />
-                <Typography sx={{fontSize: '12px', color: 'text.disabled', whiteSpace: 'nowrap'}}>
-                    {searchString ? `${filteredRows.length} of ${objects.length} entries` : `${objects.length} entries`}
-                </Typography>
-            </SearchRow>
-
-            <Box sx={{px: 2, pb: 2}}>
-                {filteredRows.length === 0 && (
-                    <EmptyState
-                        icon="widgets"
-                        title="No container entries found"
-                        description={searchString ? `No entries match "${searchString}"` : undefined}
-                    />
-                )}
-                {groups.map((group) => (
-                    <GroupCard
-                        key={group.name || '__services__'}
-                        name={group.displayName}
-                        count={group.entries.length}
-                        countLabel={group.entries.length === 1 ? 'entry' : 'entries'}
-                        defaultExpanded={filteredRows.length <= 10 || groups.length === 1 || !!searchString}
-                        preview={
-                            <>
-                                {group.entries.slice(0, 4).map((entry, i) => (
-                                    <span key={entry.id}>
-                                        {i > 0 && <span style={{opacity: 0.4}}>{' · '}</span>}
-                                        {stripNamespace(entry.id, group.name)}
-                                    </span>
-                                ))}
-                                {group.entries.length > 4 && <span style={{opacity: 0.4}}> …</span>}
-                            </>
-                        }
-                    >
-                        {group.entries.map((entry) => (
-                            <EntryRow key={entry.id}>
-                                <NameCell>
-                                    <Tooltip title={entry.id} placement="top-start">
-                                        <NameText>{stripNamespace(entry.id, group.name)}</NameText>
-                                    </Tooltip>
-                                </NameCell>
-                                <ValueCell>
-                                    <ContainerValue entry={entry} onLoad={handleLoadObject} />
-                                </ValueCell>
-                                <ActionsCell>
-                                    <Tooltip title="Open class source">
-                                        <IconButton
-                                            size="small"
-                                            component={RouterLink}
-                                            to={`/inspector/files?class=${encodeURIComponent(entry.id)}`}
-                                            aria-label="Open class source"
-                                        >
-                                            <Code sx={{fontSize: 14}} />
-                                        </IconButton>
-                                    </Tooltip>
-                                    <Tooltip title="Copy class name">
-                                        <IconButton
-                                            size="small"
-                                            onClick={() => clipboardCopy(entry.id)}
-                                            aria-label="Copy class name"
-                                        >
-                                            <ContentCopy sx={{fontSize: 14}} />
-                                        </IconButton>
-                                    </Tooltip>
-                                    <Tooltip title="Examine as container entry">
-                                        <IconButton
-                                            size="small"
-                                            component={RouterLink}
-                                            to={'/inspector/container/view?class=' + entry.id}
-                                            aria-label="Examine as container entry"
-                                        >
-                                            <DataObject sx={{fontSize: 14}} />
-                                        </IconButton>
-                                    </Tooltip>
-                                </ActionsCell>
-                            </EntryRow>
-                        ))}
-                    </GroupCard>
-                ))}
-            </Box>
+            )}
+            {groups.map((group) => (
+                <GroupCard
+                    key={group.name || '__services__'}
+                    name={group.displayName}
+                    count={group.entries.length}
+                    countLabel={group.entries.length === 1 ? 'entry' : 'entries'}
+                    defaultExpanded={filteredRows.length <= 10 || groups.length === 1 || !!searchString}
+                    preview={
+                        <>
+                            {group.entries.slice(0, 4).map((entry, i) => (
+                                <span key={entry.id}>
+                                    {i > 0 && <span style={{opacity: 0.4}}>{' · '}</span>}
+                                    {stripNamespace(entry.id, group.name)}
+                                </span>
+                            ))}
+                            {group.entries.length > 4 && <span style={{opacity: 0.4}}> …</span>}
+                        </>
+                    }
+                >
+                    {group.entries.map((entry) => (
+                        <EntryRow key={entry.id}>
+                            <NameCell>
+                                <Tooltip title={entry.id} placement="top-start">
+                                    <NameText>{stripNamespace(entry.id, group.name)}</NameText>
+                                </Tooltip>
+                            </NameCell>
+                            <ValueCell>
+                                <ContainerValue entry={entry} onLoad={handleLoadObject} />
+                            </ValueCell>
+                            <ActionsCell>
+                                <Tooltip title="Open class source">
+                                    <IconButton
+                                        size="small"
+                                        component={RouterLink}
+                                        to={`/inspector/files?class=${encodeURIComponent(entry.id)}`}
+                                        aria-label="Open class source"
+                                    >
+                                        <Code sx={{fontSize: 14}} />
+                                    </IconButton>
+                                </Tooltip>
+                                <Tooltip title="Copy class name">
+                                    <IconButton
+                                        size="small"
+                                        onClick={() => clipboardCopy(entry.id)}
+                                        aria-label="Copy class name"
+                                    >
+                                        <ContentCopy sx={{fontSize: 14}} />
+                                    </IconButton>
+                                </Tooltip>
+                                <Tooltip title="Examine as container entry">
+                                    <IconButton
+                                        size="small"
+                                        component={RouterLink}
+                                        to={'/inspector/container/view?class=' + entry.id}
+                                        aria-label="Examine as container entry"
+                                    >
+                                        <DataObject sx={{fontSize: 14}} />
+                                    </IconButton>
+                                </Tooltip>
+                            </ActionsCell>
+                        </EntryRow>
+                    ))}
+                </GroupCard>
+            ))}
         </Box>
     );
 };

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.tsx
@@ -1,15 +1,15 @@
 import {useGetClassesQuery, useLazyGetObjectQuery} from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
 import {DataContext} from '@app-dev-panel/panel/Module/Inspector/Context/DataContext';
-import {GroupCard} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/GroupCard';
 import {groupByNamespace, stripNamespace} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/grouping';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
+import {GroupCard} from '@app-dev-panel/sdk/Component/GroupCard';
 import {JsonRenderer} from '@app-dev-panel/sdk/Component/JsonRenderer';
 import {QueryErrorState} from '@app-dev-panel/sdk/Component/QueryErrorState';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';
 import {regexpQuote} from '@app-dev-panel/sdk/Helper/regexpQuote';
-import {ContentCopy, Download, ErrorOutline, OpenInNew} from '@mui/icons-material';
+import {Code, ContentCopy, DataObject, Download, ErrorOutline} from '@mui/icons-material';
 import {Box, CircularProgress, IconButton, Tooltip, Typography} from '@mui/material';
 import {styled} from '@mui/material/styles';
 import clipboardCopy from 'clipboard-copy';
@@ -218,6 +218,16 @@ export const ContainerPage = () => {
                                     <ContainerValue entry={entry} onLoad={handleLoadObject} />
                                 </ValueCell>
                                 <ActionsCell>
+                                    <Tooltip title="Open class source">
+                                        <IconButton
+                                            size="small"
+                                            component={RouterLink}
+                                            to={`/inspector/files?class=${encodeURIComponent(entry.id)}`}
+                                            aria-label="Open class source"
+                                        >
+                                            <Code sx={{fontSize: 14}} />
+                                        </IconButton>
+                                    </Tooltip>
                                     <Tooltip title="Copy class name">
                                         <IconButton
                                             size="small"
@@ -234,7 +244,7 @@ export const ContainerPage = () => {
                                             to={'/inspector/container/view?class=' + entry.id}
                                             aria-label="Examine as container entry"
                                         >
-                                            <OpenInNew sx={{fontSize: 14}} />
+                                            <DataObject sx={{fontSize: 14}} />
                                         </IconButton>
                                     </Tooltip>
                                 </ActionsCell>

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ContainerPage.tsx
@@ -1,5 +1,7 @@
 import {useGetClassesQuery, useLazyGetObjectQuery} from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
 import {DataContext} from '@app-dev-panel/panel/Module/Inspector/Context/DataContext';
+import {GroupCard} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/GroupCard';
+import {groupByNamespace, stripNamespace} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/grouping';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
@@ -8,7 +10,7 @@ import {QueryErrorState} from '@app-dev-panel/sdk/Component/QueryErrorState';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';
 import {regexpQuote} from '@app-dev-panel/sdk/Helper/regexpQuote';
 import {ContentCopy, Download, ErrorOutline, OpenInNew} from '@mui/icons-material';
-import {Box, CircularProgress, IconButton, TablePagination, Tooltip, Typography} from '@mui/material';
+import {Box, CircularProgress, IconButton, Tooltip, Typography} from '@mui/material';
 import {styled} from '@mui/material/styles';
 import clipboardCopy from 'clipboard-copy';
 import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
@@ -36,14 +38,13 @@ const EntryRow = styled(Box)(({theme}) => ({
     alignItems: 'flex-start',
     gap: theme.spacing(2),
     padding: theme.spacing(1, 2),
-    borderBottom: `1px solid ${theme.palette.divider}`,
-    '&:last-child': {borderBottom: 'none'},
+    borderTop: `1px solid ${theme.palette.divider}`,
     '&:hover': {backgroundColor: theme.palette.action.hover},
     [theme.breakpoints.down('sm')]: {flexDirection: 'column', gap: theme.spacing(0.5), padding: theme.spacing(1, 1.5)},
 }));
 
 const NameCell = styled(Box)(({theme}) => ({
-    width: 280,
+    width: 240,
     flexShrink: 0,
     display: 'flex',
     alignItems: 'flex-start',
@@ -64,29 +65,6 @@ const NameText = styled(Typography)(({theme}) => ({
 const ValueCell = styled(Box)({flex: 1, minWidth: 0, overflow: 'hidden', paddingTop: 4});
 
 const ActionsCell = styled(Box)({display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0, paddingTop: 2});
-
-const ListContainer = styled(Box)(({theme}) => ({
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadius,
-    overflow: 'hidden',
-}));
-
-const ListHeader = styled(Box)(({theme}) => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(2),
-    padding: theme.spacing(1, 2),
-    backgroundColor: theme.palette.action.hover,
-    borderBottom: `1px solid ${theme.palette.divider}`,
-}));
-
-const HeaderLabel = styled(Typography)(({theme}) => ({
-    fontSize: '11px',
-    fontWeight: 600,
-    textTransform: 'uppercase',
-    letterSpacing: '0.05em',
-    color: theme.palette.text.disabled,
-}));
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -140,9 +118,6 @@ export const ContainerPage = () => {
 
     const {objects, setObjects, insertObject} = useContext(DataContext);
 
-    const [page, setPage] = useState(0);
-    const [rowsPerPage, setRowsPerPage] = useState(50);
-
     const handleLoadObject = useCallback(
         async (id: string): Promise<string | null> => {
             const result = await lazyLoadObject(id);
@@ -168,15 +143,11 @@ export const ContainerPage = () => {
         return objects.filter((object) => patterns.some((re) => re.test(object.id)));
     }, [objects, searchString]);
 
-    const paginatedRows = useMemo(() => {
-        const start = page * rowsPerPage;
-        return filteredRows.slice(start, start + rowsPerPage);
-    }, [filteredRows, page, rowsPerPage]);
+    const groups = useMemo(() => groupByNamespace(filteredRows), [filteredRows]);
 
     const onChangeHandler = useCallback(
         (value: string) => {
             setSearchParams({filter: value});
-            setPage(0);
         },
         [setSearchParams],
     );
@@ -210,30 +181,49 @@ export const ContainerPage = () => {
             </SearchRow>
 
             <Box sx={{px: 2, pb: 2}}>
-                {filteredRows.length === 0 ? (
+                {filteredRows.length === 0 && (
                     <EmptyState
                         icon="widgets"
                         title="No container entries found"
                         description={searchString ? `No entries match "${searchString}"` : undefined}
                     />
-                ) : (
-                    <ListContainer>
-                        <ListHeader>
-                            <HeaderLabel sx={{width: 280, flexShrink: 0}}>Class</HeaderLabel>
-                            <HeaderLabel sx={{flex: 1}}>Value</HeaderLabel>
-                            <HeaderLabel sx={{width: 68, flexShrink: 0, textAlign: 'right'}}>Actions</HeaderLabel>
-                        </ListHeader>
-                        {paginatedRows.map((entry) => (
+                )}
+                {groups.map((group) => (
+                    <GroupCard
+                        key={group.name || '__services__'}
+                        name={group.displayName}
+                        count={group.entries.length}
+                        countLabel={group.entries.length === 1 ? 'entry' : 'entries'}
+                        defaultExpanded={filteredRows.length <= 10 || groups.length === 1 || !!searchString}
+                        preview={
+                            <>
+                                {group.entries.slice(0, 4).map((entry, i) => (
+                                    <span key={entry.id}>
+                                        {i > 0 && <span style={{opacity: 0.4}}>{' · '}</span>}
+                                        {stripNamespace(entry.id, group.name)}
+                                    </span>
+                                ))}
+                                {group.entries.length > 4 && <span style={{opacity: 0.4}}> …</span>}
+                            </>
+                        }
+                    >
+                        {group.entries.map((entry) => (
                             <EntryRow key={entry.id}>
                                 <NameCell>
-                                    <NameText>{entry.id}</NameText>
+                                    <Tooltip title={entry.id} placement="top-start">
+                                        <NameText>{stripNamespace(entry.id, group.name)}</NameText>
+                                    </Tooltip>
                                 </NameCell>
                                 <ValueCell>
                                     <ContainerValue entry={entry} onLoad={handleLoadObject} />
                                 </ValueCell>
                                 <ActionsCell>
                                     <Tooltip title="Copy class name">
-                                        <IconButton size="small" onClick={() => clipboardCopy(entry.id)}>
+                                        <IconButton
+                                            size="small"
+                                            onClick={() => clipboardCopy(entry.id)}
+                                            aria-label="Copy class name"
+                                        >
                                             <ContentCopy sx={{fontSize: 14}} />
                                         </IconButton>
                                     </Tooltip>
@@ -242,6 +232,7 @@ export const ContainerPage = () => {
                                             size="small"
                                             component={RouterLink}
                                             to={'/inspector/container/view?class=' + entry.id}
+                                            aria-label="Examine as container entry"
                                         >
                                             <OpenInNew sx={{fontSize: 14}} />
                                         </IconButton>
@@ -249,23 +240,8 @@ export const ContainerPage = () => {
                                 </ActionsCell>
                             </EntryRow>
                         ))}
-                        {filteredRows.length > 20 && (
-                            <TablePagination
-                                component="div"
-                                count={filteredRows.length}
-                                page={page}
-                                onPageChange={(_, p) => setPage(p)}
-                                rowsPerPage={rowsPerPage}
-                                onRowsPerPageChange={(e) => {
-                                    setRowsPerPage(parseInt(e.target.value, 10));
-                                    setPage(0);
-                                }}
-                                rowsPerPageOptions={[20, 50, 100]}
-                                sx={{borderTop: 1, borderColor: 'divider'}}
-                            />
-                        )}
-                    </ListContainer>
-                )}
+                    </GroupCard>
+                ))}
             </Box>
         </Box>
     );

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.test.tsx
@@ -9,6 +9,9 @@ import {MemoryRouter} from 'react-router';
 import {describe, expect, it, vi} from 'vitest';
 import {DefinitionsPage} from './DefinitionsPage';
 
+// Note: filter UI is rendered by the parent `ConfigurationPage`. Subpage tests
+// simulate filter changes by passing it as a URL query param via MemoryRouter.
+
 // ---------------------------------------------------------------------------
 // Mock Inspector API
 // ---------------------------------------------------------------------------
@@ -79,45 +82,21 @@ describe('DefinitionsPage', () => {
         expect(screen.getByText('yii\\db\\Connection')).toBeInTheDocument();
     });
 
-    it('displays total definition count', () => {
-        renderPage();
-        expect(screen.getAllByText('5 definitions').length).toBeGreaterThanOrEqual(1);
-    });
-
     it('groups definitions without a namespace under Services', () => {
         renderPage();
         expect(screen.getByText('Services')).toBeInTheDocument();
     });
 
-    it('filters definitions by name', async () => {
-        const user = userEvent.setup();
-        renderPage();
-
-        const input = screen.getByPlaceholderText('Search definitions...');
-        await user.type(input, 'db');
+    it('filters definitions by URL query param', async () => {
+        renderPage('/inspector/config/definitions?filter=db');
 
         expect(screen.getByText('db')).toBeInTheDocument();
         expect(screen.queryByText('assetManager')).not.toBeInTheDocument();
         expect(screen.queryByText('session')).not.toBeInTheDocument();
     });
 
-    it('shows filtered count', async () => {
-        const user = userEvent.setup();
-        renderPage();
-
-        const input = screen.getByPlaceholderText('Search definitions...');
-        await user.type(input, 'error');
-
-        expect(screen.getByText('1 of 5 definitions')).toBeInTheDocument();
-    });
-
-    it('shows empty state when filter matches nothing', async () => {
-        const user = userEvent.setup();
-        renderPage();
-
-        const input = screen.getByPlaceholderText('Search definitions...');
-        await user.type(input, 'zzzzzzzzz');
-
+    it('shows empty state when filter matches nothing', () => {
+        renderPage('/inspector/config/definitions?filter=zzzzzzzzz');
         expect(screen.getByText('No definitions found')).toBeInTheDocument();
     });
 

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.test.tsx
@@ -81,14 +81,12 @@ describe('DefinitionsPage', () => {
 
     it('displays total definition count', () => {
         renderPage();
-        expect(screen.getByText('5 definitions')).toBeInTheDocument();
+        expect(screen.getAllByText('5 definitions').length).toBeGreaterThanOrEqual(1);
     });
 
-    it('shows column headers', () => {
+    it('groups definitions without a namespace under Services', () => {
         renderPage();
-        expect(screen.getByText('Name')).toBeInTheDocument();
-        expect(screen.getByText('Value')).toBeInTheDocument();
-        expect(screen.getByText('Actions')).toBeInTheDocument();
+        expect(screen.getByText('Services')).toBeInTheDocument();
     });
 
     it('filters definitions by name', async () => {

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.tsx
@@ -637,7 +637,7 @@ export const DefinitionsPage = () => {
     }
 
     return (
-        <Box sx={{px: 2, pb: 2}}>
+        <Box sx={{pb: 2}}>
             {filteredRows.length === 0 && (
                 <EmptyState
                     icon="account_tree"

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.tsx
@@ -1,12 +1,12 @@
 import {useGetConfigurationQuery, useLazyGetObjectQuery} from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
 import {DataContext} from '@app-dev-panel/panel/Module/Inspector/Context/DataContext';
-import {GroupCard} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/GroupCard';
 import {groupByNamespace, stripNamespace} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/grouping';
 import {CodeHighlight} from '@app-dev-panel/sdk/Component/CodeHighlight';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
+import {GroupCard} from '@app-dev-panel/sdk/Component/GroupCard';
 import {JsonRenderer} from '@app-dev-panel/sdk/Component/JsonRenderer';
 import {QueryErrorState} from '@app-dev-panel/sdk/Component/QueryErrorState';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.tsx
@@ -4,7 +4,6 @@ import {groupByNamespace, stripNamespace} from '@app-dev-panel/panel/Module/Insp
 import {CodeHighlight} from '@app-dev-panel/sdk/Component/CodeHighlight';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
-import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
 import {GroupCard} from '@app-dev-panel/sdk/Component/GroupCard';
 import {JsonRenderer} from '@app-dev-panel/sdk/Component/JsonRenderer';
@@ -101,13 +100,6 @@ const countLines = (source: string): number => source.split('\n').length;
 // ---------------------------------------------------------------------------
 // Styled components
 // ---------------------------------------------------------------------------
-
-const SearchRow = styled(Box)(({theme}) => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1.5),
-    padding: theme.spacing(2),
-}));
 
 const Row = styled(Box, {shouldForwardProp: (p) => p !== 'expanded'})<{expanded?: boolean}>(({theme, expanded}) => ({
     borderTop: `1px solid ${theme.palette.divider}`,
@@ -595,7 +587,7 @@ const DefinitionRow = ({
 export const DefinitionsPage = () => {
     const {data, isLoading, isError, error, refetch} = useGetConfigurationQuery('di');
     const [lazyLoadObject] = useLazyGetObjectQuery();
-    const [searchParams, setSearchParams] = useSearchParams();
+    const [searchParams] = useSearchParams();
     const searchString = searchParams.get('filter') || '';
 
     const {objects, setObjects, insertObject} = useContext(DataContext);
@@ -629,13 +621,6 @@ export const DefinitionsPage = () => {
 
     const groups = useMemo(() => groupByNamespace(filteredRows), [filteredRows]);
 
-    const onChangeHandler = useCallback(
-        (value: string) => {
-            setSearchParams({filter: value});
-        },
-        [setSearchParams],
-    );
-
     if (isLoading) {
         return <FullScreenCircularProgress />;
     }
@@ -652,54 +637,43 @@ export const DefinitionsPage = () => {
     }
 
     return (
-        <Box>
-            <SearchRow>
-                <FilterInput value={searchString} onChange={onChangeHandler} placeholder="Search definitions..." />
-                <Typography sx={{fontSize: '12px', color: 'text.disabled', whiteSpace: 'nowrap'}}>
-                    {searchString
-                        ? `${filteredRows.length} of ${objects.length} definitions`
-                        : `${objects.length} definitions`}
-                </Typography>
-            </SearchRow>
-
-            <Box sx={{px: 2, pb: 2}}>
-                {filteredRows.length === 0 && (
-                    <EmptyState
-                        icon="account_tree"
-                        title="No definitions found"
-                        description={searchString ? `No definitions match "${searchString}"` : undefined}
-                    />
-                )}
-                {groups.map((group) => (
-                    <GroupCard
-                        key={group.name || '__services__'}
-                        name={group.displayName}
-                        count={group.entries.length}
-                        countLabel={group.entries.length === 1 ? 'definition' : 'definitions'}
-                        defaultExpanded={filteredRows.length <= 10 || groups.length === 1 || !!searchString}
-                        preview={
-                            <>
-                                {group.entries.slice(0, 4).map((entry, i) => (
-                                    <span key={entry.id}>
-                                        {i > 0 && <span style={{opacity: 0.4}}>{' · '}</span>}
-                                        {stripNamespace(entry.id, group.name)}
-                                    </span>
-                                ))}
-                                {group.entries.length > 4 && <span style={{opacity: 0.4}}> …</span>}
-                            </>
-                        }
-                    >
-                        {group.entries.map((entry) => (
-                            <DefinitionRow
-                                key={entry.id}
-                                entry={entry}
-                                displayName={stripNamespace(entry.id, group.name)}
-                                onLoad={handleLoadObject}
-                            />
-                        ))}
-                    </GroupCard>
-                ))}
-            </Box>
+        <Box sx={{px: 2, pb: 2}}>
+            {filteredRows.length === 0 && (
+                <EmptyState
+                    icon="account_tree"
+                    title="No definitions found"
+                    description={searchString ? `No definitions match "${searchString}"` : undefined}
+                />
+            )}
+            {groups.map((group) => (
+                <GroupCard
+                    key={group.name || '__services__'}
+                    name={group.displayName}
+                    count={group.entries.length}
+                    countLabel={group.entries.length === 1 ? 'definition' : 'definitions'}
+                    defaultExpanded={filteredRows.length <= 10 || groups.length === 1 || !!searchString}
+                    preview={
+                        <>
+                            {group.entries.slice(0, 4).map((entry, i) => (
+                                <span key={entry.id}>
+                                    {i > 0 && <span style={{opacity: 0.4}}>{' · '}</span>}
+                                    {stripNamespace(entry.id, group.name)}
+                                </span>
+                            ))}
+                            {group.entries.length > 4 && <span style={{opacity: 0.4}}> …</span>}
+                        </>
+                    }
+                >
+                    {group.entries.map((entry) => (
+                        <DefinitionRow
+                            key={entry.id}
+                            entry={entry}
+                            displayName={stripNamespace(entry.id, group.name)}
+                            onLoad={handleLoadObject}
+                        />
+                    ))}
+                </GroupCard>
+            ))}
         </Box>
     );
 };

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/DefinitionsPage.tsx
@@ -1,5 +1,7 @@
 import {useGetConfigurationQuery, useLazyGetObjectQuery} from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
 import {DataContext} from '@app-dev-panel/panel/Module/Inspector/Context/DataContext';
+import {GroupCard} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/GroupCard';
+import {groupByNamespace, stripNamespace} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/grouping';
 import {CodeHighlight} from '@app-dev-panel/sdk/Component/CodeHighlight';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
@@ -10,7 +12,7 @@ import {QueryErrorState} from '@app-dev-panel/sdk/Component/QueryErrorState';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';
 import {regexpQuote} from '@app-dev-panel/sdk/Helper/regexpQuote';
 import {ChevronRight, Code, ContentCopy, DataObject, Download, ErrorOutline} from '@mui/icons-material';
-import {Box, CircularProgress, Collapse, IconButton, TablePagination, Tooltip, Typography} from '@mui/material';
+import {Box, CircularProgress, Collapse, IconButton, Tooltip, Typography} from '@mui/material';
 import {alpha, styled} from '@mui/material/styles';
 import clipboardCopy from 'clipboard-copy';
 import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
@@ -107,32 +109,8 @@ const SearchRow = styled(Box)(({theme}) => ({
     padding: theme.spacing(2),
 }));
 
-const ListContainer = styled(Box)(({theme}) => ({
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadius,
-    overflow: 'hidden',
-}));
-
-const ListHeader = styled(Box)(({theme}) => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(2),
-    padding: theme.spacing(1, 2),
-    backgroundColor: theme.palette.action.hover,
-    borderBottom: `1px solid ${theme.palette.divider}`,
-}));
-
-const HeaderLabel = styled(Typography)(({theme}) => ({
-    fontSize: '11px',
-    fontWeight: 600,
-    textTransform: 'uppercase',
-    letterSpacing: '0.05em',
-    color: theme.palette.text.disabled,
-}));
-
 const Row = styled(Box, {shouldForwardProp: (p) => p !== 'expanded'})<{expanded?: boolean}>(({theme, expanded}) => ({
-    borderBottom: `1px solid ${theme.palette.divider}`,
-    '&:last-child': {borderBottom: 'none'},
+    borderTop: `1px solid ${theme.palette.divider}`,
     backgroundColor: expanded ? theme.palette.action.hover : 'transparent',
     transition: 'background-color 120ms',
 }));
@@ -154,7 +132,7 @@ const RowHead = styled(Box, {shouldForwardProp: (p) => p !== 'clickable'})<{clic
 );
 
 const NameCell = styled(Box)(({theme}) => ({
-    width: 240,
+    width: 220,
     flexShrink: 0,
     display: 'flex',
     alignItems: 'flex-start',
@@ -459,7 +437,15 @@ const resolveTargetClass = (kind: DefinitionKind, value: unknown, id: string): s
     return null;
 };
 
-const DefinitionRow = ({entry, onLoad}: {entry: DefinitionEntry; onLoad: (id: string) => Promise<string | null>}) => {
+const DefinitionRow = ({
+    entry,
+    displayName,
+    onLoad,
+}: {
+    entry: DefinitionEntry;
+    displayName: string;
+    onLoad: (id: string) => Promise<string | null>;
+}) => {
     const kind = useMemo(() => detectKind(entry.value), [entry.value]);
     const [expanded, setExpanded] = useState(false);
     const expandable = kind === 'factory' || kind === 'object';
@@ -485,7 +471,9 @@ const DefinitionRow = ({entry, onLoad}: {entry: DefinitionEntry; onLoad: (id: st
                     <ChevronRight sx={{fontSize: 14}} />
                 </ExpandIndicator>
                 <NameCell>
-                    <NameText>{entry.id}</NameText>
+                    <Tooltip title={entry.id} placement="top-start">
+                        <NameText>{displayName}</NameText>
+                    </Tooltip>
                 </NameCell>
                 <ValueCell>
                     <KindBadge kind={kind}>{KIND_LABEL[kind]}</KindBadge>
@@ -612,9 +600,6 @@ export const DefinitionsPage = () => {
 
     const {objects, setObjects, insertObject} = useContext(DataContext);
 
-    const [page, setPage] = useState(0);
-    const [rowsPerPage, setRowsPerPage] = useState(50);
-
     const handleLoadObject = useCallback(
         async (id: string): Promise<string | null> => {
             const result = await lazyLoadObject(id);
@@ -642,15 +627,11 @@ export const DefinitionsPage = () => {
         return objects.filter((object) => patterns.some((re) => re.test(object.id)));
     }, [objects, searchString]);
 
-    const paginatedRows = useMemo(() => {
-        const start = page * rowsPerPage;
-        return filteredRows.slice(start, start + rowsPerPage);
-    }, [filteredRows, page, rowsPerPage]);
+    const groups = useMemo(() => groupByNamespace(filteredRows), [filteredRows]);
 
     const onChangeHandler = useCallback(
         (value: string) => {
             setSearchParams({filter: value});
-            setPage(0);
         },
         [setSearchParams],
     );
@@ -682,40 +663,42 @@ export const DefinitionsPage = () => {
             </SearchRow>
 
             <Box sx={{px: 2, pb: 2}}>
-                {filteredRows.length === 0 ? (
+                {filteredRows.length === 0 && (
                     <EmptyState
                         icon="account_tree"
                         title="No definitions found"
                         description={searchString ? `No definitions match "${searchString}"` : undefined}
                     />
-                ) : (
-                    <ListContainer>
-                        <ListHeader>
-                            <Box sx={{width: 16, flexShrink: 0}} />
-                            <HeaderLabel sx={{width: 240, flexShrink: 0}}>Name</HeaderLabel>
-                            <HeaderLabel sx={{flex: 1}}>Value</HeaderLabel>
-                            <HeaderLabel sx={{width: 92, flexShrink: 0, textAlign: 'right'}}>Actions</HeaderLabel>
-                        </ListHeader>
-                        {paginatedRows.map((entry) => (
-                            <DefinitionRow key={entry.id} entry={entry} onLoad={handleLoadObject} />
-                        ))}
-                        {filteredRows.length > 20 && (
-                            <TablePagination
-                                component="div"
-                                count={filteredRows.length}
-                                page={page}
-                                onPageChange={(_, p) => setPage(p)}
-                                rowsPerPage={rowsPerPage}
-                                onRowsPerPageChange={(e) => {
-                                    setRowsPerPage(parseInt(e.target.value, 10));
-                                    setPage(0);
-                                }}
-                                rowsPerPageOptions={[20, 50, 100]}
-                                sx={{borderTop: 1, borderColor: 'divider'}}
-                            />
-                        )}
-                    </ListContainer>
                 )}
+                {groups.map((group) => (
+                    <GroupCard
+                        key={group.name || '__services__'}
+                        name={group.displayName}
+                        count={group.entries.length}
+                        countLabel={group.entries.length === 1 ? 'definition' : 'definitions'}
+                        defaultExpanded={filteredRows.length <= 10 || groups.length === 1 || !!searchString}
+                        preview={
+                            <>
+                                {group.entries.slice(0, 4).map((entry, i) => (
+                                    <span key={entry.id}>
+                                        {i > 0 && <span style={{opacity: 0.4}}>{' · '}</span>}
+                                        {stripNamespace(entry.id, group.name)}
+                                    </span>
+                                ))}
+                                {group.entries.length > 4 && <span style={{opacity: 0.4}}> …</span>}
+                            </>
+                        }
+                    >
+                        {group.entries.map((entry) => (
+                            <DefinitionRow
+                                key={entry.id}
+                                entry={entry}
+                                displayName={stripNamespace(entry.id, group.name)}
+                                onLoad={handleLoadObject}
+                            />
+                        ))}
+                    </GroupCard>
+                ))}
             </Box>
         </Box>
     );

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/GroupCard.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/GroupCard.tsx
@@ -1,0 +1,65 @@
+import {Box, Chip, Collapse, Icon, Typography} from '@mui/material';
+import {styled} from '@mui/material/styles';
+import {ReactNode, useState} from 'react';
+
+type GroupCardProps = {
+    name: string;
+    count: number;
+    countLabel: string;
+    defaultExpanded: boolean;
+    preview: ReactNode;
+    children: ReactNode;
+};
+
+const Card = styled(Box)(({theme}) => ({
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    overflow: 'hidden',
+    '&:not(:last-child)': {marginBottom: theme.spacing(1.5)},
+}));
+
+const Header = styled(Box, {shouldForwardProp: (p) => p !== 'expanded'})<{expanded?: boolean}>(({theme, expanded}) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(1.5, 2),
+    cursor: 'pointer',
+    backgroundColor: expanded ? theme.palette.action.hover : 'transparent',
+    '&:hover': {backgroundColor: theme.palette.action.hover},
+}));
+
+const PreviewRow = styled(Box)(({theme}) => ({
+    padding: theme.spacing(0, 2, 1.5, 4.5),
+    fontFamily: theme.adp.fontFamilyMono,
+    fontSize: '12px',
+    color: theme.palette.text.secondary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+}));
+
+export const GroupCard = ({name, count, countLabel, defaultExpanded, preview, children}: GroupCardProps) => {
+    const [expanded, setExpanded] = useState(defaultExpanded);
+
+    return (
+        <Card>
+            <Header expanded={expanded} onClick={() => setExpanded(!expanded)}>
+                <Icon sx={{fontSize: 16, color: 'text.disabled'}}>{expanded ? 'expand_less' : 'expand_more'}</Icon>
+                <Typography sx={{fontWeight: 600, fontSize: '13px', flex: 1, fontFamily: 'monospace'}}>
+                    {name}
+                </Typography>
+                <Chip
+                    label={`${count} ${countLabel}`}
+                    size="small"
+                    sx={{fontSize: '10px', height: 20, borderRadius: 1, backgroundColor: 'action.selected'}}
+                />
+            </Header>
+
+            {!expanded && <PreviewRow>{preview}</PreviewRow>}
+
+            <Collapse in={expanded} unmountOnExit>
+                {children}
+            </Collapse>
+        </Card>
+    );
+};

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ParametersPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ParametersPage.tsx
@@ -1,6 +1,5 @@
 import {useGetParametersQuery} from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
-import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
 import {JsonRenderer} from '@app-dev-panel/sdk/Component/JsonRenderer';
 import {QueryErrorState} from '@app-dev-panel/sdk/Component/QueryErrorState';
@@ -9,7 +8,7 @@ import {regexpQuote} from '@app-dev-panel/sdk/Helper/regexpQuote';
 import {Box, Chip, Collapse, Icon, IconButton, Tooltip, Typography} from '@mui/material';
 import {styled} from '@mui/material/styles';
 import clipboardCopy from 'clipboard-copy';
-import {useCallback, useMemo, useState} from 'react';
+import {useMemo, useState} from 'react';
 import {useSearchParams} from 'react-router';
 
 // ---------------------------------------------------------------------------
@@ -21,13 +20,6 @@ type ParamGroup = {name: string; params: Array<{key: string; value: unknown}>};
 // ---------------------------------------------------------------------------
 // Styled components
 // ---------------------------------------------------------------------------
-
-const SearchRow = styled(Box)(({theme}) => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1.5),
-    padding: theme.spacing(2),
-}));
 
 const Card = styled(Box)(({theme}) => ({
     border: `1px solid ${theme.palette.divider}`,
@@ -207,7 +199,7 @@ const ParamCard = ({
 
 export const ParametersPage = () => {
     const {data, isLoading, isError, error, refetch} = useGetParametersQuery();
-    const [searchParams, setSearchParams] = useSearchParams();
+    const [searchParams] = useSearchParams();
     const searchString = searchParams.get('filter') || '';
 
     const groups = useMemo(() => groupParams(data), [data]);
@@ -228,15 +220,6 @@ export const ParametersPage = () => {
             .filter(Boolean) as ParamGroup[];
     }, [groups, searchString]);
 
-    const totalParams = groups.reduce((acc, g) => acc + g.params.length, 0);
-
-    const onChangeHandler = useCallback(
-        (e: React.ChangeEvent<HTMLInputElement>) => {
-            setSearchParams({filter: e.target.value});
-        },
-        [setSearchParams],
-    );
-
     if (isLoading) {
         return <FullScreenCircularProgress />;
     }
@@ -253,35 +236,22 @@ export const ParametersPage = () => {
     }
 
     return (
-        <Box>
-            <SearchRow>
-                <FilterInput
-                    value={searchString}
-                    onChange={(v) => onChangeHandler({target: {value: v}} as React.ChangeEvent<HTMLInputElement>)}
-                    placeholder="Search configuration..."
+        <Box sx={{px: 2, pb: 2}}>
+            {filtered.length === 0 && (
+                <EmptyState
+                    icon="tune"
+                    title="No parameters found"
+                    description={searchString ? `No parameters match "${searchString}"` : undefined}
                 />
-                <Typography sx={{fontSize: '12px', color: 'text.disabled', whiteSpace: 'nowrap'}}>
-                    {searchString ? `${filtered.length} groups` : `${totalParams} params`}
-                </Typography>
-            </SearchRow>
-
-            <Box sx={{px: 2, pb: 2}}>
-                {filtered.length === 0 && (
-                    <EmptyState
-                        icon="tune"
-                        title="No parameters found"
-                        description={searchString ? `No parameters match "${searchString}"` : undefined}
-                    />
-                )}
-                {filtered.map((group) => (
-                    <ParamCard
-                        key={group.name}
-                        group={group}
-                        filter={searchString}
-                        defaultExpanded={filtered.length === 1 || !!searchString}
-                    />
-                ))}
-            </Box>
+            )}
+            {filtered.map((group) => (
+                <ParamCard
+                    key={group.name}
+                    group={group}
+                    filter={searchString}
+                    defaultExpanded={filtered.length === 1 || !!searchString}
+                />
+            ))}
         </Box>
     );
 };

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ParametersPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/ParametersPage.tsx
@@ -236,7 +236,7 @@ export const ParametersPage = () => {
     }
 
     return (
-        <Box sx={{px: 2, pb: 2}}>
+        <Box sx={{pb: 2}}>
             {filtered.length === 0 && (
                 <EmptyState
                     icon="tune"

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/grouping.ts
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/grouping.ts
@@ -1,0 +1,38 @@
+export type NamespaceGroup<T> = {name: string; displayName: string; entries: T[]};
+
+const SERVICES_GROUP = '';
+const SERVICES_LABEL = 'Services';
+
+function namespaceKey(id: string): string {
+    if (!id.includes('\\')) return SERVICES_GROUP;
+    const parts = id.split('\\');
+    if (parts.length <= 2) return parts[0];
+    return parts.slice(0, 2).join('\\');
+}
+
+export function groupByNamespace<T extends {id: string}>(entries: T[]): NamespaceGroup<T>[] {
+    const groups = new Map<string, T[]>();
+    for (const entry of entries) {
+        const key = namespaceKey(entry.id);
+        const bucket = groups.get(key);
+        if (bucket) {
+            bucket.push(entry);
+        } else {
+            groups.set(key, [entry]);
+        }
+    }
+    return [...groups.entries()]
+        .sort(([a], [b]) => {
+            if (a === SERVICES_GROUP) return 1;
+            if (b === SERVICES_GROUP) return -1;
+            return a.localeCompare(b);
+        })
+        .map(([name, entries]) => ({name, displayName: name === SERVICES_GROUP ? SERVICES_LABEL : name, entries}));
+}
+
+export function stripNamespace(id: string, groupName: string): string {
+    if (!groupName) return id;
+    const prefix = groupName + '\\';
+    if (id.startsWith(prefix)) return id.slice(prefix.length);
+    return id;
+}

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/EnvironmentPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/EnvironmentPage.tsx
@@ -46,7 +46,7 @@ export const EnvironmentPage = () => {
                 </Tabs>
             </Box>
             {activeTab === 'phpinfo' && <PhpInfoPage />}
-            {activeTab === 'composer' && <ComposerPage />}
+            {activeTab === 'composer' && <ComposerPage showHeader={false} />}
             {activeTab === 'opcache' && <OpcachePage />}
             {activeTab === 'git' && <GitPage showHeader={false} />}
             {activeTab === 'git-log' && <GitLogPage showHeader={false} />}

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/EventsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/EventsPage.tsx
@@ -292,7 +292,7 @@ const EventListeners = React.memo(({entries}: EventListenersProps) => {
     }
 
     return (
-        <Box sx={{px: 2, pb: 2}}>
+        <Box sx={{pb: 2}}>
             {groups.map((group) => (
                 <GroupCard
                     key={group.name || '__events__'}

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/EventsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/EventsPage.tsx
@@ -5,6 +5,7 @@ import {
     EventListenersType,
     useGetEventsQuery,
 } from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
+import {groupByNamespace, stripNamespace} from '@app-dev-panel/panel/Module/Inspector/Pages/Config/grouping';
 import {CodeHighlight} from '@app-dev-panel/sdk/Component/CodeHighlight';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
@@ -16,14 +17,14 @@ import {QueryErrorState} from '@app-dev-panel/sdk/Component/QueryErrorState';
 import {serializeCallable} from '@app-dev-panel/sdk/Helper/callableSerializer';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';
 import {regexpQuote} from '@app-dev-panel/sdk/Helper/regexpQuote';
-import {ContentCopy, Description} from '@mui/icons-material';
+import {ChevronRight, Code, ContentCopy, Description} from '@mui/icons-material';
 import {TabContext, TabPanel} from '@mui/lab';
 import TabList from '@mui/lab/TabList';
-import {Box, IconButton, Tab, Tooltip, Typography} from '@mui/material';
+import {Box, Chip, Collapse, IconButton, Tab, Tooltip, Typography} from '@mui/material';
 import {styled} from '@mui/material/styles';
 import clipboardCopy from 'clipboard-copy';
 import React, {SyntheticEvent, useCallback, useMemo, useState} from 'react';
-import {useSearchParams} from 'react-router';
+import {Link as RouterLink, useSearchParams} from 'react-router';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -59,19 +60,6 @@ function isClassName(value: string): boolean {
     return value.includes('\\') && !value.includes(' ');
 }
 
-function parseEventName(name: string): {className: string; member: string} | {className: string} | null {
-    if (name.includes('::')) {
-        const [className, member] = name.split('::', 2);
-        if (className && member && isClassName(className)) {
-            return {className, member};
-        }
-    }
-    if (isClassName(name)) {
-        return {className: name};
-    }
-    return null;
-}
-
 // ---------------------------------------------------------------------------
 // Styled components
 // ---------------------------------------------------------------------------
@@ -87,6 +75,38 @@ const ListenerRow = styled(Box)(({theme}) => ({
     '&:hover .copy-btn': {opacity: 1},
 }));
 
+const EventRowBox = styled(Box, {shouldForwardProp: (p) => p !== 'expanded'})<{expanded?: boolean}>(
+    ({theme, expanded}) => ({
+        borderTop: `1px solid ${theme.palette.divider}`,
+        backgroundColor: expanded ? theme.palette.action.hover : 'transparent',
+        transition: 'background-color 120ms',
+        '& .event-row-actions': {opacity: 0, transition: 'opacity 0.15s'},
+        '&:hover .event-row-actions': {opacity: 1},
+    }),
+);
+
+const EventRowHead = styled(Box)(({theme}) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+    padding: theme.spacing(1, 2),
+    cursor: 'pointer',
+    '&:hover': {backgroundColor: theme.palette.action.hover},
+}));
+
+const EventExpandIndicator = styled(Box, {shouldForwardProp: (p) => p !== 'open'})<{open?: boolean}>(
+    ({theme, open}) => ({
+        width: 16,
+        flexShrink: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: theme.palette.text.disabled,
+        transition: 'transform 150ms',
+        transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
+    }),
+);
+
 // ---------------------------------------------------------------------------
 // Shared sx constants
 // ---------------------------------------------------------------------------
@@ -99,55 +119,6 @@ const monoLinkSx = (theme: import('@mui/material/styles').Theme) =>
         wordBreak: 'break-all',
         '&:hover': {textDecoration: 'underline'},
     }) as const;
-
-// ---------------------------------------------------------------------------
-// Event name rendering
-// ---------------------------------------------------------------------------
-
-const EventName = React.memo(({name, eventClass}: {name: string; eventClass: string | null}) => {
-    const parsed = parseEventName(name);
-
-    if (parsed) {
-        const methodName = 'member' in parsed ? parsed.member : undefined;
-        return (
-            <FileLink className={parsed.className} methodName={methodName} sx={{minWidth: 0}}>
-                <Typography
-                    component="span"
-                    sx={(theme) => ({...monoLinkSx(theme), fontWeight: 600, fontSize: '13px'})}
-                >
-                    {name}
-                </Typography>
-            </FileLink>
-        );
-    }
-
-    if (eventClass && eventClass !== name) {
-        return (
-            <Box sx={{display: 'flex', alignItems: 'baseline', gap: 0.5, minWidth: 0}}>
-                <FileLink className={eventClass} sx={{flexShrink: 0}}>
-                    <Typography
-                        component="span"
-                        sx={{
-                            fontWeight: 600,
-                            fontSize: '13px',
-                            color: 'primary.main',
-                            '&:hover': {textDecoration: 'underline'},
-                        }}
-                    >
-                        {eventClass.split('\\').pop()}
-                    </Typography>
-                </FileLink>
-                <Typography component="span" sx={{fontSize: '12px', color: 'text.secondary', wordBreak: 'break-all'}}>
-                    ({name})
-                </Typography>
-            </Box>
-        );
-    }
-
-    return (
-        <Typography sx={{fontWeight: 600, fontSize: '13px', wordBreak: 'break-all', minWidth: 0}}>{name}</Typography>
-    );
-});
 
 // ---------------------------------------------------------------------------
 // Listener rendering
@@ -222,43 +193,131 @@ const ListenerItem = React.memo(({listener}: {listener: EventListener}) => {
 });
 
 // ---------------------------------------------------------------------------
-// Event accordion
+// Event row (inside a namespace group)
+// ---------------------------------------------------------------------------
+
+const EventRow = React.memo(({entry, displayName}: {entry: EventEntry; displayName: string}) => {
+    const [expanded, setExpanded] = useState(false);
+    const targetClass = entry.class || (isClassName(entry.name) ? entry.name : null);
+    const toggle = useCallback(() => {
+        const selection = typeof window !== 'undefined' ? window.getSelection()?.toString() : '';
+        if (selection && selection.length > 0) return;
+        setExpanded((v) => !v);
+    }, []);
+    const stopProp = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
+
+    return (
+        <EventRowBox expanded={expanded}>
+            <EventRowHead onClick={toggle}>
+                <EventExpandIndicator open={expanded}>
+                    <ChevronRight sx={{fontSize: 14}} />
+                </EventExpandIndicator>
+                <Tooltip title={entry.name} placement="top-start">
+                    <Typography
+                        sx={(theme) => ({
+                            fontFamily: theme.adp.fontFamilyMono,
+                            fontSize: '12px',
+                            fontWeight: 600,
+                            wordBreak: 'break-all',
+                            flex: 1,
+                            minWidth: 0,
+                        })}
+                    >
+                        {displayName}
+                    </Typography>
+                </Tooltip>
+                <Chip
+                    label={`${entry.listeners.length} ${entry.listeners.length === 1 ? 'listener' : 'listeners'}`}
+                    size="small"
+                    sx={{
+                        fontSize: '10px',
+                        height: 20,
+                        borderRadius: 1,
+                        backgroundColor: 'action.selected',
+                        flexShrink: 0,
+                    }}
+                />
+                <Box
+                    className="event-row-actions"
+                    sx={{display: 'flex', alignItems: 'center', gap: 0.25, flexShrink: 0}}
+                    onClick={stopProp}
+                >
+                    {targetClass && (
+                        <Tooltip title="Open class source">
+                            <IconButton
+                                size="small"
+                                component={RouterLink}
+                                to={`/inspector/files?class=${encodeURIComponent(targetClass)}`}
+                                aria-label="Open class source"
+                                sx={{p: 0.25}}
+                            >
+                                <Code sx={{fontSize: 14}} />
+                            </IconButton>
+                        </Tooltip>
+                    )}
+                    <Tooltip title="Copy event name">
+                        <IconButton
+                            size="small"
+                            onClick={() => clipboardCopy(entry.name)}
+                            aria-label="Copy event name"
+                            sx={{p: 0.25}}
+                        >
+                            <ContentCopy sx={{fontSize: 14}} />
+                        </IconButton>
+                    </Tooltip>
+                </Box>
+            </EventRowHead>
+            <Collapse in={expanded} unmountOnExit>
+                <Box sx={{borderTop: 1, borderColor: 'divider'}}>
+                    {entry.listeners.map((listener, i) => (
+                        <ListenerItem key={i} listener={listener} />
+                    ))}
+                </Box>
+            </Collapse>
+        </EventRowBox>
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Event listeners list (groups of events by namespace)
 // ---------------------------------------------------------------------------
 
 type EventListenersProps = {entries: EventEntry[]};
 
 const EventListeners = React.memo(({entries}: EventListenersProps) => {
+    const groups = useMemo(() => groupByNamespace(entries.map((e) => ({...e, id: e.name}))), [entries]);
+
     if (entries.length === 0) {
         return <EmptyState icon="bolt" title="No event listeners found" />;
     }
 
     return (
-        <>
-            {entries.map((entry) => (
+        <Box sx={{px: 2, pb: 2}}>
+            {groups.map((group) => (
                 <GroupCard
-                    key={entry.name}
-                    name={<EventName name={entry.name} eventClass={entry.class} />}
-                    count={entry.listeners.length}
-                    defaultExpanded={entries.length === 1}
-                    actions={
+                    key={group.name || '__events__'}
+                    name={group.displayName}
+                    count={group.entries.length}
+                    countLabel={group.entries.length === 1 ? 'event' : 'events'}
+                    defaultExpanded={entries.length <= 10 || groups.length === 1}
+                    preview={
                         <>
-                            <Tooltip title="Copy event name">
-                                <IconButton size="small" onClick={() => clipboardCopy(entry.name)} sx={{p: 0.25}}>
-                                    <ContentCopy sx={{fontSize: 14}} />
-                                </IconButton>
-                            </Tooltip>
-                            {entry.class && <FileLink className={entry.class} />}
+                            {group.entries.slice(0, 4).map((entry, i) => (
+                                <span key={entry.name}>
+                                    {i > 0 && <span style={{opacity: 0.4}}>{' · '}</span>}
+                                    {stripNamespace(entry.name, group.name)}
+                                </span>
+                            ))}
+                            {group.entries.length > 4 && <span style={{opacity: 0.4}}> …</span>}
                         </>
                     }
                 >
-                    <Box sx={{borderTop: 1, borderColor: 'divider'}}>
-                        {entry.listeners.map((listener, i) => (
-                            <ListenerItem key={i} listener={listener} />
-                        ))}
-                    </Box>
+                    {group.entries.map((entry) => (
+                        <EventRow key={entry.name} entry={entry} displayName={stripNamespace(entry.name, group.name)} />
+                    ))}
                 </GroupCard>
             ))}
-        </>
+        </Box>
     );
 });
 

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/EventsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/EventsPage.tsx
@@ -10,25 +10,16 @@ import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
+import {GroupCard} from '@app-dev-panel/sdk/Component/GroupCard';
 import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {QueryErrorState} from '@app-dev-panel/sdk/Component/QueryErrorState';
 import {serializeCallable} from '@app-dev-panel/sdk/Helper/callableSerializer';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';
 import {regexpQuote} from '@app-dev-panel/sdk/Helper/regexpQuote';
-import {ContentCopy, Description, ExpandMore} from '@mui/icons-material';
+import {ContentCopy, Description} from '@mui/icons-material';
 import {TabContext, TabPanel} from '@mui/lab';
 import TabList from '@mui/lab/TabList';
-import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
-    Box,
-    Chip,
-    IconButton,
-    Tab,
-    Tooltip,
-    Typography,
-} from '@mui/material';
+import {Box, IconButton, Tab, Tooltip, Typography} from '@mui/material';
 import {styled} from '@mui/material/styles';
 import clipboardCopy from 'clipboard-copy';
 import React, {SyntheticEvent, useCallback, useMemo, useState} from 'react';
@@ -94,29 +85,6 @@ const ListenerRow = styled(Box)(({theme}) => ({
     '&:hover': {backgroundColor: theme.palette.action.hover},
     '& .copy-btn': {opacity: 0, transition: 'opacity 0.15s'},
     '&:hover .copy-btn': {opacity: 1},
-}));
-
-const StyledAccordion = styled(Accordion)(({theme}) => ({
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: `${theme.shape.borderRadius}px !important`,
-    '&:before': {display: 'none'},
-    '&:not(:last-child)': {marginBottom: theme.spacing(1)},
-    '&.Mui-expanded': {margin: 0, '&:not(:last-child)': {marginBottom: theme.spacing(1)}},
-}));
-
-const StyledAccordionSummary = styled(AccordionSummary)(({theme}) => ({
-    minHeight: 40,
-    padding: theme.spacing(0, 2),
-    '&.Mui-expanded': {minHeight: 40},
-    '& .MuiAccordionSummary-content': {
-        margin: theme.spacing(0.75, 0),
-        alignItems: 'center',
-        gap: theme.spacing(1),
-        overflow: 'hidden',
-    },
-    '& .MuiAccordionSummary-content.Mui-expanded': {margin: theme.spacing(0.75, 0)},
-    '& .header-actions': {opacity: 0, transition: 'opacity 0.15s'},
-    '&:hover .header-actions': {opacity: 1},
 }));
 
 // ---------------------------------------------------------------------------
@@ -267,54 +235,28 @@ const EventListeners = React.memo(({entries}: EventListenersProps) => {
     return (
         <>
             {entries.map((entry) => (
-                <StyledAccordion
+                <GroupCard
                     key={entry.name}
-                    disableGutters
-                    elevation={0}
-                    slotProps={{transition: {unmountOnExit: true}}}
-                >
-                    <StyledAccordionSummary expandIcon={<ExpandMore />}>
-                        <Box sx={{flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 1}}>
-                            <EventName name={entry.name} eventClass={entry.class} />
-                        </Box>
-                        <Box className="header-actions" sx={{display: 'flex', alignItems: 'center', flexShrink: 0}}>
+                    name={<EventName name={entry.name} eventClass={entry.class} />}
+                    count={entry.listeners.length}
+                    defaultExpanded={entries.length === 1}
+                    actions={
+                        <>
                             <Tooltip title="Copy event name">
-                                <IconButton
-                                    size="small"
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        clipboardCopy(entry.name);
-                                    }}
-                                    sx={{p: 0.25}}
-                                >
+                                <IconButton size="small" onClick={() => clipboardCopy(entry.name)} sx={{p: 0.25}}>
                                     <ContentCopy sx={{fontSize: 14}} />
                                 </IconButton>
                             </Tooltip>
-                        </Box>
-                        {entry.class && (
-                            <Box className="header-actions" sx={{flexShrink: 0}} onClick={(e) => e.stopPropagation()}>
-                                <FileLink className={entry.class} />
-                            </Box>
-                        )}
-                        <Chip
-                            label={entry.listeners.length}
-                            size="small"
-                            sx={{
-                                fontSize: '10px',
-                                height: 20,
-                                minWidth: 24,
-                                borderRadius: 1,
-                                backgroundColor: 'action.selected',
-                                flexShrink: 0,
-                            }}
-                        />
-                    </StyledAccordionSummary>
-                    <AccordionDetails sx={{p: 0, borderTop: 1, borderColor: 'divider'}}>
+                            {entry.class && <FileLink className={entry.class} />}
+                        </>
+                    }
+                >
+                    <Box sx={{borderTop: 1, borderColor: 'divider'}}>
                         {entry.listeners.map((listener, i) => (
                             <ListenerItem key={i} listener={listener} />
                         ))}
-                    </AccordionDetails>
-                </StyledAccordion>
+                    </Box>
+                </GroupCard>
             ))}
         </>
     );

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/FileExplorerPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/FileExplorerPage.tsx
@@ -6,6 +6,7 @@ import {
 } from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
 import {TreeView} from '@app-dev-panel/panel/Module/Inspector/Component/TreeView/TreeView';
 import {CodeHighlight} from '@app-dev-panel/sdk/Component/CodeHighlight';
+import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {SearchFilter, type SearchMatch} from '@app-dev-panel/sdk/Component/SearchFilter';
 import {parseFilePath, parsePathLineAnchor} from '@app-dev-panel/sdk/Helper/filePathParser';
 import {formatBytes} from '@app-dev-panel/sdk/Helper/formatBytes';
@@ -272,6 +273,11 @@ export const FileExplorerPage = () => {
 
     return (
         <>
+            <PageHeader
+                title="File Explorer"
+                icon="folder_open"
+                description="Browse application files and source code"
+            />
             {error && (
                 <Box sx={{display: 'flex', flexDirection: 'column', gap: 2}}>
                     <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/TranslationsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/TranslationsPage.tsx
@@ -7,6 +7,7 @@ import {FilterInput} from '@app-dev-panel/sdk/Component/Form/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
 import {DataTable} from '@app-dev-panel/sdk/Component/Grid';
 import {JsonRenderer} from '@app-dev-panel/sdk/Component/JsonRenderer';
+import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {QueryErrorState} from '@app-dev-panel/sdk/Component/QueryErrorState';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';
 import {regexpQuote} from '@app-dev-panel/sdk/Helper/regexpQuote';
@@ -75,17 +76,21 @@ export const TranslationsPage = () => {
 
     if (isError) {
         return (
-            <QueryErrorState
-                error={error}
-                title="Failed to load translations"
-                fallback="Failed to load translations."
-                onRetry={refetch}
-            />
+            <>
+                <PageHeader title="Translations" icon="translate" description="Application translations and messages" />
+                <QueryErrorState
+                    error={error}
+                    title="Failed to load translations"
+                    fallback="Failed to load translations."
+                    onRetry={refetch}
+                />
+            </>
         );
     }
 
     return (
         <>
+            <PageHeader title="Translations" icon="translate" description="Application translations and messages" />
             <FilterInput value={searchString} onChange={onChangeHandler} />
             <TranslationUpdaterContextProvider updater={updateTranslationHandler}>
                 <DataTable rows={filteredRows as GridValidRowModel[]} getRowId={(row) => row[0]} columns={columns} />

--- a/libs/frontend/packages/sdk/src/Component/GroupCard.tsx
+++ b/libs/frontend/packages/sdk/src/Component/GroupCard.tsx
@@ -1,13 +1,14 @@
-import {Box, Chip, Collapse, Icon, Typography} from '@mui/material';
+import {Box, Chip, Collapse, Icon} from '@mui/material';
 import {styled} from '@mui/material/styles';
 import {ReactNode, useState} from 'react';
 
 type GroupCardProps = {
-    name: string;
+    name: ReactNode;
     count: number;
-    countLabel: string;
+    countLabel?: string;
     defaultExpanded: boolean;
-    preview: ReactNode;
+    preview?: ReactNode;
+    actions?: ReactNode;
     children: ReactNode;
 };
 
@@ -26,7 +27,20 @@ const Header = styled(Box, {shouldForwardProp: (p) => p !== 'expanded'})<{expand
     cursor: 'pointer',
     backgroundColor: expanded ? theme.palette.action.hover : 'transparent',
     '&:hover': {backgroundColor: theme.palette.action.hover},
+    '& .group-card-actions': {opacity: 0, transition: 'opacity 0.15s'},
+    '&:hover .group-card-actions': {opacity: 1},
 }));
+
+const NameBox = styled(Box)({
+    fontWeight: 600,
+    fontSize: '13px',
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    fontFamily: 'monospace',
+});
 
 const PreviewRow = styled(Box)(({theme}) => ({
     padding: theme.spacing(0, 2, 1.5, 4.5),
@@ -38,24 +52,38 @@ const PreviewRow = styled(Box)(({theme}) => ({
     whiteSpace: 'nowrap',
 }));
 
-export const GroupCard = ({name, count, countLabel, defaultExpanded, preview, children}: GroupCardProps) => {
+export const GroupCard = ({name, count, countLabel, defaultExpanded, preview, actions, children}: GroupCardProps) => {
     const [expanded, setExpanded] = useState(defaultExpanded);
 
     return (
         <Card>
             <Header expanded={expanded} onClick={() => setExpanded(!expanded)}>
                 <Icon sx={{fontSize: 16, color: 'text.disabled'}}>{expanded ? 'expand_less' : 'expand_more'}</Icon>
-                <Typography sx={{fontWeight: 600, fontSize: '13px', flex: 1, fontFamily: 'monospace'}}>
-                    {name}
-                </Typography>
+                <NameBox>{name}</NameBox>
+                {actions && (
+                    <Box
+                        className="group-card-actions"
+                        sx={{display: 'flex', alignItems: 'center', flexShrink: 0}}
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        {actions}
+                    </Box>
+                )}
                 <Chip
-                    label={`${count} ${countLabel}`}
+                    label={countLabel ? `${count} ${countLabel}` : String(count)}
                     size="small"
-                    sx={{fontSize: '10px', height: 20, borderRadius: 1, backgroundColor: 'action.selected'}}
+                    sx={{
+                        fontSize: '10px',
+                        height: 20,
+                        minWidth: 24,
+                        borderRadius: 1,
+                        backgroundColor: 'action.selected',
+                        flexShrink: 0,
+                    }}
                 />
             </Header>
 
-            {!expanded && <PreviewRow>{preview}</PreviewRow>}
+            {!expanded && preview && <PreviewRow>{preview}</PreviewRow>}
 
             <Collapse in={expanded} unmountOnExit>
                 {children}


### PR DESCRIPTION
## Summary
Refactored the configuration pages (Events, Container, Definitions, Parameters) to organize entries by namespace using a new grouping utility and a reusable `GroupCard` component. This improves navigation and reduces visual clutter for large datasets.

## Key Changes

- **New `GroupCard` component** (`libs/frontend/packages/sdk/src/Component/GroupCard.tsx`): A reusable collapsible card component for grouping related items with preview, count badges, and optional actions.

- **New grouping utility** (`libs/frontend/packages/panel/src/Module/Inspector/Pages/Config/grouping.ts`): 
  - `groupByNamespace()`: Groups entries by their namespace (vendor\package level), with "Services" as the default group for entries without namespaces
  - `stripNamespace()`: Removes namespace prefix from display names for cleaner UI

- **EventsPage refactoring**:
  - Replaced `Accordion`-based layout with `GroupCard` + `EventRow` components
  - Removed `parseEventName()` and `EventName` components in favor of simpler display logic
  - Events now grouped by namespace with collapsible sections
  - Updated icons (added `ChevronRight`, `Code`; removed `ExpandMore`)

- **ContainerPage refactoring**:
  - Removed pagination and search UI (moved to parent `ConfigurationPage`)
  - Replaced table-like layout with `GroupCard` groups
  - Simplified entry display with namespace grouping
  - Removed `ListContainer`, `ListHeader`, `HeaderLabel` styled components

- **DefinitionsPage refactoring**:
  - Removed pagination and search UI (moved to parent)
  - Replaced table-like layout with `GroupCard` groups
  - Updated `DefinitionRow` to accept `displayName` parameter for stripped namespace display
  - Removed list header and pagination components

- **ParametersPage refactoring**:
  - Removed search UI from page (moved to parent `ConfigurationPage`)
  - Kept existing card-based layout but removed search row

- **ConfigurationPage enhancement**:
  - Added `PageHeader` with title and description
  - Centralized filter input for all sub-pages
  - Added tab labels with entry counts (Parameters, Definitions, Container)
  - Filter state managed via URL query params and passed to child pages

- **Test updates**: Updated test expectations to reflect namespace grouping and removed assertions for old UI elements (column headers, pagination, search inputs)

## Implementation Details

- Namespace grouping uses the first two path segments (e.g., `App\Controller` from `App\Controller\HomeController`)
- Entries without backslashes are grouped under "Services"
- Services group always appears last in the sorted list
- Filter input moved to parent page for consistency across all configuration tabs
- Collapse state managed per `GroupCard` instance with sensible defaults (expanded if ≤10 items or single group)

https://claude.ai/code/session_01GpWHLyzSePY4y4t3hdNtHD