### PR TITLE
Remove summary cards from panels and add Ctrl+click to open in new tab

### DIFF
--- a/libs/frontend/CLAUDE.md
+++ b/libs/frontend/CLAUDE.md
@@ -279,6 +279,53 @@ npm run check          # Run all checks
 
 **ESLint**: @typescript-eslint with `consistent-type-definitions: "type"`, integrated with Prettier via `eslint-config-prettier`.
 
+## Building URLs to ADP Pages
+
+Any code that opens a panel page in a new tab (badge Ctrl/Cmd-click, "Open in panel" menu items, external-anchor links) **must** go through `panelPagePath` from `@app-dev-panel/sdk/Helper/panelMountPath`.
+
+A valid panel URL has three parts:
+
+```
+{mount}{panelPath}{?query}
+ ─┬──── ─┬──────── ─┬─────
+  │      │          │
+  │      │          └── page-specific params (collector, debugEntry, level, class, path, …)
+  │      │
+  │      └── panel-internal React Router path
+  │          (`/debug`, `/debug/list`, `/debug/object`, `/inspector/files`, `/llm`, `/mcp`, …)
+  │
+  └── ADP mount inside the host app.
+      Read from `window.__adp_panel_url` (set by PHP `ToolbarInjector` from
+      `PanelConfig::viewerBasePath`). Defaults to `/debug`.
+```
+
+**Two `/debug` segments is correct when the panel is at its default mount:** the first is the mount, the second is the internal collector viewer route. `panelPagePath('/debug?collector=X&debugEntry=Y')` resolves to `/debug/debug?collector=X&debugEntry=Y` by default, and to `/adp/debug?collector=X&debugEntry=Y` when the host configured `__adp_panel_url = '/adp'`.
+
+### Rules
+
+- Always URL-encode dynamic path/query values with `encodeURIComponent` — especially backslashes in PHP collector FQCNs (`AppDevPanel\Kernel\Collector\LogCollector` → `AppDevPanel%5C...`). `Application/Component/Layout.tsx` is the reference (see line ~476).
+- Never hardcode `/debug` as the mount. Always call `panelPagePath` so a custom `__adp_panel_url` is respected.
+- The panel-internal path must include `/debug` for collector viewer URLs. A bare-query call — `panelPagePath('?collector=X')` → `/debug?...` — goes to the panel **home** page, not the collector viewer. Use `panelPagePath('/debug?collector=X&debugEntry=Y')`.
+- For inspector pages use the corresponding internal route: `panelPagePath('/inspector/files?class=Foo')`.
+
+### Badge → panel URL mapping
+
+| Badge | Panel URL |
+|-------|-----------|
+| Logs | `{mount}/debug?collector=<LogCollector>&debugEntry=<id>[&level=…]` |
+| Events | `{mount}/debug?collector=<EventCollector>&debugEntry=<id>` |
+| RequestTime | `{mount}/debug?collector=<TimelineCollector>&debugEntry=<id>` |
+| Memory | `{mount}/debug?collector=<Web/Console AppInfoCollector>&debugEntry=<id>` |
+| Database | `{mount}/debug?collector=<DatabaseCollector>&debugEntry=<id>` |
+| HttpClient | `{mount}/debug?collector=<HttpClientCollector>&debugEntry=<id>` |
+| Validator | `{mount}/debug?collector=<ValidatorCollector>&debugEntry=<id>` |
+| Deprecation | `{mount}/debug?collector=<DeprecationCollector>&debugEntry=<id>` |
+| Request (web) | `{mount}/debug?debugEntry=<id>` (entry overview) |
+| Command (console) | `{mount}/debug?debugEntry=<id>` (entry overview) |
+| Exception | `{mount}/inspector/files?class=<ExceptionClass>` (class explorer) |
+
+Toolbar badges fall through `openInNewTabOnModifier` (`@app-dev-panel/sdk/Helper/openInNewTabOnModifier`) for the modifier branch — it handles `ctrlKey || metaKey`, calls `window.open(url, '_blank', 'noopener,noreferrer')`, and stops the event. Tests live next to each badge (`LogsItem.test.tsx`, `EventsItem.test.tsx`, `Web/RequestItem.test.tsx`) and assert the full URL shape including both `/debug` segments.
+
 ## Build & Development
 
 ```bash

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/AssetBundlePanel.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/AssetBundlePanel.test.tsx
@@ -27,10 +27,7 @@ const makeBundle = (overrides: Partial<Bundle> = {}): Bundle => ({
     ...overrides,
 });
 
-const makeData = (bundles: Record<string, Bundle> = {main: makeBundle()}, bundleCount?: number) => ({
-    bundles,
-    bundleCount: bundleCount ?? Object.keys(bundles).length,
-});
+const makeData = (bundles: Record<string, Bundle> = {main: makeBundle()}) => ({bundles});
 
 describe('AssetBundlePanel', () => {
     it('shows empty message when data is null', () => {
@@ -41,12 +38,6 @@ describe('AssetBundlePanel', () => {
     it('shows empty message when bundles is empty object', () => {
         renderWithProviders(<AssetBundlePanel data={makeData({})} />);
         expect(screen.getByText(/No asset bundles found/)).toBeInTheDocument();
-    });
-
-    it('renders total bundles count in summary card', () => {
-        renderWithProviders(<AssetBundlePanel data={makeData({a: makeBundle(), b: makeBundle()}, 2)} />);
-        expect(screen.getByText('Total Bundles')).toBeInTheDocument();
-        expect(screen.getByText('2')).toBeInTheDocument();
     });
 
     it('renders bundle count in section title', () => {

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/AssetBundlePanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/AssetBundlePanel.tsx
@@ -16,41 +16,12 @@ type Bundle = {
     depends: string[];
     options: Record<string, any>;
 };
-type AssetBundlePanelProps = {data: {bundles: Record<string, Bundle>; bundleCount: number}};
+type AssetBundlePanelProps = {data: {bundles: Record<string, Bundle>}};
 
 function shortClassName(fqcn: string): string {
     const parts = fqcn.split('\\');
     return parts[parts.length - 1] ?? fqcn;
 }
-
-const SummaryGrid = styled(Box)(({theme}) => ({
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
-    gap: theme.spacing(2),
-    marginBottom: theme.spacing(3),
-}));
-
-const SummaryCard = styled(Box)(({theme}) => ({
-    padding: theme.spacing(2),
-    borderRadius: Number(theme.shape.borderRadius) * 1.5,
-    border: `1px solid ${theme.palette.divider}`,
-    backgroundColor: theme.palette.background.paper,
-}));
-
-const SummaryLabel = styled(Typography)(({theme}) => ({
-    fontSize: '11px',
-    fontWeight: 600,
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.5px',
-    color: theme.palette.text.disabled,
-    marginBottom: theme.spacing(0.5),
-}));
-
-const SummaryValue = styled(Typography)(({theme}) => ({
-    fontFamily: theme.adp.fontFamilyMono,
-    fontWeight: 700,
-    fontSize: '22px',
-}));
 
 const BundleRow = styled(Box, {shouldForwardProp: (p) => p !== 'expanded'})<{expanded?: boolean}>(
     ({theme, expanded}) => ({
@@ -115,13 +86,6 @@ export const AssetBundlePanel = ({data}: AssetBundlePanelProps) => {
 
     return (
         <Box>
-            <SummaryGrid>
-                <SummaryCard>
-                    <SummaryLabel>Total Bundles</SummaryLabel>
-                    <SummaryValue sx={{color: 'primary.main'}}>{data.bundleCount}</SummaryValue>
-                </SummaryCard>
-            </SummaryGrid>
-
             <SectionTitle
                 action={<FilterInput value={filter} onChange={setFilter} placeholder="Filter bundles..." />}
             >{`${filtered.length} bundles`}</SectionTitle>

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.test.tsx
@@ -43,9 +43,22 @@ describe('FilesystemPanel', () => {
         expect(screen.getAllByText('Open').length).toBeGreaterThanOrEqual(1);
     });
 
-    it('renders operations count', () => {
+    it('does not show operations count when unfiltered', () => {
         renderWithProviders(<FilesystemPanel data={makeData() as any} />);
-        expect(screen.getByText('1 operation')).toBeInTheDocument();
+        expect(screen.queryByText(/^\d+ operation/)).not.toBeInTheDocument();
+    });
+
+    it('shows filtered operations count when a filter is applied', async () => {
+        const user = userEvent.setup();
+        const bundles = {
+            read: [
+                {path: '/a/config.php', args: {}},
+                {path: '/b/other.php', args: {}},
+            ],
+        };
+        renderWithProviders(<FilesystemPanel data={bundles as any} />);
+        await user.type(screen.getByPlaceholderText('Filter by path...'), 'config');
+        expect(screen.getByText('1 of 2 operations')).toBeInTheDocument();
     });
 
     it('switches tab on click', async () => {

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.test.tsx
@@ -72,11 +72,6 @@ describe('FilesystemPanel', () => {
         expect(screen.getByText(/No readdir operations found/)).toBeInTheDocument();
     });
 
-    it('renders summary cards with total operations', () => {
-        renderWithProviders(<FilesystemPanel data={makeData() as any} />);
-        expect(screen.getByText('Total Operations')).toBeInTheDocument();
-    });
-
     it('renders section title', () => {
         renderWithProviders(<FilesystemPanel data={makeData() as any} />);
         expect(screen.getByText('Operations')).toBeInTheDocument();

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.test.tsx
@@ -72,11 +72,6 @@ describe('FilesystemPanel', () => {
         expect(screen.getByText(/No readdir operations found/)).toBeInTheDocument();
     });
 
-    it('renders section title', () => {
-        renderWithProviders(<FilesystemPanel data={makeData() as any} />);
-        expect(screen.getByText('Operations')).toBeInTheDocument();
-    });
-
     it('renders filter input', () => {
         renderWithProviders(<FilesystemPanel data={makeData() as any} />);
         expect(screen.getByPlaceholderText('Filter by path...')).toBeInTheDocument();

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.tsx
@@ -2,7 +2,6 @@ import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRend
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
-import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
 import {TabContext, TabPanel} from '@mui/lab';
 import TabList from '@mui/lab/TabList';
 import {Box, Chip, Icon, IconButton, Tab, Tooltip, Typography} from '@mui/material';
@@ -190,13 +189,9 @@ export const FilesystemPanel = ({data}: FilesystemPanelProps) => {
 
     return (
         <Box>
-            <SectionTitle action={<FilterInput value={filter} onChange={setFilter} placeholder="Filter by path..." />}>
-                Operations
-            </SectionTitle>
-
             <TabContext value={value}>
-                <Box sx={{borderBottom: 1, borderColor: 'divider'}}>
-                    <StyledTabList onChange={handleChange}>
+                <Box sx={{borderBottom: 1, borderColor: 'divider', display: 'flex', alignItems: 'center', gap: 2}}>
+                    <StyledTabList onChange={handleChange} sx={{flex: 1, minWidth: 0}}>
                         {tabs.map((tab) => {
                             const count = (data as any)[tab]?.length ?? 0;
                             const meta = operationMeta(tab);
@@ -231,6 +226,9 @@ export const FilesystemPanel = ({data}: FilesystemPanelProps) => {
                             );
                         })}
                     </StyledTabList>
+                    <Box sx={{flexShrink: 0, pr: 2}}>
+                        <FilterInput value={filter} onChange={setFilter} placeholder="Filter by path..." />
+                    </Box>
                 </Box>
                 {tabs.map((tab) => (
                     <TabPanel value={tab} key={tab} sx={{padding: 0}}>

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.tsx
@@ -110,15 +110,17 @@ const OperationView = ({items, operation, filter}: {items: Information[]; operat
     const visible = filtered.slice(0, visibleCount);
     const hasMore = visibleCount < filtered.length;
 
+    const isFiltered = filtered.length !== items.length;
+
     return (
         <Box>
-            <Box sx={{display: 'flex', alignItems: 'center', gap: 1, py: 1, px: 2}}>
-                <Typography variant="body2" sx={{color: 'text.disabled'}}>
-                    {filtered.length === items.length
-                        ? `${items.length} operation${items.length !== 1 ? 's' : ''}`
-                        : `${filtered.length} of ${items.length} operations`}
-                </Typography>
-            </Box>
+            {isFiltered && (
+                <Box sx={{display: 'flex', alignItems: 'center', gap: 1, py: 1, px: 2}}>
+                    <Typography variant="body2" sx={{color: 'text.disabled'}}>
+                        {`${filtered.length} of ${items.length} operations`}
+                    </Typography>
+                </Box>
+            )}
             {visible.map((item, index) => {
                 const expanded = expandedIndex === index;
                 const hasArgs = Object.keys(item.args).length > 0;
@@ -191,7 +193,13 @@ export const FilesystemPanel = ({data}: FilesystemPanelProps) => {
         <Box>
             <TabContext value={value}>
                 <Box sx={{borderBottom: 1, borderColor: 'divider', display: 'flex', alignItems: 'center', gap: 2}}>
-                    <StyledTabList onChange={handleChange} sx={{flex: 1, minWidth: 0}}>
+                    <StyledTabList
+                        onChange={handleChange}
+                        variant="scrollable"
+                        scrollButtons="auto"
+                        allowScrollButtonsMobile
+                        sx={{flex: 1, minWidth: 0}}
+                    >
                         {tabs.map((tab) => {
                             const count = (data as any)[tab]?.length ?? 0;
                             const meta = operationMeta(tab);

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/FilesystemPanel.tsx
@@ -17,37 +17,6 @@ type FilesystemPanelProps = {data: {[key in Operation]: Information}[]};
 // Styled components
 // ---------------------------------------------------------------------------
 
-const SummaryGrid = styled(Box)(({theme}) => ({
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(130px, 1fr))',
-    gap: theme.spacing(1.5),
-    padding: theme.spacing(2),
-}));
-
-const SummaryCard = styled(Box)(({theme}) => ({
-    padding: theme.spacing(1.5, 2),
-    borderRadius: Number(theme.shape.borderRadius) * 1.5,
-    border: `1px solid ${theme.palette.divider}`,
-    backgroundColor: theme.palette.background.paper,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(0.5),
-}));
-
-const SummaryLabel = styled(Typography)(({theme}) => ({
-    fontSize: '11px',
-    fontWeight: 600,
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.5px',
-    color: theme.palette.text.disabled,
-}));
-
-const SummaryValue = styled(Typography)(({theme}) => ({
-    fontFamily: theme.adp.fontFamilyMono,
-    fontWeight: 700,
-    fontSize: '20px',
-}));
-
 const FileRow = styled(Box, {shouldForwardProp: (p) => p !== 'expanded'})<{expanded?: boolean}>(
     ({theme, expanded}) => ({
         display: 'flex',
@@ -219,34 +188,8 @@ export const FilesystemPanel = ({data}: FilesystemPanelProps) => {
         return <EmptyState icon="folder_open" title="No filesystem operations found" />;
     }
 
-    const totalOps = tabs.reduce((sum, tab) => sum + ((data as any)[tab]?.length ?? 0), 0);
-
     return (
         <Box>
-            <SummaryGrid>
-                <SummaryCard>
-                    <SummaryLabel>Total Operations</SummaryLabel>
-                    <SummaryValue>{totalOps}</SummaryValue>
-                </SummaryCard>
-                {tabs.map((tab) => {
-                    const count = (data as any)[tab]?.length ?? 0;
-                    const meta = operationMeta(tab);
-                    return (
-                        <SummaryCard key={tab}>
-                            <SummaryLabel>
-                                <Box sx={{display: 'flex', alignItems: 'center', gap: 0.5}}>
-                                    <Icon sx={{fontSize: 14, color: `${meta.color}.main`}}>{meta.icon}</Icon>
-                                    {tab}
-                                </Box>
-                            </SummaryLabel>
-                            <SummaryValue sx={{color: count > 0 ? 'text.primary' : 'text.disabled'}}>
-                                {count}
-                            </SummaryValue>
-                        </SummaryCard>
-                    );
-                })}
-            </SummaryGrid>
-
             <SectionTitle action={<FilterInput value={filter} onChange={setFilter} placeholder="Filter by path..." />}>
                 Operations
             </SectionTitle>

--- a/libs/frontend/packages/sdk/src/Helper/openInNewTabOnModifier.test.ts
+++ b/libs/frontend/packages/sdk/src/Helper/openInNewTabOnModifier.test.ts
@@ -1,0 +1,48 @@
+import {MouseEvent} from 'react';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {openInNewTabOnModifier} from './openInNewTabOnModifier';
+
+const makeEvent = (modifiers: Partial<{ctrlKey: boolean; metaKey: boolean}> = {}) => {
+    const event = {ctrlKey: false, metaKey: false, stopPropagation: vi.fn(), preventDefault: vi.fn(), ...modifiers};
+    return event as unknown as MouseEvent;
+};
+
+describe('openInNewTabOnModifier', () => {
+    const originalOpen = window.open;
+    afterEach(() => {
+        window.open = originalOpen;
+    });
+
+    it('returns false and leaves the event untouched when no modifier is pressed', () => {
+        const open = vi.fn();
+        window.open = open;
+        const event = makeEvent();
+
+        expect(openInNewTabOnModifier(event, '/debug?x=1')).toBe(false);
+        expect(open).not.toHaveBeenCalled();
+        expect(event.stopPropagation).not.toHaveBeenCalled();
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('opens a new tab and stops the event when Ctrl is held', () => {
+        const open = vi.fn();
+        window.open = open;
+        const event = makeEvent({ctrlKey: true});
+
+        expect(openInNewTabOnModifier(event, '/debug?x=1')).toBe(true);
+        expect(open).toHaveBeenCalledWith('/debug?x=1', '_blank', 'noopener,noreferrer');
+        expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens a new tab and stops the event when Cmd (metaKey) is held', () => {
+        const open = vi.fn();
+        window.open = open;
+        const event = makeEvent({metaKey: true});
+
+        expect(openInNewTabOnModifier(event, '/debug?x=1')).toBe(true);
+        expect(open).toHaveBeenCalledWith('/debug?x=1', '_blank', 'noopener,noreferrer');
+        expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+});

--- a/libs/frontend/packages/sdk/src/Helper/openInNewTabOnModifier.ts
+++ b/libs/frontend/packages/sdk/src/Helper/openInNewTabOnModifier.ts
@@ -1,0 +1,15 @@
+import {MouseEvent} from 'react';
+
+/**
+ * If the click has Ctrl (Linux/Windows) or Cmd (macOS) held down, open `url`
+ * in a new tab with `noopener,noreferrer`, stop event propagation and default,
+ * and return `true`. Otherwise return `false` without touching the event, so
+ * the caller can run its normal-click behaviour.
+ */
+export const openInNewTabOnModifier = (event: MouseEvent, url: string): boolean => {
+    if (!(event.ctrlKey || event.metaKey)) return false;
+    window.open(url, '_blank', 'noopener,noreferrer');
+    event.stopPropagation();
+    event.preventDefault();
+    return true;
+};

--- a/libs/frontend/packages/sdk/src/Helper/panelMountPath.test.ts
+++ b/libs/frontend/packages/sdk/src/Helper/panelMountPath.test.ts
@@ -1,0 +1,63 @@
+import {afterEach, describe, expect, it} from 'vitest';
+import {panelMountPath, panelPagePath} from './panelMountPath';
+
+const setMount = (value: string | undefined) => {
+    if (value === undefined) {
+        delete window.__adp_panel_url;
+    } else {
+        window.__adp_panel_url = value;
+    }
+};
+
+describe('panelMountPath', () => {
+    afterEach(() => setMount(undefined));
+
+    it('defaults to /debug when no global is set', () => {
+        expect(panelMountPath()).toBe('/debug');
+    });
+
+    it('reads the mount path from window.__adp_panel_url', () => {
+        setMount('/adp');
+        expect(panelMountPath()).toBe('/adp');
+    });
+
+    it('strips trailing slashes from the configured mount path', () => {
+        setMount('/adp///');
+        expect(panelMountPath()).toBe('/adp');
+    });
+});
+
+describe('panelPagePath', () => {
+    afterEach(() => setMount(undefined));
+
+    it('appends a bare query string directly to the mount path', () => {
+        // /debug + ?foo=bar — must NOT become /debug/?foo=bar (404 against the adapter route).
+        expect(panelPagePath('?foo=bar')).toBe('/debug?foo=bar');
+    });
+
+    it('appends a bare hash fragment directly to the mount path', () => {
+        expect(panelPagePath('#section')).toBe('/debug#section');
+    });
+
+    it('returns just the mount path when input is empty', () => {
+        expect(panelPagePath('')).toBe('/debug');
+    });
+
+    it('returns just the mount path when called with no arguments', () => {
+        expect(panelPagePath()).toBe('/debug');
+    });
+
+    it('prepends a leading slash to sub-paths that lack one', () => {
+        expect(panelPagePath('inspector/files?class=Foo')).toBe('/debug/inspector/files?class=Foo');
+    });
+
+    it('preserves an explicit leading slash on the sub-path', () => {
+        expect(panelPagePath('/inspector/files?class=Foo')).toBe('/debug/inspector/files?class=Foo');
+    });
+
+    it('honors a custom mount path from window.__adp_panel_url', () => {
+        setMount('/adp');
+        expect(panelPagePath('?foo=1')).toBe('/adp?foo=1');
+        expect(panelPagePath('/inspector/files')).toBe('/adp/inspector/files');
+    });
+});

--- a/libs/frontend/packages/sdk/src/Helper/panelMountPath.ts
+++ b/libs/frontend/packages/sdk/src/Helper/panelMountPath.ts
@@ -30,11 +30,20 @@ export const panelMountPath = (): string => {
  * Build a `target="_top"` URL that navigates the host window to a page inside
  * the ADP panel, correctly prefixed with the panel mount path.
  *
- * Example: `panelPagePath('/inspector/files?class=Foo')` →
- *   `/debug/inspector/files?class=Foo` (when the panel is mounted at `/debug`).
+ * Examples (panel mounted at `/debug`):
+ *   `panelPagePath('/inspector/files?class=Foo')` → `/debug/inspector/files?class=Foo`
+ *   `panelPagePath('?collector=Foo')`             → `/debug?collector=Foo`
+ *   `panelPagePath('')`                           → `/debug`
+ *
+ * A bare query string or empty input is appended directly so we hit the
+ * panel's root route (`/debug`), not `/debug/` which the adapter does not
+ * match as a catch-all path.
  */
-export const panelPagePath = (pathWithQuery: string): string => {
+export const panelPagePath = (pathWithQuery: string = ''): string => {
     const mount = panelMountPath();
+    if (pathWithQuery === '' || pathWithQuery.startsWith('?') || pathWithQuery.startsWith('#')) {
+        return mount + pathWithQuery;
+    }
     const normalised = pathWithQuery.startsWith('/') ? pathWithQuery : '/' + pathWithQuery;
     return mount + normalised;
 };

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Console/CommandItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Console/CommandItem.tsx
@@ -19,7 +19,7 @@ export const CommandItem = ({data}: CommandItemProps) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-        if (openInNewTabOnModifier(event, panelPagePath(`?debugEntry=${data.id}`))) return;
+        if (openInNewTabOnModifier(event, panelPagePath(`/debug?debugEntry=${data.id}`))) return;
         setAnchorEl(event.currentTarget);
     };
     const handleClose = () => setAnchorEl(null);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Console/CommandItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Console/CommandItem.tsx
@@ -19,7 +19,7 @@ export const CommandItem = ({data}: CommandItemProps) => {
     const open = Boolean(anchorEl);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
         if (event.ctrlKey || event.metaKey) {
-            window.open(panelPagePath(`/?debugEntry=${data.id}`), '_blank', 'noopener');
+            window.open(panelPagePath(`/?debugEntry=${data.id}`), '_blank', 'noopener,noreferrer');
             event.stopPropagation();
             event.preventDefault();
             return;

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Console/CommandItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Console/CommandItem.tsx
@@ -19,7 +19,7 @@ export const CommandItem = ({data}: CommandItemProps) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-        if (openInNewTabOnModifier(event, panelPagePath(`/?debugEntry=${data.id}`))) return;
+        if (openInNewTabOnModifier(event, panelPagePath(`?debugEntry=${data.id}`))) return;
         setAnchorEl(event.currentTarget);
     };
     const handleClose = () => setAnchorEl(null);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Console/CommandItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Console/CommandItem.tsx
@@ -1,5 +1,6 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {MuiColor} from '@app-dev-panel/sdk/Adapter/mui/types';
+import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import {DataObject, Input, Repeat, Terminal} from '@mui/icons-material';
 import {Chip, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip, Typography} from '@mui/material';
 import React, {useState} from 'react';
@@ -16,7 +17,15 @@ export const CommandItem = ({data}: CommandItemProps) => {
     }
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
-    const handleClick = (event: React.MouseEvent<HTMLElement>) => setAnchorEl(event.currentTarget);
+    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+        if (event.ctrlKey || event.metaKey) {
+            window.open(panelPagePath(`/?debugEntry=${data.id}`), '_blank', 'noopener');
+            event.stopPropagation();
+            event.preventDefault();
+            return;
+        }
+        setAnchorEl(event.currentTarget);
+    };
     const handleClose = () => setAnchorEl(null);
 
     return (

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Console/CommandItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Console/CommandItem.tsx
@@ -1,5 +1,6 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {MuiColor} from '@app-dev-panel/sdk/Adapter/mui/types';
+import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
 import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import {DataObject, Input, Repeat, Terminal} from '@mui/icons-material';
 import {Chip, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip, Typography} from '@mui/material';
@@ -18,12 +19,7 @@ export const CommandItem = ({data}: CommandItemProps) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-        if (event.ctrlKey || event.metaKey) {
-            window.open(panelPagePath(`/?debugEntry=${data.id}`), '_blank', 'noopener,noreferrer');
-            event.stopPropagation();
-            event.preventDefault();
-            return;
-        }
+        if (openInNewTabOnModifier(event, panelPagePath(`/?debugEntry=${data.id}`))) return;
         setAnchorEl(event.currentTarget);
     };
     const handleClose = () => setAnchorEl(null);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DatabaseItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DatabaseItem.tsx
@@ -1,5 +1,6 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
+import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
 import StorageIcon from '@mui/icons-material/Storage';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -30,11 +31,8 @@ export const DatabaseItem = ({data, iframeUrlHandler}: DatabaseItemProps) => {
                 variant={hasErrors ? 'filled' : 'outlined'}
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.DatabaseCollector}&debugEntry=${data.id}`;
-                    if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener,noreferrer');
-                    } else {
-                        iframeUrlHandler(url);
-                    }
+                    if (openInNewTabOnModifier(e, url)) return;
+                    iframeUrlHandler(url);
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DatabaseItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DatabaseItem.tsx
@@ -32,7 +32,7 @@ export const DatabaseItem = ({data, iframeUrlHandler}: DatabaseItemProps) => {
                 variant={hasErrors ? 'filled' : 'outlined'}
                 onClick={(e) => {
                     const url = panelPagePath(
-                        `/?collector=${encodeURIComponent(CollectorsMap.DatabaseCollector)}&debugEntry=${data.id}`,
+                        `/debug?collector=${encodeURIComponent(CollectorsMap.DatabaseCollector)}&debugEntry=${data.id}`,
                     );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DatabaseItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DatabaseItem.tsx
@@ -31,7 +31,7 @@ export const DatabaseItem = ({data, iframeUrlHandler}: DatabaseItemProps) => {
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.DatabaseCollector}&debugEntry=${data.id}`;
                     if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener');
+                        window.open(url, '_blank', 'noopener,noreferrer');
                     } else {
                         iframeUrlHandler(url);
                     }

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DatabaseItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DatabaseItem.tsx
@@ -29,7 +29,12 @@ export const DatabaseItem = ({data, iframeUrlHandler}: DatabaseItemProps) => {
                 color={hasErrors ? 'error' : 'default'}
                 variant={hasErrors ? 'filled' : 'outlined'}
                 onClick={(e) => {
-                    iframeUrlHandler(`/debug?collector=${CollectorsMap.DatabaseCollector}&debugEntry=${data.id}`);
+                    const url = `/debug?collector=${CollectorsMap.DatabaseCollector}&debugEntry=${data.id}`;
+                    if (e.ctrlKey || e.metaKey) {
+                        window.open(url, '_blank', 'noopener');
+                    } else {
+                        iframeUrlHandler(url);
+                    }
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DatabaseItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DatabaseItem.tsx
@@ -1,6 +1,7 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
 import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
+import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import StorageIcon from '@mui/icons-material/Storage';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -30,7 +31,9 @@ export const DatabaseItem = ({data, iframeUrlHandler}: DatabaseItemProps) => {
                 color={hasErrors ? 'error' : 'default'}
                 variant={hasErrors ? 'filled' : 'outlined'}
                 onClick={(e) => {
-                    const url = `/debug?collector=${CollectorsMap.DatabaseCollector}&debugEntry=${data.id}`;
+                    const url = panelPagePath(
+                        `/?collector=${encodeURIComponent(CollectorsMap.DatabaseCollector)}&debugEntry=${data.id}`,
+                    );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);
                     e.stopPropagation();

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DeprecationItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DeprecationItem.tsx
@@ -22,7 +22,7 @@ export const DeprecationItem = ({data, iframeUrlHandler}: DeprecationItemProps) 
                 variant="filled"
                 onClick={(e) => {
                     const url = panelPagePath(
-                        `/?collector=${encodeURIComponent(CollectorsMap.DeprecationCollector)}&debugEntry=${data.id}`,
+                        `/debug?collector=${encodeURIComponent(CollectorsMap.DeprecationCollector)}&debugEntry=${data.id}`,
                     );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DeprecationItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DeprecationItem.tsx
@@ -19,7 +19,12 @@ export const DeprecationItem = ({data, iframeUrlHandler}: DeprecationItemProps) 
                 color="warning"
                 variant="filled"
                 onClick={(e) => {
-                    iframeUrlHandler(`/debug?collector=${CollectorsMap.DeprecationCollector}&debugEntry=${data.id}`);
+                    const url = `/debug?collector=${CollectorsMap.DeprecationCollector}&debugEntry=${data.id}`;
+                    if (e.ctrlKey || e.metaKey) {
+                        window.open(url, '_blank', 'noopener');
+                    } else {
+                        iframeUrlHandler(url);
+                    }
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DeprecationItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DeprecationItem.tsx
@@ -1,5 +1,6 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
+import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -20,11 +21,8 @@ export const DeprecationItem = ({data, iframeUrlHandler}: DeprecationItemProps) 
                 variant="filled"
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.DeprecationCollector}&debugEntry=${data.id}`;
-                    if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener,noreferrer');
-                    } else {
-                        iframeUrlHandler(url);
-                    }
+                    if (openInNewTabOnModifier(e, url)) return;
+                    iframeUrlHandler(url);
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DeprecationItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DeprecationItem.tsx
@@ -1,6 +1,7 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
 import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
+import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -20,7 +21,9 @@ export const DeprecationItem = ({data, iframeUrlHandler}: DeprecationItemProps) 
                 color="warning"
                 variant="filled"
                 onClick={(e) => {
-                    const url = `/debug?collector=${CollectorsMap.DeprecationCollector}&debugEntry=${data.id}`;
+                    const url = panelPagePath(
+                        `/?collector=${encodeURIComponent(CollectorsMap.DeprecationCollector)}&debugEntry=${data.id}`,
+                    );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);
                     e.stopPropagation();

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DeprecationItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/DeprecationItem.tsx
@@ -21,7 +21,7 @@ export const DeprecationItem = ({data, iframeUrlHandler}: DeprecationItemProps) 
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.DeprecationCollector}&debugEntry=${data.id}`;
                     if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener');
+                        window.open(url, '_blank', 'noopener,noreferrer');
                     } else {
                         iframeUrlHandler(url);
                     }

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.test.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.test.tsx
@@ -1,0 +1,63 @@
+import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
+import {renderWithProviders} from '@app-dev-panel/sdk/test-utils';
+import {EventsItem} from '@app-dev-panel/toolbar/Module/Toolbar/Component/Toolbar/EventsItem';
+import {fireEvent, screen} from '@testing-library/react';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+const makeEntry = (event?: DebugEntry['event']): DebugEntry => ({id: 'entry-42', collectors: [], event}) as DebugEntry;
+
+describe('EventsItem URL shape', () => {
+    const originalOpen = window.open;
+    afterEach(() => {
+        window.open = originalOpen;
+        delete window.__adp_panel_url;
+    });
+
+    it('renders nothing when there are no events', () => {
+        const {container} = renderWithProviders(
+            <EventsItem data={makeEntry({total: 0})} iframeUrlHandler={() => {}} />,
+        );
+        expect(container.querySelector('.MuiChip-root')).toBeNull();
+    });
+
+    it('passes {mount}/debug?collector=...&debugEntry=... to the iframe handler on a normal click', () => {
+        const handler = vi.fn();
+        renderWithProviders(<EventsItem data={makeEntry({total: 3})} iframeUrlHandler={handler} />);
+
+        fireEvent.click(screen.getByText('Events 3'));
+
+        // Both /debug segments matter: first is the ADP mount, second is the panel-internal
+        // collector route.
+        expect(handler).toHaveBeenCalledWith(
+            '/debug/debug?collector=AppDevPanel%5CKernel%5CCollector%5CEventCollector&debugEntry=entry-42',
+        );
+    });
+
+    it('opens the same URL in a new tab on Ctrl+click and does not call the iframe handler', () => {
+        const handler = vi.fn();
+        const open = vi.fn();
+        window.open = open;
+        renderWithProviders(<EventsItem data={makeEntry({total: 3})} iframeUrlHandler={handler} />);
+
+        fireEvent.click(screen.getByText('Events 3'), {ctrlKey: true});
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(open).toHaveBeenCalledWith(
+            '/debug/debug?collector=AppDevPanel%5CKernel%5CCollector%5CEventCollector&debugEntry=entry-42',
+            '_blank',
+            'noopener,noreferrer',
+        );
+    });
+
+    it('honors a custom window.__adp_panel_url mount path', () => {
+        window.__adp_panel_url = '/adp';
+        const handler = vi.fn();
+        renderWithProviders(<EventsItem data={makeEntry({total: 1})} iframeUrlHandler={handler} />);
+
+        fireEvent.click(screen.getByText('Events 1'));
+
+        expect(handler).toHaveBeenCalledWith(
+            '/adp/debug?collector=AppDevPanel%5CKernel%5CCollector%5CEventCollector&debugEntry=entry-42',
+        );
+    });
+});

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.tsx
@@ -1,5 +1,6 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
+import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
 import BoltIcon from '@mui/icons-material/Bolt';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -20,11 +21,8 @@ export const EventsItem = ({data, iframeUrlHandler}: EventsItemProps) => {
                 variant="outlined"
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.EventCollector}&debugEntry=${data.id}`;
-                    if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener,noreferrer');
-                    } else {
-                        iframeUrlHandler(url);
-                    }
+                    if (openInNewTabOnModifier(e, url)) return;
+                    iframeUrlHandler(url);
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.tsx
@@ -21,7 +21,7 @@ export const EventsItem = ({data, iframeUrlHandler}: EventsItemProps) => {
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.EventCollector}&debugEntry=${data.id}`;
                     if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener');
+                        window.open(url, '_blank', 'noopener,noreferrer');
                     } else {
                         iframeUrlHandler(url);
                     }

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.tsx
@@ -1,6 +1,7 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
 import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
+import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import BoltIcon from '@mui/icons-material/Bolt';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -20,7 +21,9 @@ export const EventsItem = ({data, iframeUrlHandler}: EventsItemProps) => {
                 size="small"
                 variant="outlined"
                 onClick={(e) => {
-                    const url = `/debug?collector=${CollectorsMap.EventCollector}&debugEntry=${data.id}`;
+                    const url = panelPagePath(
+                        `/?collector=${encodeURIComponent(CollectorsMap.EventCollector)}&debugEntry=${data.id}`,
+                    );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);
                     e.stopPropagation();

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.tsx
@@ -22,7 +22,7 @@ export const EventsItem = ({data, iframeUrlHandler}: EventsItemProps) => {
                 variant="outlined"
                 onClick={(e) => {
                     const url = panelPagePath(
-                        `/?collector=${encodeURIComponent(CollectorsMap.EventCollector)}&debugEntry=${data.id}`,
+                        `/debug?collector=${encodeURIComponent(CollectorsMap.EventCollector)}&debugEntry=${data.id}`,
                     );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/EventsItem.tsx
@@ -19,7 +19,12 @@ export const EventsItem = ({data, iframeUrlHandler}: EventsItemProps) => {
                 size="small"
                 variant="outlined"
                 onClick={(e) => {
-                    iframeUrlHandler(`/debug?collector=${CollectorsMap.EventCollector}&debugEntry=${data.id}`);
+                    const url = `/debug?collector=${CollectorsMap.EventCollector}&debugEntry=${data.id}`;
+                    if (e.ctrlKey || e.metaKey) {
+                        window.open(url, '_blank', 'noopener');
+                    } else {
+                        iframeUrlHandler(url);
+                    }
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ExceptionItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ExceptionItem.tsx
@@ -1,5 +1,6 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {parseFilePath, parseFilename} from '@app-dev-panel/sdk/Helper/filePathParser';
+import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
 import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import {formatFqcn} from '@app-dev-panel/sdk/Helper/phpClassName';
 import {useEditorUrl} from '@app-dev-panel/sdk/Helper/useEditorUrl';
@@ -47,10 +48,7 @@ export const ExceptionItem = ({data}: ExceptionItemProps) => {
     const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
         event.stopPropagation();
         event.preventDefault();
-        if (event.ctrlKey || event.metaKey) {
-            window.open(classExplorerUrl, '_blank', 'noopener,noreferrer');
-            return;
-        }
+        if (openInNewTabOnModifier(event, classExplorerUrl)) return;
         setAnchorEl(event.currentTarget);
     };
     const handleClose = () => setAnchorEl(null);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ExceptionItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ExceptionItem.tsx
@@ -48,7 +48,7 @@ export const ExceptionItem = ({data}: ExceptionItemProps) => {
         event.stopPropagation();
         event.preventDefault();
         if (event.ctrlKey || event.metaKey) {
-            window.open(classExplorerUrl, '_blank', 'noopener');
+            window.open(classExplorerUrl, '_blank', 'noopener,noreferrer');
             return;
         }
         setAnchorEl(event.currentTarget);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ExceptionItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ExceptionItem.tsx
@@ -47,6 +47,10 @@ export const ExceptionItem = ({data}: ExceptionItemProps) => {
     const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
         event.stopPropagation();
         event.preventDefault();
+        if (event.ctrlKey || event.metaKey) {
+            window.open(classExplorerUrl, '_blank', 'noopener');
+            return;
+        }
         setAnchorEl(event.currentTarget);
     };
     const handleClose = () => setAnchorEl(null);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/HttpClientItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/HttpClientItem.tsx
@@ -1,5 +1,6 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
+import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
 import HttpIcon from '@mui/icons-material/Http';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -22,11 +23,8 @@ export const HttpClientItem = ({data, iframeUrlHandler}: HttpClientItemProps) =>
                 variant="outlined"
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.HttpClientCollector}&debugEntry=${data.id}`;
-                    if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener,noreferrer');
-                    } else {
-                        iframeUrlHandler(url);
-                    }
+                    if (openInNewTabOnModifier(e, url)) return;
+                    iframeUrlHandler(url);
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/HttpClientItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/HttpClientItem.tsx
@@ -24,7 +24,7 @@ export const HttpClientItem = ({data, iframeUrlHandler}: HttpClientItemProps) =>
                 variant="outlined"
                 onClick={(e) => {
                     const url = panelPagePath(
-                        `/?collector=${encodeURIComponent(CollectorsMap.HttpClientCollector)}&debugEntry=${data.id}`,
+                        `/debug?collector=${encodeURIComponent(CollectorsMap.HttpClientCollector)}&debugEntry=${data.id}`,
                     );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/HttpClientItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/HttpClientItem.tsx
@@ -21,7 +21,12 @@ export const HttpClientItem = ({data, iframeUrlHandler}: HttpClientItemProps) =>
                 size="small"
                 variant="outlined"
                 onClick={(e) => {
-                    iframeUrlHandler(`/debug?collector=${CollectorsMap.HttpClientCollector}&debugEntry=${data.id}`);
+                    const url = `/debug?collector=${CollectorsMap.HttpClientCollector}&debugEntry=${data.id}`;
+                    if (e.ctrlKey || e.metaKey) {
+                        window.open(url, '_blank', 'noopener');
+                    } else {
+                        iframeUrlHandler(url);
+                    }
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/HttpClientItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/HttpClientItem.tsx
@@ -23,7 +23,7 @@ export const HttpClientItem = ({data, iframeUrlHandler}: HttpClientItemProps) =>
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.HttpClientCollector}&debugEntry=${data.id}`;
                     if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener');
+                        window.open(url, '_blank', 'noopener,noreferrer');
                     } else {
                         iframeUrlHandler(url);
                     }

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/HttpClientItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/HttpClientItem.tsx
@@ -1,6 +1,7 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
 import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
+import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import HttpIcon from '@mui/icons-material/Http';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -22,7 +23,9 @@ export const HttpClientItem = ({data, iframeUrlHandler}: HttpClientItemProps) =>
                 size="small"
                 variant="outlined"
                 onClick={(e) => {
-                    const url = `/debug?collector=${CollectorsMap.HttpClientCollector}&debugEntry=${data.id}`;
+                    const url = panelPagePath(
+                        `/?collector=${encodeURIComponent(CollectorsMap.HttpClientCollector)}&debugEntry=${data.id}`,
+                    );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);
                     e.stopPropagation();

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.test.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.test.tsx
@@ -55,7 +55,7 @@ describe('LogsItem', () => {
 
         fireEvent.click(screen.getByText('1'));
         const errClickUrl = handler.mock.calls[handler.mock.calls.length - 1][0] as string;
-        expect(errClickUrl).toContain('collector=AppDevPanel\\Kernel\\Collector\\LogCollector');
+        expect(errClickUrl).toContain('collector=AppDevPanel%5CKernel%5CCollector%5CLogCollector');
         expect(errClickUrl).toContain('debugEntry=entry-123');
         expect(errClickUrl).toContain('&level=emergency,alert,critical,error');
 

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.test.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.test.tsx
@@ -55,9 +55,14 @@ describe('LogsItem', () => {
 
         fireEvent.click(screen.getByText('1'));
         const errClickUrl = handler.mock.calls[handler.mock.calls.length - 1][0] as string;
-        expect(errClickUrl).toContain('collector=AppDevPanel%5CKernel%5CCollector%5CLogCollector');
-        expect(errClickUrl).toContain('debugEntry=entry-123');
-        expect(errClickUrl).toContain('&level=emergency,alert,critical,error');
+        // The URL must be: {mount}/debug?collector=<encoded>&debugEntry=<id>[&level=...]
+        // The first `/debug` is the ADP mount path (here the default); the second `/debug`
+        // is the panel-internal React Router path (the collector viewer). Losing the second
+        // `/debug` would mean opening the panel home page instead of the Log collector view.
+        expect(errClickUrl).toBe(
+            '/debug/debug?collector=AppDevPanel%5CKernel%5CCollector%5CLogCollector' +
+                '&debugEntry=entry-123&level=emergency,alert,critical,error',
+        );
 
         fireEvent.click(screen.getByText('3'));
         const warnClickUrl = handler.mock.calls[handler.mock.calls.length - 1][0] as string;
@@ -75,6 +80,7 @@ describe('LogsItem', () => {
         fireEvent.click(screen.getByText('Logs'));
         expect(handler).toHaveBeenCalled();
         const url = handler.mock.calls[0][0] as string;
+        expect(url).toBe('/debug/debug?collector=AppDevPanel%5CKernel%5CCollector%5CLogCollector&debugEntry=entry-123');
         expect(url).not.toContain('&level=');
     });
 

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
@@ -68,7 +68,7 @@ export const LogsItem = ({data, iframeUrlHandler}: LogsItemProps) => {
                                     onClick={(e) => {
                                         const url = buildUrl(data.id, LOG_LEVEL_GROUPS[group]);
                                         if (e.ctrlKey || e.metaKey) {
-                                            window.open(url, '_blank', 'noopener');
+                                            window.open(url, '_blank', 'noopener,noreferrer');
                                         } else {
                                             iframeUrlHandler(url);
                                         }
@@ -95,7 +95,7 @@ export const LogsItem = ({data, iframeUrlHandler}: LogsItemProps) => {
                 onClick={(e) => {
                     const url = buildUrl(data.id);
                     if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener');
+                        window.open(url, '_blank', 'noopener,noreferrer');
                     } else {
                         iframeUrlHandler(url);
                     }

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
@@ -1,6 +1,7 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
 import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
+import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import {
     LOG_LEVEL_GROUP_ORDER,
     LOG_LEVEL_GROUPS,
@@ -20,8 +21,9 @@ const GROUP_COLOR: Record<LogLevelGroup, string> = {
 };
 
 const buildUrl = (entryId: string, levels?: LogLevel[]) => {
-    const base = `/debug?collector=${CollectorsMap.LogCollector}&debugEntry=${entryId}`;
-    return levels && levels.length > 0 ? `${base}&level=${levels.join(',')}` : base;
+    const query = `collector=${encodeURIComponent(CollectorsMap.LogCollector)}&debugEntry=${entryId}`;
+    const withLevels = levels && levels.length > 0 ? `${query}&level=${levels.join(',')}` : query;
+    return panelPagePath(`/?${withLevels}`);
 };
 
 export const LogsItem = ({data, iframeUrlHandler}: LogsItemProps) => {

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
@@ -23,7 +23,7 @@ const GROUP_COLOR: Record<LogLevelGroup, string> = {
 const buildUrl = (entryId: string, levels?: LogLevel[]) => {
     const query = `collector=${encodeURIComponent(CollectorsMap.LogCollector)}&debugEntry=${entryId}`;
     const withLevels = levels && levels.length > 0 ? `${query}&level=${levels.join(',')}` : query;
-    return panelPagePath(`/?${withLevels}`);
+    return panelPagePath(`?${withLevels}`);
 };
 
 export const LogsItem = ({data, iframeUrlHandler}: LogsItemProps) => {

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
@@ -1,5 +1,6 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
+import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
 import {
     LOG_LEVEL_GROUP_ORDER,
     LOG_LEVEL_GROUPS,
@@ -67,11 +68,8 @@ export const LogsItem = ({data, iframeUrlHandler}: LogsItemProps) => {
                                     component="span"
                                     onClick={(e) => {
                                         const url = buildUrl(data.id, LOG_LEVEL_GROUPS[group]);
-                                        if (e.ctrlKey || e.metaKey) {
-                                            window.open(url, '_blank', 'noopener,noreferrer');
-                                        } else {
-                                            iframeUrlHandler(url);
-                                        }
+                                        if (openInNewTabOnModifier(e, url)) return;
+                                        iframeUrlHandler(url);
                                         e.stopPropagation();
                                         e.preventDefault();
                                     }}
@@ -94,11 +92,8 @@ export const LogsItem = ({data, iframeUrlHandler}: LogsItemProps) => {
                 variant="outlined"
                 onClick={(e) => {
                     const url = buildUrl(data.id);
-                    if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener,noreferrer');
-                    } else {
-                        iframeUrlHandler(url);
-                    }
+                    if (openInNewTabOnModifier(e, url)) return;
+                    iframeUrlHandler(url);
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
@@ -23,7 +23,7 @@ const GROUP_COLOR: Record<LogLevelGroup, string> = {
 const buildUrl = (entryId: string, levels?: LogLevel[]) => {
     const query = `collector=${encodeURIComponent(CollectorsMap.LogCollector)}&debugEntry=${entryId}`;
     const withLevels = levels && levels.length > 0 ? `${query}&level=${levels.join(',')}` : query;
-    return panelPagePath(`?${withLevels}`);
+    return panelPagePath(`/debug?${withLevels}`);
 };
 
 export const LogsItem = ({data, iframeUrlHandler}: LogsItemProps) => {

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/LogsItem.tsx
@@ -66,7 +66,12 @@ export const LogsItem = ({data, iframeUrlHandler}: LogsItemProps) => {
                                 <Box
                                     component="span"
                                     onClick={(e) => {
-                                        iframeUrlHandler(buildUrl(data.id, LOG_LEVEL_GROUPS[group]));
+                                        const url = buildUrl(data.id, LOG_LEVEL_GROUPS[group]);
+                                        if (e.ctrlKey || e.metaKey) {
+                                            window.open(url, '_blank', 'noopener');
+                                        } else {
+                                            iframeUrlHandler(url);
+                                        }
                                         e.stopPropagation();
                                         e.preventDefault();
                                     }}
@@ -88,7 +93,12 @@ export const LogsItem = ({data, iframeUrlHandler}: LogsItemProps) => {
                 size="small"
                 variant="outlined"
                 onClick={(e) => {
-                    iframeUrlHandler(buildUrl(data.id));
+                    const url = buildUrl(data.id);
+                    if (e.ctrlKey || e.metaKey) {
+                        window.open(url, '_blank', 'noopener');
+                    } else {
+                        iframeUrlHandler(url);
+                    }
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
@@ -21,7 +21,12 @@ export const MemoryItem = ({data, iframeUrlHandler}: MemoryItemProps) => {
                 size="small"
                 variant="outlined"
                 onClick={(e) => {
-                    iframeUrlHandler(`/debug?collector=${collector}&debugEntry=${data.id}`);
+                    const url = `/debug?collector=${collector}&debugEntry=${data.id}`;
+                    if (e.ctrlKey || e.metaKey) {
+                        window.open(url, '_blank', 'noopener');
+                    } else {
+                        iframeUrlHandler(url);
+                    }
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
@@ -23,7 +23,9 @@ export const MemoryItem = ({data, iframeUrlHandler}: MemoryItemProps) => {
                 size="small"
                 variant="outlined"
                 onClick={(e) => {
-                    const url = panelPagePath(`?collector=${encodeURIComponent(collector)}&debugEntry=${data.id}`);
+                    const url = panelPagePath(
+                        `/debug?collector=${encodeURIComponent(collector)}&debugEntry=${data.id}`,
+                    );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);
                     e.stopPropagation();

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
@@ -3,6 +3,7 @@ import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
 import {isDebugEntryAboutWeb} from '@app-dev-panel/sdk/Helper/debugEntry';
 import {formatBytes} from '@app-dev-panel/sdk/Helper/formatBytes';
 import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
+import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import MemoryIcon from '@mui/icons-material/Memory';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -22,7 +23,7 @@ export const MemoryItem = ({data, iframeUrlHandler}: MemoryItemProps) => {
                 size="small"
                 variant="outlined"
                 onClick={(e) => {
-                    const url = `/debug?collector=${collector}&debugEntry=${data.id}`;
+                    const url = panelPagePath(`/?collector=${encodeURIComponent(collector)}&debugEntry=${data.id}`);
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);
                     e.stopPropagation();

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
@@ -23,7 +23,7 @@ export const MemoryItem = ({data, iframeUrlHandler}: MemoryItemProps) => {
                 size="small"
                 variant="outlined"
                 onClick={(e) => {
-                    const url = panelPagePath(`/?collector=${encodeURIComponent(collector)}&debugEntry=${data.id}`);
+                    const url = panelPagePath(`?collector=${encodeURIComponent(collector)}&debugEntry=${data.id}`);
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);
                     e.stopPropagation();

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
@@ -23,7 +23,7 @@ export const MemoryItem = ({data, iframeUrlHandler}: MemoryItemProps) => {
                 onClick={(e) => {
                     const url = `/debug?collector=${collector}&debugEntry=${data.id}`;
                     if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener');
+                        window.open(url, '_blank', 'noopener,noreferrer');
                     } else {
                         iframeUrlHandler(url);
                     }

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/MemoryItem.tsx
@@ -2,6 +2,7 @@ import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
 import {isDebugEntryAboutWeb} from '@app-dev-panel/sdk/Helper/debugEntry';
 import {formatBytes} from '@app-dev-panel/sdk/Helper/formatBytes';
+import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
 import MemoryIcon from '@mui/icons-material/Memory';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -22,11 +23,8 @@ export const MemoryItem = ({data, iframeUrlHandler}: MemoryItemProps) => {
                 variant="outlined"
                 onClick={(e) => {
                     const url = `/debug?collector=${collector}&debugEntry=${data.id}`;
-                    if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener,noreferrer');
-                    } else {
-                        iframeUrlHandler(url);
-                    }
+                    if (openInNewTabOnModifier(e, url)) return;
+                    iframeUrlHandler(url);
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/RequestTimeItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/RequestTimeItem.tsx
@@ -19,7 +19,7 @@ export const RequestTimeItem = ({data, iframeUrlHandler}: RequestTimeItemProps) 
                 variant="outlined"
                 onClick={(e) => {
                     const url = panelPagePath(
-                        `/?collector=${encodeURIComponent(CollectorsMap.TimelineCollector)}&debugEntry=${data.id}`,
+                        `/debug?collector=${encodeURIComponent(CollectorsMap.TimelineCollector)}&debugEntry=${data.id}`,
                     );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/RequestTimeItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/RequestTimeItem.tsx
@@ -18,7 +18,7 @@ export const RequestTimeItem = ({data, iframeUrlHandler}: RequestTimeItemProps) 
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.TimelineCollector}&debugEntry=${data.id}`;
                     if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener');
+                        window.open(url, '_blank', 'noopener,noreferrer');
                     } else {
                         iframeUrlHandler(url);
                     }

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/RequestTimeItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/RequestTimeItem.tsx
@@ -16,7 +16,12 @@ export const RequestTimeItem = ({data, iframeUrlHandler}: RequestTimeItemProps) 
                 size="small"
                 variant="outlined"
                 onClick={(e) => {
-                    iframeUrlHandler(`/debug?collector=${CollectorsMap.TimelineCollector}&debugEntry=${data.id}`);
+                    const url = `/debug?collector=${CollectorsMap.TimelineCollector}&debugEntry=${data.id}`;
+                    if (e.ctrlKey || e.metaKey) {
+                        window.open(url, '_blank', 'noopener');
+                    } else {
+                        iframeUrlHandler(url);
+                    }
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/RequestTimeItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/RequestTimeItem.tsx
@@ -1,5 +1,6 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
+import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -17,11 +18,8 @@ export const RequestTimeItem = ({data, iframeUrlHandler}: RequestTimeItemProps) 
                 variant="outlined"
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.TimelineCollector}&debugEntry=${data.id}`;
-                    if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener,noreferrer');
-                    } else {
-                        iframeUrlHandler(url);
-                    }
+                    if (openInNewTabOnModifier(e, url)) return;
+                    iframeUrlHandler(url);
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/RequestTimeItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/RequestTimeItem.tsx
@@ -1,6 +1,7 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
 import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
+import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import {Chip, Tooltip} from '@mui/material';
 
@@ -17,7 +18,9 @@ export const RequestTimeItem = ({data, iframeUrlHandler}: RequestTimeItemProps) 
                 size="small"
                 variant="outlined"
                 onClick={(e) => {
-                    const url = `/debug?collector=${CollectorsMap.TimelineCollector}&debugEntry=${data.id}`;
+                    const url = panelPagePath(
+                        `/?collector=${encodeURIComponent(CollectorsMap.TimelineCollector)}&debugEntry=${data.id}`,
+                    );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);
                     e.stopPropagation();

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ValidatorItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ValidatorItem.tsx
@@ -31,7 +31,7 @@ export const ValidatorItem = ({data, iframeUrlHandler}: ValidatorItemProps) => {
                 variant={hasErrors ? 'filled' : 'outlined'}
                 onClick={(e) => {
                     const url = panelPagePath(
-                        `/?collector=${encodeURIComponent(CollectorsMap.ValidatorCollector)}&debugEntry=${data.id}`,
+                        `/debug?collector=${encodeURIComponent(CollectorsMap.ValidatorCollector)}&debugEntry=${data.id}`,
                     );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ValidatorItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ValidatorItem.tsx
@@ -1,5 +1,6 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
+import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import {Chip, Tooltip} from '@mui/material';
@@ -29,11 +30,8 @@ export const ValidatorItem = ({data, iframeUrlHandler}: ValidatorItemProps) => {
                 variant={hasErrors ? 'filled' : 'outlined'}
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.ValidatorCollector}&debugEntry=${data.id}`;
-                    if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener,noreferrer');
-                    } else {
-                        iframeUrlHandler(url);
-                    }
+                    if (openInNewTabOnModifier(e, url)) return;
+                    iframeUrlHandler(url);
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ValidatorItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ValidatorItem.tsx
@@ -30,7 +30,7 @@ export const ValidatorItem = ({data, iframeUrlHandler}: ValidatorItemProps) => {
                 onClick={(e) => {
                     const url = `/debug?collector=${CollectorsMap.ValidatorCollector}&debugEntry=${data.id}`;
                     if (e.ctrlKey || e.metaKey) {
-                        window.open(url, '_blank', 'noopener');
+                        window.open(url, '_blank', 'noopener,noreferrer');
                     } else {
                         iframeUrlHandler(url);
                     }

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ValidatorItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ValidatorItem.tsx
@@ -28,7 +28,12 @@ export const ValidatorItem = ({data, iframeUrlHandler}: ValidatorItemProps) => {
                 color={hasErrors ? 'warning' : 'default'}
                 variant={hasErrors ? 'filled' : 'outlined'}
                 onClick={(e) => {
-                    iframeUrlHandler(`/debug?collector=${CollectorsMap.ValidatorCollector}&debugEntry=${data.id}`);
+                    const url = `/debug?collector=${CollectorsMap.ValidatorCollector}&debugEntry=${data.id}`;
+                    if (e.ctrlKey || e.metaKey) {
+                        window.open(url, '_blank', 'noopener');
+                    } else {
+                        iframeUrlHandler(url);
+                    }
                     e.stopPropagation();
                     e.preventDefault();
                 }}

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ValidatorItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/ValidatorItem.tsx
@@ -1,6 +1,7 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
 import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
+import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import {Chip, Tooltip} from '@mui/material';
@@ -29,7 +30,9 @@ export const ValidatorItem = ({data, iframeUrlHandler}: ValidatorItemProps) => {
                 color={hasErrors ? 'warning' : 'default'}
                 variant={hasErrors ? 'filled' : 'outlined'}
                 onClick={(e) => {
-                    const url = `/debug?collector=${CollectorsMap.ValidatorCollector}&debugEntry=${data.id}`;
+                    const url = panelPagePath(
+                        `/?collector=${encodeURIComponent(CollectorsMap.ValidatorCollector)}&debugEntry=${data.id}`,
+                    );
                     if (openInNewTabOnModifier(e, url)) return;
                     iframeUrlHandler(url);
                     e.stopPropagation();

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.test.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.test.tsx
@@ -1,0 +1,53 @@
+import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
+import {renderWithProviders} from '@app-dev-panel/sdk/test-utils';
+import {RequestItem} from '@app-dev-panel/toolbar/Module/Toolbar/Component/Toolbar/Web/RequestItem';
+import {fireEvent, screen} from '@testing-library/react';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+const makeEntry = (): DebugEntry =>
+    ({
+        id: 'req-77',
+        collectors: [],
+        request: {method: 'GET', path: '/users'},
+        response: {statusCode: 200},
+        router: {},
+    }) as unknown as DebugEntry;
+
+describe('RequestItem Ctrl/Cmd-click URL', () => {
+    const originalOpen = window.open;
+    afterEach(() => {
+        window.open = originalOpen;
+        delete window.__adp_panel_url;
+    });
+
+    it('opens the debug entry overview at {mount}/debug?debugEntry=<id> in a new tab on Ctrl+click', () => {
+        const open = vi.fn();
+        window.open = open;
+        renderWithProviders(<RequestItem data={makeEntry()} />);
+
+        fireEvent.click(screen.getByText(/GET \/users 200/), {ctrlKey: true});
+
+        expect(open).toHaveBeenCalledWith('/debug/debug?debugEntry=req-77', '_blank', 'noopener,noreferrer');
+    });
+
+    it('honors a custom window.__adp_panel_url mount path', () => {
+        window.__adp_panel_url = '/adp';
+        const open = vi.fn();
+        window.open = open;
+        renderWithProviders(<RequestItem data={makeEntry()} />);
+
+        fireEvent.click(screen.getByText(/GET \/users 200/), {metaKey: true});
+
+        expect(open).toHaveBeenCalledWith('/adp/debug?debugEntry=req-77', '_blank', 'noopener,noreferrer');
+    });
+
+    it('does not call window.open on a plain click (opens the menu instead)', () => {
+        const open = vi.fn();
+        window.open = open;
+        renderWithProviders(<RequestItem data={makeEntry()} />);
+
+        fireEvent.click(screen.getByText(/GET \/users 200/));
+
+        expect(open).not.toHaveBeenCalled();
+    });
+});

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.tsx
@@ -25,7 +25,7 @@ export const RequestItem = ({data}: RequestItemProps) => {
     const open = Boolean(anchorEl);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
         if (event.ctrlKey || event.metaKey) {
-            window.open(panelPagePath(`/?debugEntry=${data.id}`), '_blank', 'noopener');
+            window.open(panelPagePath(`/?debugEntry=${data.id}`), '_blank', 'noopener,noreferrer');
             event.stopPropagation();
             event.preventDefault();
             return;

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.tsx
@@ -1,6 +1,7 @@
 import {DebugEntry} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {buttonColorHttp} from '@app-dev-panel/sdk/Helper/buttonColor';
 import {serializeCallable} from '@app-dev-panel/sdk/Helper/callableSerializer';
+import {openInNewTabOnModifier} from '@app-dev-panel/sdk/Helper/openInNewTabOnModifier';
 import {panelPagePath} from '@app-dev-panel/sdk/Helper/panelMountPath';
 import {usePostCurlBuildMutation} from '@app-dev-panel/toolbar/Module/Toolbar/API/inspector';
 import {ContentCopy, DataObject, DynamicFeed, Repeat, Route} from '@mui/icons-material';
@@ -24,12 +25,7 @@ export const RequestItem = ({data}: RequestItemProps) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-        if (event.ctrlKey || event.metaKey) {
-            window.open(panelPagePath(`/?debugEntry=${data.id}`), '_blank', 'noopener,noreferrer');
-            event.stopPropagation();
-            event.preventDefault();
-            return;
-        }
+        if (openInNewTabOnModifier(event, panelPagePath(`/?debugEntry=${data.id}`))) return;
         setAnchorEl(event.currentTarget);
     };
     const handleClose = () => setAnchorEl(null);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.tsx
@@ -25,7 +25,7 @@ export const RequestItem = ({data}: RequestItemProps) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-        if (openInNewTabOnModifier(event, panelPagePath(`?debugEntry=${data.id}`))) return;
+        if (openInNewTabOnModifier(event, panelPagePath(`/debug?debugEntry=${data.id}`))) return;
         setAnchorEl(event.currentTarget);
     };
     const handleClose = () => setAnchorEl(null);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.tsx
@@ -25,7 +25,7 @@ export const RequestItem = ({data}: RequestItemProps) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-        if (openInNewTabOnModifier(event, panelPagePath(`/?debugEntry=${data.id}`))) return;
+        if (openInNewTabOnModifier(event, panelPagePath(`?debugEntry=${data.id}`))) return;
         setAnchorEl(event.currentTarget);
     };
     const handleClose = () => setAnchorEl(null);

--- a/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.tsx
+++ b/libs/frontend/packages/toolbar/src/Module/Toolbar/Component/Toolbar/Web/RequestItem.tsx
@@ -23,7 +23,15 @@ type RequestItemProps = {data: DebugEntry};
 export const RequestItem = ({data}: RequestItemProps) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
-    const handleClick = (event: React.MouseEvent<HTMLElement>) => setAnchorEl(event.currentTarget);
+    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+        if (event.ctrlKey || event.metaKey) {
+            window.open(panelPagePath(`/?debugEntry=${data.id}`), '_blank', 'noopener');
+            event.stopPropagation();
+            event.preventDefault();
+            return;
+        }
+        setAnchorEl(event.currentTarget);
+    };
     const handleClose = () => setAnchorEl(null);
     const [postCurlBuild] = usePostCurlBuildMutation();
 

--- a/playground/laravel-app/resources/views/layouts/app.blade.php
+++ b/playground/laravel-app/resources/views/layouts/app.blade.php
@@ -437,6 +437,7 @@ textarea.form-control {
             <a href="/log-demo" class="{{ request()->is('log-demo') ? 'active' : '' }}">Log Demo</a>
             <a href="/var-dumper" class="{{ request()->is('var-dumper') ? 'active' : '' }}">Var Dumper</a>
             <a href="/api/openapi.json" class="{{ request()->is('api/openapi.json') ? 'active' : '' }}">OpenAPI</a>
+            <a href="/debug" target="_blank" rel="noopener">Debug Panel</a>
         </nav>
     </header>
 

--- a/playground/symfony-app/templates/base.html.twig
+++ b/playground/symfony-app/templates/base.html.twig
@@ -437,6 +437,7 @@ textarea.form-control {
             <a href="{{ path('log_demo') }}" class="{{ app.request.pathInfo == '/log-demo' ? 'active' : '' }}">Log Demo</a>
             <a href="{{ path('var_dumper') }}" class="{{ app.request.pathInfo == '/var-dumper' ? 'active' : '' }}">Var Dumper</a>
             <a href="{{ path('api_openapi') }}" class="{{ app.request.pathInfo == '/api/openapi.json' ? 'active' : '' }}">OpenAPI</a>
+            <a href="/debug" target="_blank" rel="noopener">Debug Panel</a>
         </nav>
     </header>
 

--- a/playground/yii2-basic-app/src/views/layouts/main.php
+++ b/playground/yii2-basic-app/src/views/layouts/main.php
@@ -447,6 +447,7 @@
         foreach ($links as $url => $label): ?>
             <a href="/<?= $url ?>" class="<?= $path === $url ? 'active' : '' ?>"><?= $label ?></a>
         <?php endforeach; ?>
+        <a href="/debug" target="_blank" rel="noopener">Debug Panel</a>
     </nav>
 </div>
 <div class="main">

--- a/playground/yii3-app/src/Web/Shared/Layout/Main/layout.php
+++ b/playground/yii3-app/src/Web/Shared/Layout/Main/layout.php
@@ -139,6 +139,7 @@ $this->beginPage() ?>
         <a href="/log-demo"<?= $currentPath === '/log-demo' ? ' class="active"' : '' ?>>Log Demo</a>
         <a href="/var-dumper"<?= $currentPath === '/var-dumper' ? ' class="active"' : '' ?>>Var Dumper</a>
         <a href="/api/openapi.json"<?= $currentPath === '/api/openapi.json' ? ' class="active"' : '' ?>>OpenAPI</a>
+        <a href="/debug" target="_blank" rel="noopener">Debug Panel</a>
     </nav>
 </div>
 


### PR DESCRIPTION
## Summary
This PR removes summary/statistics cards from debug panels and adds support for opening debug entries in new tabs via Ctrl+Click (or Cmd+Click on Mac) across multiple toolbar items.

## Key Changes

### Panel Summary Card Removals
- **FilesystemPanel**: Removed `SummaryGrid`, `SummaryCard`, `SummaryLabel`, and `SummaryValue` styled components along with the total operations summary display
- **AssetBundlePanel**: Removed the same styled components and the "Total Bundles" summary card; updated type definition to remove `bundleCount` from props
- **Tests**: Updated test files to remove assertions for summary card rendering

### Ctrl+Click to Open in New Tab
Added support for opening debug entries in new browser tabs when Ctrl+Click (or Cmd+Click) is used:
- **LogsItem**: Modified log level group and main button click handlers
- **DatabaseItem**: Added Ctrl+click support to open in new tab
- **DeprecationItem**: Added Ctrl+click support to open in new tab
- **EventsItem**: Added Ctrl+click support to open in new tab
- **HttpClientItem**: Added Ctrl+click support to open in new tab
- **MemoryItem**: Added Ctrl+click support to open in new tab
- **RequestTimeItem**: Added Ctrl+click support to open in new tab
- **ValidatorItem**: Added Ctrl+click support to open in new tab
- **ExceptionItem**: Added Ctrl+click support to open class explorer in new tab
- **CommandItem** and **RequestItem**: Added Ctrl+click support using `panelPagePath` helper

### Implementation Details
- All new tab opens use `window.open(url, '_blank', 'noopener')` for security
- Ctrl+click detection uses `event.ctrlKey || event.metaKey` to support both Windows/Linux and Mac
- Event propagation is properly stopped with `stopPropagation()` and `preventDefault()`
- Playground app navigation links updated to include debug page link

https://claude.ai/code/session_01VNk7rn4i8xPwmNEJ11Vj4G