### PR TITLE
Enhance test fixtures with debug logging and var dumping

### DIFF
--- a/playground/laravel-app/app/Http/Controllers/TestFixtures/LogsAction.php
+++ b/playground/laravel-app/app/Http/Controllers/TestFixtures/LogsAction.php
@@ -19,6 +19,18 @@ final readonly class LogsAction
         $this->logger->warning('Test log: warning level message');
         $this->logger->error('Test log: error level message');
 
+        $this->logger->debug('Test log: debug with dump-like context', [
+            'user' => ['id' => 42, 'name' => 'Alice', 'roles' => ['admin', 'editor']],
+            'metadata' => ['session' => 'abc123', 'request_id' => 'req-789'],
+        ]);
+        dump(['fixture' => 'logs:basic', 'dump_example' => ['key' => 'value', 'nested' => [1, 2, 3]]]);
+
+        $this->logger->notice('Test log: deprecated API usage detected');
+        @trigger_error(
+            'Method LegacyApi::doStuff() is deprecated since v2.0, use NewApi::doStuff() instead.',
+            E_USER_DEPRECATED,
+        );
+
         return new JsonResponse(['fixture' => 'logs:basic', 'status' => 'ok']);
     }
 }

--- a/playground/symfony-app/src/Controller/TestFixtures/LogsAction.php
+++ b/playground/symfony-app/src/Controller/TestFixtures/LogsAction.php
@@ -21,6 +21,18 @@ final readonly class LogsAction
         $this->logger->warning('Test log: warning level message');
         $this->logger->error('Test log: error level message');
 
+        $this->logger->debug('Test log: debug with dump-like context', [
+            'user' => ['id' => 42, 'name' => 'Alice', 'roles' => ['admin', 'editor']],
+            'metadata' => ['session' => 'abc123', 'request_id' => 'req-789'],
+        ]);
+        dump(['fixture' => 'logs:basic', 'dump_example' => ['key' => 'value', 'nested' => [1, 2, 3]]]);
+
+        $this->logger->notice('Test log: deprecated API usage detected');
+        @trigger_error(
+            'Method LegacyApi::doStuff() is deprecated since v2.0, use NewApi::doStuff() instead.',
+            E_USER_DEPRECATED,
+        );
+
         return new JsonResponse(['fixture' => 'logs:basic', 'status' => 'ok']);
     }
 }

--- a/playground/yii2-basic-app/src/actions/testFixtures/LogsAction.php
+++ b/playground/yii2-basic-app/src/actions/testFixtures/LogsAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\actions\testFixtures;
 
+use AppDevPanel\Kernel\Collector\VarDumperCollector;
 use yii\base\Action;
 
 final class LogsAction extends Action
@@ -13,6 +14,29 @@ final class LogsAction extends Action
         \Yii::info('Test log: info level message', 'application');
         \Yii::warning('Test log: warning level message', 'application');
         \Yii::error('Test log: error level message', 'application');
+
+        \Yii::info(
+            ['Test log: debug with dump-like context' => [
+                'user' => ['id' => 42, 'name' => 'Alice', 'roles' => ['admin', 'editor']],
+                'metadata' => ['session' => 'abc123', 'request_id' => 'req-789'],
+            ]],
+            'application',
+        );
+
+        /** @var VarDumperCollector|null $collector */
+        $collector = \Yii::$container->has(VarDumperCollector::class)
+            ? \Yii::$container->get(VarDumperCollector::class)
+            : null;
+        $collector?->collect(
+            ['fixture' => 'logs:basic', 'dump_example' => ['key' => 'value', 'nested' => [1, 2, 3]]],
+            __FILE__ . ':' . __LINE__,
+        );
+
+        \Yii::warning('Test log: deprecated API usage detected', 'application');
+        @trigger_error(
+            'Method LegacyApi::doStuff() is deprecated since v2.0, use NewApi::doStuff() instead.',
+            E_USER_DEPRECATED,
+        );
 
         return ['fixture' => 'logs:basic', 'status' => 'ok'];
     }

--- a/playground/yii3-app/src/Web/TestFixtures/LogsAction.php
+++ b/playground/yii3-app/src/Web/TestFixtures/LogsAction.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 use Yiisoft\DataResponse\DataResponseFactoryInterface;
+use Yiisoft\VarDumper\VarDumper;
 
 final readonly class LogsAction implements RequestHandlerInterface
 {
@@ -22,6 +23,18 @@ final readonly class LogsAction implements RequestHandlerInterface
         $this->logger->info('Test log: info level message');
         $this->logger->warning('Test log: warning level message');
         $this->logger->error('Test log: error level message');
+
+        $this->logger->debug('Test log: debug with dump-like context', [
+            'user' => ['id' => 42, 'name' => 'Alice', 'roles' => ['admin', 'editor']],
+            'metadata' => ['session' => 'abc123', 'request_id' => 'req-789'],
+        ]);
+        VarDumper::dump(['fixture' => 'logs:basic', 'dump_example' => ['key' => 'value', 'nested' => [1, 2, 3]]]);
+
+        $this->logger->notice('Test log: deprecated API usage detected');
+        @trigger_error(
+            'Method LegacyApi::doStuff() is deprecated since v2.0, use NewApi::doStuff() instead.',
+            E_USER_DEPRECATED,
+        );
 
         return $this->responseFactory->createResponse(['fixture' => 'logs:basic', 'status' => 'ok']);
     }


### PR DESCRIPTION
## Summary
Enhanced the LogsAction test fixtures across all framework playground applications to include additional logging scenarios: debug-level logging with structured context data, variable dumping, and deprecated API usage detection via error triggering.

## Key Changes
- **Yii2 Basic App**: Added import for `VarDumperCollector`, implemented debug logging with nested user/metadata context, integrated var dumper collection via container, and added deprecated API error triggering
- **Yii3 App**: Added import for `Yiisoft\VarDumper\VarDumper`, implemented debug logging with structured context, direct var dumper usage, and deprecated API error triggering
- **Laravel App**: Added debug logging with structured context, `dump()` helper function call, and deprecated API error triggering
- **Symfony App**: Added debug logging with structured context, `dump()` helper function call, and deprecated API error triggering

## Implementation Details
- All implementations log a debug/info message with a consistent data structure containing user information (id, name, roles) and metadata (session, request_id)
- Variable dumping is performed using framework-appropriate methods (VarDumperCollector for Yii2, VarDumper for Yii3, dump() helper for Laravel/Symfony)
- Deprecated API usage is simulated consistently across all frameworks using `trigger_error()` with `E_USER_DEPRECATED` flag
- The test fixture maintains backward compatibility by returning the same response structure

https://claude.ai/code/session_01BTkfakDz3FRp1vM9DmBz6a