### PR TITLE
feat(playgrounds): richer cache-heavy fixtures with real hits and varied ops

### DIFF
--- a/playground/laravel-app/app/Http/Controllers/TestFixtures/CacheHeavyAction.php
+++ b/playground/laravel-app/app/Http/Controllers/TestFixtures/CacheHeavyAction.php
@@ -7,29 +7,173 @@ namespace App\Http\Controllers\TestFixtures;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Cache;
 
+/**
+ * Stress fixture: realistic mix of cache operations producing genuine hits,
+ * misses, overwrites, deletes, has-probes, batched writes, and a final flush().
+ */
 final class CacheHeavyAction
 {
     public function __invoke(): JsonResponse
     {
-        for ($i = 0; $i < 100; $i++) {
-            $key = sprintf('app:item:%d', $i);
-            $value = [
-                'id' => $i,
-                'title' => sprintf('Item #%d', $i),
-                'tags' => ['tag-' . ($i % 5), 'tag-' . ($i % 7)],
-                'metadata' => ['created_at' => '2026-01-15T10:00:00Z', 'ttl' => 3600],
-            ];
-
-            $operation = $i % 6;
-
-            match ($operation) {
-                0 => Cache::put($key, $value, 3600),
-                1, 2, 3 => Cache::get($key),
-                4 => Cache::forget($key),
-                5 => Cache::has($key),
-            };
-        }
+        $this->warmupProducts();
+        $this->warmupUsers();
+        $this->readProducts();
+        $this->readUsers();
+        $this->readColdKeys();
+        $this->probeHas();
+        $this->overwriteAndReread();
+        $this->bulkPages();
+        $this->deleteAndReread();
+        $this->scalarValues();
+        $this->longTailSingleOps();
+        Cache::flush();
 
         return new JsonResponse(['fixture' => 'cache:heavy', 'status' => 'ok']);
+    }
+
+    private function warmupProducts(): void
+    {
+        $products = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $products[sprintf('product:%d', $i)] = [
+                'id' => $i,
+                'sku' => sprintf('SKU-%04d', $i),
+                'name' => sprintf('Product #%d', $i),
+                'price' => 10.0 + ($i * 2.5),
+                'tags' => ['category-' . ($i % 3), 'tier-' . ($i % 4)],
+                'stock' => ($i * 7) % 100,
+            ];
+        }
+        Cache::putMany($products, 3600);
+    }
+
+    private function warmupUsers(): void
+    {
+        for ($i = 1; $i <= 8; $i++) {
+            Cache::put(
+                sprintf('user:%d', $i),
+                [
+                    'id' => $i,
+                    'email' => sprintf('user%d@example.com', $i),
+                    'roles' => $i === 1 ? ['admin', 'editor'] : ['viewer'],
+                    'lastLogin' => '2026-04-23T09:' . sprintf('%02d', $i) . ':00Z',
+                ],
+                300,
+            );
+        }
+    }
+
+    private function readProducts(): void
+    {
+        $keys = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $keys[] = sprintf('product:%d', $i);
+        }
+        Cache::many($keys);
+    }
+
+    private function readUsers(): void
+    {
+        for ($i = 1; $i <= 8; $i++) {
+            Cache::get(sprintf('user:%d', $i));
+        }
+    }
+
+    private function readColdKeys(): void
+    {
+        Cache::get('missing:nobody-home');
+        Cache::get('missing:stale-session');
+        Cache::get('missing:invalidated');
+        Cache::many(['missing:multi-1', 'missing:multi-2', 'missing:multi-3']);
+    }
+
+    private function probeHas(): void
+    {
+        Cache::has('product:1');
+        Cache::has('product:5');
+        Cache::has('user:1');
+        Cache::has('user:7');
+        Cache::has('ghost:a');
+        Cache::has('ghost:b');
+        Cache::has('ghost:c');
+        Cache::has('ghost:d');
+    }
+
+    private function overwriteAndReread(): void
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            $key = sprintf('product:%d', $i);
+            Cache::put(
+                $key,
+                [
+                    'id' => $i,
+                    'sku' => sprintf('SKU-%04d', $i),
+                    'name' => sprintf('Product #%d (discounted)', $i),
+                    'price' => 9.99,
+                    'tags' => ['category-' . ($i % 3), 'tier-' . ($i % 4), 'sale'],
+                    'stock' => 0,
+                ],
+                600,
+            );
+            Cache::get($key);
+        }
+    }
+
+    private function bulkPages(): void
+    {
+        $pages = [];
+        for ($i = 1; $i <= 12; $i++) {
+            $pages[sprintf('page:fragment:%d', $i)] = [
+                'html' => sprintf('<section data-page="%d">…</section>', $i),
+                'renderedAt' => '2026-04-23T10:' . sprintf('%02d', $i) . ':00Z',
+                'ttl' => 120,
+            ];
+        }
+        Cache::putMany($pages, 120);
+        Cache::many(array_keys($pages));
+    }
+
+    private function deleteAndReread(): void
+    {
+        Cache::forget('user:6');
+        Cache::forget('user:7');
+        Cache::forget('user:8');
+        Cache::get('user:6');
+        Cache::get('user:7');
+        Cache::get('user:8');
+    }
+
+    private function scalarValues(): void
+    {
+        Cache::put('config:site-name', 'ADP Playground', 900);
+        Cache::get('config:site-name');
+
+        Cache::put('counter:page-views', 42_195, 60);
+        Cache::get('counter:page-views');
+
+        Cache::put('rate:conversion', 1.3375, 300);
+        Cache::get('rate:conversion');
+
+        Cache::put('flag:feature-x-enabled', true, 1800);
+        Cache::get('flag:feature-x-enabled');
+    }
+
+    private function longTailSingleOps(): void
+    {
+        for ($i = 1; $i <= 8; $i++) {
+            $key = sprintf('report:monthly:%d', $i);
+            if (Cache::get($key) === null) {
+                Cache::put(
+                    $key,
+                    [
+                        'month' => $i,
+                        'totalRevenue' => 1000 * $i,
+                        'orders' => 42 + $i,
+                    ],
+                    1800,
+                );
+            }
+            Cache::get($key);
+        }
     }
 }

--- a/playground/symfony-app/src/Controller/TestFixtures/CacheHeavyAction.php
+++ b/playground/symfony-app/src/Controller/TestFixtures/CacheHeavyAction.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace App\Controller\TestFixtures;
 
+use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
+/**
+ * Stress fixture: realistic mix of PSR-6 operations producing genuine hits,
+ * misses, overwrites, deletes, has-probes, batched writes, and a final clear().
+ */
 #[Route('/test/fixtures/cache-heavy', name: 'test_cache_heavy', methods: ['GET'])]
 final readonly class CacheHeavyAction
 {
@@ -17,33 +22,182 @@ final readonly class CacheHeavyAction
 
     public function __invoke(): JsonResponse
     {
-        // Generate many cache operations — the SymfonyCacheProxy intercepts all
-        // calls and feeds them to CacheCollector.
-        for ($i = 0; $i < 100; $i++) {
-            $key = sprintf('app_item_%d', $i);
-
-            if (($i % 6) === 0) {
-                // Set
-                $item = $this->cache->getItem($key);
-                $item->set([
-                    'id' => $i,
-                    'title' => sprintf('Item #%d', $i),
-                    'tags' => ['tag-' . ($i % 5), 'tag-' . ($i % 7)],
-                    'metadata' => ['created_at' => '2026-01-15T10:00:00Z', 'ttl' => 3600],
-                ]);
-                $this->cache->save($item);
-            } elseif (($i % 6) === 4) {
-                // Delete
-                $this->cache->deleteItem($key);
-            } elseif (($i % 6) === 5) {
-                // Has
-                $this->cache->hasItem($key);
-            } else {
-                // Get (may be hit or miss depending on whether item was set before)
-                $this->cache->getItem($key);
-            }
-        }
+        $this->warmupProducts();
+        $this->warmupUsers();
+        $this->readProducts();
+        $this->readUsers();
+        $this->readColdKeys();
+        $this->probeHas();
+        $this->overwriteAndReread();
+        $this->bulkPages();
+        $this->deleteAndReread();
+        $this->scalarValues();
+        $this->longTailSingleOps();
+        $this->cache->clear();
 
         return new JsonResponse(['fixture' => 'cache:heavy', 'status' => 'ok']);
+    }
+
+    private function warmupProducts(): void
+    {
+        for ($i = 1; $i <= 10; $i++) {
+            $item = $this->cache->getItem(sprintf('product.%d', $i));
+            $item->set([
+                'id' => $i,
+                'sku' => sprintf('SKU-%04d', $i),
+                'name' => sprintf('Product #%d', $i),
+                'price' => 10.0 + ($i * 2.5),
+                'tags' => ['category-' . ($i % 3), 'tier-' . ($i % 4)],
+                'stock' => ($i * 7) % 100,
+            ]);
+            $item->expiresAfter(3600);
+            $this->cache->saveDeferred($item);
+        }
+        $this->cache->commit();
+    }
+
+    private function warmupUsers(): void
+    {
+        for ($i = 1; $i <= 8; $i++) {
+            $item = $this->cache->getItem(sprintf('user.%d', $i));
+            $item->set([
+                'id' => $i,
+                'email' => sprintf('user%d@example.com', $i),
+                'roles' => $i === 1 ? ['admin', 'editor'] : ['viewer'],
+                'lastLogin' => '2026-04-23T09:' . sprintf('%02d', $i) . ':00Z',
+            ]);
+            $item->expiresAfter(300);
+            $this->cache->save($item);
+        }
+    }
+
+    private function readProducts(): void
+    {
+        $keys = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $keys[] = sprintf('product.%d', $i);
+        }
+        foreach ($this->cache->getItems($keys) as $item) {
+            $item->isHit();
+        }
+    }
+
+    private function readUsers(): void
+    {
+        for ($i = 1; $i <= 8; $i++) {
+            $this->cache->getItem(sprintf('user.%d', $i));
+        }
+    }
+
+    private function readColdKeys(): void
+    {
+        $this->cache->getItem('missing.nobody-home');
+        $this->cache->getItem('missing.stale-session');
+        $this->cache->getItem('missing.invalidated');
+        foreach ($this->cache->getItems(['missing.multi-1', 'missing.multi-2', 'missing.multi-3']) as $item) {
+            $item->isHit();
+        }
+    }
+
+    private function probeHas(): void
+    {
+        $this->cache->hasItem('product.1');
+        $this->cache->hasItem('product.5');
+        $this->cache->hasItem('user.1');
+        $this->cache->hasItem('user.7');
+        $this->cache->hasItem('ghost.a');
+        $this->cache->hasItem('ghost.b');
+        $this->cache->hasItem('ghost.c');
+        $this->cache->hasItem('ghost.d');
+    }
+
+    private function overwriteAndReread(): void
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            $key = sprintf('product.%d', $i);
+            $item = $this->cache->getItem($key);
+            $item->set([
+                'id' => $i,
+                'sku' => sprintf('SKU-%04d', $i),
+                'name' => sprintf('Product #%d (discounted)', $i),
+                'price' => 9.99,
+                'tags' => ['category-' . ($i % 3), 'tier-' . ($i % 4), 'sale'],
+                'stock' => 0,
+            ]);
+            $item->expiresAfter(600);
+            $this->cache->save($item);
+            $this->cache->getItem($key);
+        }
+    }
+
+    private function bulkPages(): void
+    {
+        $keys = [];
+        for ($i = 1; $i <= 12; $i++) {
+            $key = sprintf('page.fragment.%d', $i);
+            $keys[] = $key;
+            $item = $this->cache->getItem($key);
+            $item->set([
+                'html' => sprintf('<section data-page="%d">…</section>', $i),
+                'renderedAt' => '2026-04-23T10:' . sprintf('%02d', $i) . ':00Z',
+                'ttl' => 120,
+            ]);
+            $item->expiresAfter(120);
+            $this->cache->saveDeferred($item);
+        }
+        $this->cache->commit();
+        foreach ($this->cache->getItems($keys) as $item) {
+            $item->isHit();
+        }
+    }
+
+    private function deleteAndReread(): void
+    {
+        $this->cache->deleteItems(['user.6', 'user.7', 'user.8']);
+        $this->cache->getItem('user.6');
+        $this->cache->getItem('user.7');
+        $this->cache->getItem('user.8');
+    }
+
+    private function scalarValues(): void
+    {
+        $this->saveScalar('config.site-name', 'ADP Playground', 900);
+        $this->cache->getItem('config.site-name');
+
+        $this->saveScalar('counter.page-views', 42_195, 60);
+        $this->cache->getItem('counter.page-views');
+
+        $this->saveScalar('rate.conversion', 1.3375, 300);
+        $this->cache->getItem('rate.conversion');
+
+        $this->saveScalar('flag.feature-x-enabled', true, 1800);
+        $this->cache->getItem('flag.feature-x-enabled');
+    }
+
+    private function longTailSingleOps(): void
+    {
+        for ($i = 1; $i <= 8; $i++) {
+            $key = sprintf('report.monthly.%d', $i);
+            $item = $this->cache->getItem($key);
+            if (!$item->isHit()) {
+                $item->set([
+                    'month' => $i,
+                    'totalRevenue' => 1000 * $i,
+                    'orders' => 42 + $i,
+                ]);
+                $item->expiresAfter(1800);
+                $this->cache->save($item);
+            }
+            $this->cache->getItem($key);
+        }
+    }
+
+    private function saveScalar(string $key, mixed $value, int $ttl): void
+    {
+        $item = $this->cache->getItem($key);
+        assert($item instanceof CacheItemInterface);
+        $item->set($value);
+        $item->expiresAfter($ttl);
+        $this->cache->save($item);
     }
 }

--- a/playground/yii2-basic-app/src/actions/testFixtures/CacheHeavyAction.php
+++ b/playground/yii2-basic-app/src/actions/testFixtures/CacheHeavyAction.php
@@ -4,59 +4,179 @@ declare(strict_types=1);
 
 namespace App\actions\testFixtures;
 
-use AppDevPanel\Kernel\Collector\CacheCollector;
-use AppDevPanel\Kernel\Collector\CacheOperationRecord;
 use yii\base\Action;
+use yii\caching\CacheInterface;
 
+/**
+ * Stress fixture: realistic mix of Yii 2 cache operations producing genuine
+ * hits, misses, overwrites, deletes, exists-probes, multi-ops, and a final flush().
+ */
 final class CacheHeavyAction extends Action
 {
     public function run(): array
     {
-        /** @var \AppDevPanel\Adapter\Yii2\Module $module */
-        $module = \Yii::$app->getModule('app-dev-panel');
+        $cache = \Yii::$app->cache;
+        $cache->flush();
 
-        /** @var CacheCollector|null $cacheCollector */
-        $cacheCollector = $module->getCollector(CacheCollector::class);
-
-        if ($cacheCollector === null) {
-            return ['fixture' => 'cache:heavy', 'status' => 'error', 'message' => 'CacheCollector not found'];
-        }
-
-        $pools = ['default', 'sessions', 'metadata'];
-        $operations = ['set', 'get', 'get', 'get', 'delete', 'has'];
-
-        for ($i = 0; $i < 100; $i++) {
-            $pool = $pools[$i % count($pools)];
-            $operation = $operations[$i % count($operations)];
-            $key = sprintf('app:%s:item:%d', $pool, $i);
-            $hit = $operation === 'get' && ($i % 3) !== 0;
-
-            $value = null;
-            if ($operation === 'set') {
-                $value = [
-                    'id' => $i,
-                    'title' => sprintf('Item #%d', $i),
-                    'tags' => ['tag-' . ($i % 5), 'tag-' . ($i % 7)],
-                    'metadata' => ['created_at' => '2026-01-15T10:00:00Z', 'ttl' => 3600],
-                ];
-            } elseif ($operation === 'get' && $hit) {
-                $value = [
-                    'id' => $i,
-                    'title' => sprintf('Item #%d', $i),
-                    'cached' => true,
-                ];
-            }
-
-            $cacheCollector->logCacheOperation(new CacheOperationRecord(
-                pool: $pool,
-                operation: $operation,
-                key: $key,
-                hit: $hit,
-                duration: rand(100, 5_000) / 1_000_000,
-                value: $value,
-            ));
-        }
+        $this->warmupProducts($cache);
+        $this->warmupUsers($cache);
+        $this->readProducts($cache);
+        $this->readUsers($cache);
+        $this->readColdKeys($cache);
+        $this->probeExists($cache);
+        $this->overwriteAndReread($cache);
+        $this->bulkPages($cache);
+        $this->deleteAndReread($cache);
+        $this->scalarValues($cache);
+        $this->longTailSingleOps($cache);
+        $cache->flush();
 
         return ['fixture' => 'cache:heavy', 'status' => 'ok'];
+    }
+
+    private function warmupProducts(CacheInterface $cache): void
+    {
+        $products = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $products[sprintf('product:%d', $i)] = [
+                'id' => $i,
+                'sku' => sprintf('SKU-%04d', $i),
+                'name' => sprintf('Product #%d', $i),
+                'price' => 10.0 + ($i * 2.5),
+                'tags' => ['category-' . ($i % 3), 'tier-' . ($i % 4)],
+                'stock' => ($i * 7) % 100,
+            ];
+        }
+        $cache->multiSet($products, 3600);
+    }
+
+    private function warmupUsers(CacheInterface $cache): void
+    {
+        for ($i = 1; $i <= 8; $i++) {
+            $cache->set(
+                sprintf('user:%d', $i),
+                [
+                    'id' => $i,
+                    'email' => sprintf('user%d@example.com', $i),
+                    'roles' => $i === 1 ? ['admin', 'editor'] : ['viewer'],
+                    'lastLogin' => '2026-04-23T09:' . sprintf('%02d', $i) . ':00Z',
+                ],
+                300,
+            );
+        }
+    }
+
+    private function readProducts(CacheInterface $cache): void
+    {
+        $keys = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $keys[] = sprintf('product:%d', $i);
+        }
+        $cache->multiGet($keys);
+    }
+
+    private function readUsers(CacheInterface $cache): void
+    {
+        for ($i = 1; $i <= 8; $i++) {
+            $cache->get(sprintf('user:%d', $i));
+        }
+    }
+
+    private function readColdKeys(CacheInterface $cache): void
+    {
+        $cache->get('missing:nobody-home');
+        $cache->get('missing:stale-session');
+        $cache->get('missing:invalidated');
+        $cache->multiGet(['missing:multi-1', 'missing:multi-2', 'missing:multi-3']);
+    }
+
+    private function probeExists(CacheInterface $cache): void
+    {
+        $cache->exists('product:1');
+        $cache->exists('product:5');
+        $cache->exists('user:1');
+        $cache->exists('user:7');
+        $cache->exists('ghost:a');
+        $cache->exists('ghost:b');
+        $cache->exists('ghost:c');
+        $cache->exists('ghost:d');
+    }
+
+    private function overwriteAndReread(CacheInterface $cache): void
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            $key = sprintf('product:%d', $i);
+            $cache->set(
+                $key,
+                [
+                    'id' => $i,
+                    'sku' => sprintf('SKU-%04d', $i),
+                    'name' => sprintf('Product #%d (discounted)', $i),
+                    'price' => 9.99,
+                    'tags' => ['category-' . ($i % 3), 'tier-' . ($i % 4), 'sale'],
+                    'stock' => 0,
+                ],
+                600,
+            );
+            $cache->get($key);
+        }
+    }
+
+    private function bulkPages(CacheInterface $cache): void
+    {
+        $pages = [];
+        for ($i = 1; $i <= 12; $i++) {
+            $pages[sprintf('page:fragment:%d', $i)] = [
+                'html' => sprintf('<section data-page="%d">…</section>', $i),
+                'renderedAt' => '2026-04-23T10:' . sprintf('%02d', $i) . ':00Z',
+                'ttl' => 120,
+            ];
+        }
+        $cache->multiSet($pages, 120);
+        $cache->multiGet(array_keys($pages));
+    }
+
+    private function deleteAndReread(CacheInterface $cache): void
+    {
+        $cache->delete('user:6');
+        $cache->delete('user:7');
+        $cache->delete('user:8');
+        $cache->get('user:6');
+        $cache->get('user:7');
+        $cache->get('user:8');
+    }
+
+    private function scalarValues(CacheInterface $cache): void
+    {
+        $cache->set('config:site-name', 'ADP Playground', 900);
+        $cache->get('config:site-name');
+
+        $cache->set('counter:page-views', 42_195, 60);
+        $cache->get('counter:page-views');
+
+        $cache->set('rate:conversion', 1.3375, 300);
+        $cache->get('rate:conversion');
+
+        $cache->set('flag:feature-x-enabled', true, 1800);
+        $cache->get('flag:feature-x-enabled');
+    }
+
+    private function longTailSingleOps(CacheInterface $cache): void
+    {
+        for ($i = 1; $i <= 8; $i++) {
+            $key = sprintf('report:monthly:%d', $i);
+            if ($cache->get($key) === false) {
+                $cache->set(
+                    $key,
+                    [
+                        'month' => $i,
+                        'totalRevenue' => 1000 * $i,
+                        'orders' => 42 + $i,
+                    ],
+                    1800,
+                );
+            }
+            $cache->get($key);
+        }
     }
 }


### PR DESCRIPTION
## Summary

The old `cache-heavy` fixture used a unique key per iteration (`app:item:$i`), so every `get()` hit a key that was never `set()` — resulting in **0 hit rate** and only sparse, misleading data in the cache panel. Since Yii 3 / Laravel use per-request in-memory caches, there was no way for the old fixture to ever produce a hit.

All four playgrounds (Yii 3, Symfony, Laravel, Yii 2) now run the same realistic stress pattern against their native cache API. Each fixture produces **≥100 operations**, **tens of real hits**, **real misses**, and exercises every code path of the corresponding cache proxy.

Fixture structure (identical across playgrounds, adapted to each framework's API):

1. **Warm-up products** — 10 items via `setMultiple` / `saveDeferred` + `commit` / `putMany` / `multiSet` (TTL 3600)
2. **Warm-up users** — 8 items via single `set` / `put` (TTL 300)
3. **Read products** — `getMultiple` / `getItems` / `many` / `multiGet` → **10 hits**
4. **Read users** — 8 single `get` → **8 hits**
5. **Cold-key reads** — 6 guaranteed **misses** (single + multi)
6. **has/exists probes** — 4 present + 4 absent keys
7. **Overwrite + re-read** — 3 products with updated payload + TTL, then re-read → **3 hits** with changed value
8. **Bulk pages** — 12 fragments via multi-set, then re-read via multi-get → **12 hits**
9. **Delete + re-read** — `deleteMultiple` / `deleteItems` / `forget` / `delete` followed by `get` on the same keys → **3 misses**
10. **Scalar values** — string / int / float / bool with `set` + `get` pairs → **4 hits**
11. **Long-tail miss-then-populate** — 8 `report:monthly:*` keys showing realistic "check cache → miss → compute → store → hit" flow
12. **Final `clear()` / `flush()`** to exercise the whole-pool wipe path

Net effect: ≥100 operations, ~45 genuine hits, ~17 misses, multiple operation types, 5 key namespaces (`product:`, `user:`, `page:fragment:`, scalar configs, `report:monthly:`).

### Framework-specific notes

- **Yii 3** — PSR-16 (`Psr\SimpleCache\CacheInterface`, yiisoft/cache `ArrayCache`). Proxy: `Psr16CacheProxy`.
- **Symfony** — PSR-6 (`CacheItemPoolInterface`) with `saveDeferred` + `commit` for batches and `deleteItems` for bulk delete. Proxy: `SymfonyCacheProxy`.
- **Laravel** — `Cache` facade (`putMany` / `many` / `has` / `forget`). Captured via `CacheHit` / `CacheMissed` / `KeyWritten` / `KeyForgotten` events.
- **Yii 2** — fixture rewritten to run through the real `CacheProxy` via `Yii::$app->cache` (`multiSet` / `multiGet` / `exists` / `delete` / `flush`), replacing the old direct `CacheCollector::logCacheOperation()` calls. Added an initial `flush()` so the on-disk `FileCache` doesn't leak state between runs.

## Test plan

- [ ] `make install-playgrounds` + start each playground (`make serve`)
- [ ] `make fixtures-yii3 -- -s cache:heavy -v` — inspect `cache.hits`, `cache.misses`, `cache.totalOperations`
- [ ] Same for `fixtures-symfony`, `fixtures-laravel`, `fixtures-yii2`
- [ ] `make test-fixtures` — existing `cache:heavy` expectations (`totalOperations ≥ 100`, `hits ≥ 1`) still pass
- [ ] Visit the Cache panel on each playground after hitting `/test/fixtures/cache-heavy` — confirm varied keys across namespaces, non-zero hit rate, and multiple operation types (`get`, `set`, `delete`, `has`/`exists`, `clear`)
- [ ] `make mago-playgrounds` — Symfony and Yii 2 baselines may need regenerating since the fixtures now make more `$cache->*` calls than the current baselines permit

https://claude.ai/code/session_01Y2Cu8XQ45K3QT4SQYpPZr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2Cu8XQ45K3QT4SQYpPZr9)_