### PR TITLE
Remove PageHeader component from module pages

### DIFF
--- a/libs/frontend/packages/panel/src/Module/Frames/Pages/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Module/Frames/Pages/Layout.tsx
@@ -2,7 +2,6 @@ import {SettingsDialog} from '@app-dev-panel/panel/Module/Frames/Component/Setti
 import {useFramesEntries} from '@app-dev-panel/panel/Module/Frames/Context/Context';
 import {DuckIcon} from '@app-dev-panel/sdk/Component/DuckIcon';
 import {InfoBox} from '@app-dev-panel/sdk/Component/InfoBox';
-import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {Settings} from '@mui/icons-material';
 import {TabContext, TabPanel} from '@mui/lab';
 import {Box, IconButton, Link, Stack, Tab, Tabs, Typography, useTheme} from '@mui/material';
@@ -112,7 +111,6 @@ export const Layout = () => {
 
     return (
         <>
-            <PageHeader title="Frames" icon="web" description="Embedded external resources" />
             <TabContext value={tab}>
                 <Stack>
                     <Stack direction="row" justifyContent="space-between">

--- a/libs/frontend/packages/panel/src/Module/Llm/Pages/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Module/Llm/Pages/Layout.tsx
@@ -2,7 +2,6 @@ import {useGetStatusQuery} from '@app-dev-panel/panel/Module/Llm/API/Llm';
 import {AnalyzePanel} from '@app-dev-panel/panel/Module/Llm/Component/AnalyzePanel';
 import {ChatPanel} from '@app-dev-panel/panel/Module/Llm/Component/ChatPanel';
 import {ConnectionCard} from '@app-dev-panel/panel/Module/Llm/Component/ConnectionCard';
-import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {Box, Tab, Tabs} from '@mui/material';
 import {useState} from 'react';
 
@@ -12,31 +11,28 @@ export const Layout = () => {
     const connected = status?.connected ?? false;
 
     return (
-        <>
-            <PageHeader title="LLM Integration" icon="psychology" description="AI-powered debug analysis" />
-            <Box sx={{display: 'flex', flexDirection: 'column', gap: 3}}>
-                <ConnectionCard />
-                {connected && (
-                    <Box>
-                        <Tabs
-                            value={tab}
-                            onChange={(_, v) => setTab(v)}
-                            variant="scrollable"
-                            scrollButtons="auto"
-                            allowScrollButtonsMobile
-                        >
-                            <Tab label="Chat" />
-                            <Tab label="Analyze Debug Entry" />
-                        </Tabs>
-                        <Box sx={{mt: 2, display: tab === 0 ? 'block' : 'none'}}>
-                            <ChatPanel />
-                        </Box>
-                        <Box sx={{mt: 2, display: tab === 1 ? 'block' : 'none'}}>
-                            <AnalyzePanel />
-                        </Box>
+        <Box sx={{display: 'flex', flexDirection: 'column', gap: 3}}>
+            <ConnectionCard />
+            {connected && (
+                <Box>
+                    <Tabs
+                        value={tab}
+                        onChange={(_, v) => setTab(v)}
+                        variant="scrollable"
+                        scrollButtons="auto"
+                        allowScrollButtonsMobile
+                    >
+                        <Tab label="Chat" />
+                        <Tab label="Analyze Debug Entry" />
+                    </Tabs>
+                    <Box sx={{mt: 2, display: tab === 0 ? 'block' : 'none'}}>
+                        <ChatPanel />
                     </Box>
-                )}
-            </Box>
-        </>
+                    <Box sx={{mt: 2, display: tab === 1 ? 'block' : 'none'}}>
+                        <AnalyzePanel />
+                    </Box>
+                </Box>
+            )}
+        </Box>
     );
 };

--- a/libs/frontend/packages/panel/src/Module/Mcp/Pages/McpPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Mcp/Pages/McpPage.tsx
@@ -1,6 +1,5 @@
 import {useSelector} from '@app-dev-panel/panel/store';
 import {CodeHighlight} from '@app-dev-panel/sdk/Component/CodeHighlight';
-import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import {
     Box,
@@ -90,89 +89,86 @@ export const McpPage = () => {
     }, [config]);
 
     return (
-        <>
-            <PageHeader title="MCP Server" icon="hub" description="Connect AI assistants to your debug data" />
-            <Box sx={{display: 'flex', flexDirection: 'column', gap: 3}}>
-                <Paper variant="outlined" sx={{p: 2, display: 'flex', flexDirection: 'column', gap: 2}}>
-                    <Box>
-                        <Typography variant="body2" color="text.secondary" sx={{mb: 0.5}}>
-                            Endpoint
-                        </Typography>
-                        <Typography
-                            variant="body2"
-                            sx={(theme) => ({fontFamily: theme.adp.fontFamilyMono, wordBreak: 'break-all'})}
-                        >
-                            {mcpUrl}
-                        </Typography>
-                    </Box>
-
-                    <ToggleButtonGroup
-                        value={tab}
-                        exclusive
-                        onChange={(_, value) => value && setTab(value)}
-                        size="small"
-                        fullWidth
+        <Box sx={{display: 'flex', flexDirection: 'column', gap: 3}}>
+            <Paper variant="outlined" sx={{p: 2, display: 'flex', flexDirection: 'column', gap: 2}}>
+                <Box>
+                    <Typography variant="body2" color="text.secondary" sx={{mb: 0.5}}>
+                        Endpoint
+                    </Typography>
+                    <Typography
+                        variant="body2"
+                        sx={(theme) => ({fontFamily: theme.adp.fontFamilyMono, wordBreak: 'break-all'})}
                     >
-                        <ToggleButton value="url">Direct URL</ToggleButton>
-                        <ToggleButton value="stdio">stdio</ToggleButton>
-                        <ToggleButton value="cli">CLI</ToggleButton>
-                    </ToggleButtonGroup>
-
-                    <Box sx={{position: 'relative'}}>
-                        <CodeHighlight language="json" code={config} showLineNumbers={false} fontSize={10} />
-                        <Tooltip title={copied ? 'Copied' : 'Copy'}>
-                            <IconButton
-                                size="small"
-                                onClick={handleCopy}
-                                sx={{position: 'absolute', top: 4, right: 4, bgcolor: 'background.paper'}}
-                            >
-                                <ContentCopyIcon sx={{fontSize: 16}} />
-                            </IconButton>
-                        </Tooltip>
-                    </Box>
-
-                    <Typography variant="body2" color="text.secondary">
-                        Add this to your AI assistant's MCP configuration file (e.g., claude_desktop_config.json,
-                        .cursor/mcp.json, or .claude/settings.json).
+                        {mcpUrl}
                     </Typography>
-                </Paper>
+                </Box>
 
-                <Paper variant="outlined" sx={{overflow: 'hidden'}}>
-                    <Typography variant="body1" fontWeight={600} sx={{px: 2, pt: 2, pb: 1}}>
-                        Available tools
-                    </Typography>
-                    <TableContainer>
-                        <Table size="small">
-                            <TableHead>
-                                <TableRow>
-                                    <TableCell sx={{fontWeight: 600}}>Tool</TableCell>
-                                    <TableCell sx={{fontWeight: 600}}>Description</TableCell>
+                <ToggleButtonGroup
+                    value={tab}
+                    exclusive
+                    onChange={(_, value) => value && setTab(value)}
+                    size="small"
+                    fullWidth
+                >
+                    <ToggleButton value="url">Direct URL</ToggleButton>
+                    <ToggleButton value="stdio">stdio</ToggleButton>
+                    <ToggleButton value="cli">CLI</ToggleButton>
+                </ToggleButtonGroup>
+
+                <Box sx={{position: 'relative'}}>
+                    <CodeHighlight language="json" code={config} showLineNumbers={false} fontSize={10} />
+                    <Tooltip title={copied ? 'Copied' : 'Copy'}>
+                        <IconButton
+                            size="small"
+                            onClick={handleCopy}
+                            sx={{position: 'absolute', top: 4, right: 4, bgcolor: 'background.paper'}}
+                        >
+                            <ContentCopyIcon sx={{fontSize: 16}} />
+                        </IconButton>
+                    </Tooltip>
+                </Box>
+
+                <Typography variant="body2" color="text.secondary">
+                    Add this to your AI assistant's MCP configuration file (e.g., claude_desktop_config.json,
+                    .cursor/mcp.json, or .claude/settings.json).
+                </Typography>
+            </Paper>
+
+            <Paper variant="outlined" sx={{overflow: 'hidden'}}>
+                <Typography variant="body1" fontWeight={600} sx={{px: 2, pt: 2, pb: 1}}>
+                    Available tools
+                </Typography>
+                <TableContainer>
+                    <Table size="small">
+                        <TableHead>
+                            <TableRow>
+                                <TableCell sx={{fontWeight: 600}}>Tool</TableCell>
+                                <TableCell sx={{fontWeight: 600}}>Description</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {mcpTools.map((tool) => (
+                                <TableRow key={tool.name}>
+                                    <TableCell
+                                        sx={(theme) => ({
+                                            fontFamily: theme.adp.fontFamilyMono,
+                                            fontSize: '12px',
+                                            whiteSpace: 'nowrap',
+                                        })}
+                                    >
+                                        {tool.name}
+                                    </TableCell>
+                                    <TableCell>
+                                        <Typography variant="body2" color="text.secondary">
+                                            {tool.description}
+                                        </Typography>
+                                    </TableCell>
                                 </TableRow>
-                            </TableHead>
-                            <TableBody>
-                                {mcpTools.map((tool) => (
-                                    <TableRow key={tool.name}>
-                                        <TableCell
-                                            sx={(theme) => ({
-                                                fontFamily: theme.adp.fontFamilyMono,
-                                                fontSize: '12px',
-                                                whiteSpace: 'nowrap',
-                                            })}
-                                        >
-                                            {tool.name}
-                                        </TableCell>
-                                        <TableCell>
-                                            <Typography variant="body2" color="text.secondary">
-                                                {tool.description}
-                                            </Typography>
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
-                    </TableContainer>
-                </Paper>
-            </Box>
-        </>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </Paper>
+        </Box>
     );
 };

--- a/libs/frontend/packages/panel/src/Module/OpenApi/Pages/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Module/OpenApi/Pages/Layout.tsx
@@ -2,7 +2,6 @@ import {SettingsDialog} from '@app-dev-panel/panel/Module/OpenApi/Component/Sett
 import {useOpenApiEntries} from '@app-dev-panel/panel/Module/OpenApi/Context/Context';
 import '@app-dev-panel/panel/Module/OpenApi/Pages/dark.css';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
-import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {Settings} from '@mui/icons-material';
 import {TabContext, TabPanel} from '@mui/lab';
 import {Box, IconButton, Stack, Tab, Tabs, useTheme} from '@mui/material';
@@ -51,7 +50,6 @@ export const Layout = () => {
 
     return (
         <>
-            <PageHeader title="Open API" icon="data_object" description="API documentation viewer" />
             <TabContext value={tab}>
                 <Stack>
                     <Stack direction="row" justifyContent="space-between">


### PR DESCRIPTION
## Summary
Removes the `PageHeader` component from multiple module pages across the panel application. The page header functionality is being removed from the McpPage, LLM Layout, Frames Layout, and OpenApi Layout components.

## Key Changes
- Removed `PageHeader` import from McpPage, LLM Layout, Frames Layout, and OpenApi Layout
- Removed `<PageHeader>` component instances that displayed titles, icons, and descriptions for each module
- Removed the fragment wrapper (`<>...</>`) that was used to wrap the PageHeader and main content, replacing it with the main content Box directly
- Adjusted indentation/nesting levels after removing the wrapper elements

## Details
The PageHeader component was previously used to display:
- Module titles (e.g., "MCP Server", "LLM Integration")
- Associated icons (e.g., "hub", "psychology")
- Descriptive text for each module

These headers are now removed, and the page content starts directly with the main Box container. This change appears to be part of a refactoring to handle page headers differently, possibly at a higher layout level or through a different mechanism.

https://claude.ai/code/session_016eTB38e2HCv1aQCWqzLcKi