### PR TITLE
Refactor collector visibility logic and add inactive collectors toggle

### DIFF
--- a/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
@@ -31,7 +31,12 @@ import {ScrollTopButton} from '@app-dev-panel/sdk/Component/ScrollTop';
 import {componentTokens} from '@app-dev-panel/sdk/Component/Theme/tokens';
 import {useCopyAsImage} from '@app-dev-panel/sdk/Component/useCopyAsImage';
 import {EventTypesEnum, useServerSentEvents} from '@app-dev-panel/sdk/Component/useServerSentEvents';
-import {compareCollectorWeight, getCollectorIcon, getCollectorLabel} from '@app-dev-panel/sdk/Helper/collectorMeta';
+import {
+    compareCollectorWeight,
+    getCollectorIcon,
+    getCollectorLabel,
+    hiddenSidebarCollectors,
+} from '@app-dev-panel/sdk/Helper/collectorMeta';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
 import {getCollectedCountByCollector} from '@app-dev-panel/sdk/Helper/collectorsTotal';
 import {isDebugEntryAboutConsole, isDebugEntryAboutWeb} from '@app-dev-panel/sdk/Helper/debugEntry';
@@ -102,20 +107,6 @@ function uiReducer(state: UIState, action: UIAction): UIState {
             return {...state, paletteOpen: false};
     }
 }
-
-// ---------------------------------------------------------------------------
-// Collectors hidden from sidebar (shown in overview instead)
-// ---------------------------------------------------------------------------
-const hiddenCollectors = new Set<string>([
-    CollectorsMap.WebAppInfoCollector,
-    CollectorsMap.ConsoleAppInfoCollector,
-    CollectorsMap.HttpStreamCollector,
-    CollectorsMap.DeprecationCollector,
-    CollectorsMap.VarDumperCollector,
-    CollectorsMap.HttpClientCollector,
-    CollectorsMap.RequestCollector,
-    CollectorsMap.CommandCollector,
-]);
 
 /**
  * Build colored segments for the Log sidebar badge: log info / warnings / errors / deprecations / dumps.
@@ -475,7 +466,7 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
             : [];
         const collectors = [...debugEntry.collectors]
             .map((c) => (typeof c === 'string' ? c : c.id))
-            .filter((c) => !hiddenCollectors.has(c))
+            .filter((c) => !hiddenSidebarCollectors.has(c))
             .sort(compareCollectorWeight)
             .map((collector) => {
                 const count = getCollectedCountByCollector(collector as CollectorsMap, debugEntry);

--- a/libs/frontend/packages/panel/src/Module/Debug/Pages/IndexPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Pages/IndexPage.tsx
@@ -1,6 +1,12 @@
+import {useSelector} from '@app-dev-panel/panel/store';
 import {useDebugEntry} from '@app-dev-panel/sdk/API/Debug/Context';
 import {DebugEntry, useLazyGetCollectorInfoQuery} from '@app-dev-panel/sdk/API/Debug/Debug';
-import {compareCollectorWeight, getCollectorIcon, getCollectorLabel} from '@app-dev-panel/sdk/Helper/collectorMeta';
+import {
+    compareCollectorWeight,
+    getCollectorIcon,
+    getCollectorLabel,
+    hiddenOverviewCollectors,
+} from '@app-dev-panel/sdk/Helper/collectorMeta';
 import {CollectorsMap} from '@app-dev-panel/sdk/Helper/collectors';
 import {getCollectedCountByCollector} from '@app-dev-panel/sdk/Helper/collectorsTotal';
 import {isDebugEntryAboutConsole, isDebugEntryAboutWeb} from '@app-dev-panel/sdk/Helper/debugEntry';
@@ -10,15 +16,6 @@ import {Box, Icon, LinearProgress, Typography} from '@mui/material';
 import {styled, useTheme} from '@mui/material/styles';
 import {useEffect, useState} from 'react';
 import {useSearchParams} from 'react-router';
-
-// Collectors hidden from the card grid (data shown elsewhere in overview)
-const hiddenCollectors = new Set<string>([
-    CollectorsMap.WebAppInfoCollector,
-    CollectorsMap.ConsoleAppInfoCollector,
-    CollectorsMap.EnvironmentCollector,
-    CollectorsMap.RequestCollector,
-    CollectorsMap.CommandCollector,
-]);
 
 // ---------------------------------------------------------------------------
 // Card icon background/foreground colors per collector (from theme tokens)
@@ -380,7 +377,7 @@ function buildCollectorCards(
 ): CollectorCardData[] {
     return [...entry.collectors]
         .map((c) => (typeof c === 'string' ? c : c.id))
-        .filter((c) => !hiddenCollectors.has(c))
+        .filter((c) => !hiddenOverviewCollectors.has(c))
         .sort(compareCollectorWeight)
         .map((collector) => {
             const count = getCollectedCountByCollector(collector as CollectorsMap, entry);
@@ -421,6 +418,7 @@ export const IndexPage = () => {
     const [getCollectorInfo] = useLazyGetCollectorInfoQuery();
     const [webAppInfo, setWebAppInfo] = useState<WebAppInfoData | null>(null);
     const [loadingPerf, setLoadingPerf] = useState(false);
+    const showInactiveCollectors = useSelector((state) => state.application.showInactiveCollectors);
 
     useEffect(() => {
         if (!entry) return;
@@ -446,7 +444,9 @@ export const IndexPage = () => {
 
     const cards = buildCollectorCards(entry, theme.adp.collectorColors);
     const activeCards = cards.filter((c) => c.badge != null && c.badge > 0);
-    const emptyCards = cards.filter((c) => c.badge == null || c.badge === 0);
+    // Mirrors sidebar: always show badge-less collectors (Router, Authorization);
+    // include zero-count ones only when the user opted in via the inactive-collectors toggle.
+    const emptyCards = cards.filter((c) => c.badge == null || (showInactiveCollectors && c.badge === 0));
 
     const handleCardClick = (collectorKey: string) => {
         setSearchParams((params) => {

--- a/libs/frontend/packages/sdk/src/Helper/collectorMeta.ts
+++ b/libs/frontend/packages/sdk/src/Helper/collectorMeta.ts
@@ -41,6 +41,28 @@ const collectorMetaMap: Record<string, CollectorMeta> = {
 
 const defaultMeta: CollectorMeta = {label: 'Unknown', icon: 'extension', weight: 99};
 
+// Collectors never listed in the sidebar or as an overview card.
+// - VarDumper / Deprecation entries are rendered inside the unified Log panel
+// - HttpClient / HttpStream entries are rendered inside the unified I/O panel
+// - WebAppInfo / ConsoleAppInfo feeds the performance strip, not a panel
+// - Request / Command is reached via the virtual EntryCollector summary bar
+export const hiddenSidebarCollectors: ReadonlySet<string> = new Set<string>([
+    CollectorsMap.WebAppInfoCollector,
+    CollectorsMap.ConsoleAppInfoCollector,
+    CollectorsMap.HttpStreamCollector,
+    CollectorsMap.DeprecationCollector,
+    CollectorsMap.VarDumperCollector,
+    CollectorsMap.HttpClientCollector,
+    CollectorsMap.RequestCollector,
+    CollectorsMap.CommandCollector,
+]);
+
+// Overview cards additionally hide Environment (it already has a dedicated strip).
+export const hiddenOverviewCollectors: ReadonlySet<string> = new Set<string>([
+    ...hiddenSidebarCollectors,
+    CollectorsMap.EnvironmentCollector,
+]);
+
 /**
  * Returns display metadata for a collector class name.
  * Falls back to parsing the short class name if no explicit mapping exists.


### PR DESCRIPTION
## Summary
This PR centralizes collector visibility configuration and implements support for toggling the display of inactive collectors in the debug panel overview.

## Key Changes

- **Centralized collector metadata**: Moved hardcoded `hiddenCollectors` sets from `Layout.tsx` and `IndexPage.tsx` into `collectorMeta.ts` as exported constants (`hiddenSidebarCollectors` and `hiddenOverviewCollectors`), making the configuration more maintainable and reusable.

- **Separated sidebar and overview visibility rules**: Created two distinct sets to handle different visibility requirements:
  - `hiddenSidebarCollectors`: Collectors hidden from the sidebar (8 collectors)
  - `hiddenOverviewCollectors`: Collectors additionally hidden from overview cards (includes Environment collector)

- **Added inactive collectors toggle**: Integrated Redux selector to read `showInactiveCollectors` state in the overview page, allowing users to control whether zero-count collectors are displayed.

- **Updated filtering logic**: Modified the overview card filtering to respect the new toggle:
  - Always shows badge-less collectors (Router, Authorization)
  - Shows zero-count collectors only when `showInactiveCollectors` is enabled
  - Added clarifying comments explaining the behavior

## Implementation Details

- The `hiddenOverviewCollectors` set extends `hiddenSidebarCollectors` to avoid duplication while maintaining the additional Environment collector exclusion for the overview.
- Both sets are marked as `ReadonlySet` to prevent accidental mutations.
- Updated imports in both `Layout.tsx` and `IndexPage.tsx` to use the new centralized constants.

https://claude.ai/code/session_017W1uHVaaxPefzcQ3RjVPW5