### PR TITLE
Extract class name rendering into dedicated ClassName component

### DIFF
--- a/libs/frontend/CLAUDE.md
+++ b/libs/frontend/CLAUDE.md
@@ -77,7 +77,7 @@ packages/
     │   │   ├── FilterInput.tsx             # Reusable filter text input with debounce
     │   │   ├── BodyPreview.tsx             # HTTP body preview (JSON, HTML, text)
     │   │   ├── ExplainPlanVisualizer.tsx   # SQL EXPLAIN plan tree visualizer
-    │   │   ├── FileLink.tsx               # Clickable file path link (IDE integration)
+    │   │   ├── FileLink.tsx               # Clickable file *path* link (File Explorer + Open in Editor). For class names use `panel/Application/Component/ClassName` instead.
     │   │   ├── StackTrace.tsx             # Exception stack trace renderer
     │   │   ├── KeyValueTable.tsx          # Key-value pair table display
     │   │   ├── StatusCard.tsx             # Status indicator card
@@ -264,6 +264,37 @@ Key features:
 - Endpoint: `/debug/api/event-stream`
 - Hook: `useServerSentEvents(baseUrl, onMessage, subscribe)`
 - Used for real-time debug entry notifications
+
+## Rendering Rules
+
+### Class names (PHP FQCN) — always use `ClassName`
+
+Any place that renders a PHP class name (fully-qualified or short) **must** use
+`packages/panel/src/Application/Component/ClassName.tsx`. It provides the two
+required affordances: a link to the internal File Explorer
+(`/inspector/files?class=…`) **and** an "Open in Editor" button that resolves
+the source path via the inspector API and opens the user's configured IDE.
+
+```tsx
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
+
+// Full FQCN, default rendering
+<ClassName value={message.messageClass} />
+
+// Short label in a list row, full FQCN drives the links
+<ClassName value={fqcn}>{shortClassName(fqcn)}</ClassName>
+
+// Callable — method name is included in both explorer and editor URLs
+<ClassName value={action.className} methodName={action.methodName} />
+```
+
+Do **not** render class names as plain `Typography`, `styled(Typography)`, or
+`<FileLink className=…>`. `FileLink` is for file *paths* only — it has no
+`className` prop anymore.
+
+Non-FQCN values (short names without a `\`) render as plain inline text
+without buttons, so the component is safe to use for both short and
+fully-qualified identifiers.
 
 ## Code Quality
 

--- a/libs/frontend/packages/panel/src/Application/Component/ClassName.test.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/ClassName.test.tsx
@@ -1,0 +1,41 @@
+import {renderWithProviders} from '@app-dev-panel/sdk/test-utils';
+import {screen} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+import {ClassName} from './ClassName';
+
+const FQCN = 'App\\Message\\ProcessPayment';
+
+describe('ClassName', () => {
+    it('renders plain text without buttons when value is not a FQCN', () => {
+        renderWithProviders(<ClassName value="NotAClass" />);
+        expect(screen.getByText('NotAClass')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Open in File Explorer')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Open in Editor')).not.toBeInTheDocument();
+    });
+
+    it('renders a File Explorer icon button for a FQCN', () => {
+        renderWithProviders(<ClassName value={FQCN} />);
+        expect(screen.getByText(FQCN)).toBeInTheDocument();
+        const button = screen.getByLabelText('Open in File Explorer');
+        expect(button).toHaveAttribute('href', expect.stringMatching(/^\/inspector\/files\?class=/));
+    });
+
+    it('includes method name in the File Explorer URL when provided', () => {
+        renderWithProviders(<ClassName value="App\Controller\HomeController" methodName="index" />);
+        const button = screen.getByLabelText('Open in File Explorer');
+        const href = button.getAttribute('href') ?? '';
+        expect(href).toContain('class=App');
+        expect(href).toContain('method=index');
+    });
+
+    it('uses custom children as the link label', () => {
+        renderWithProviders(<ClassName value={FQCN}>ProcessPayment</ClassName>);
+        expect(screen.getByText('ProcessPayment')).toBeInTheDocument();
+        expect(screen.queryByText(FQCN)).not.toBeInTheDocument();
+    });
+
+    it('does not render Open in Editor button when editor is not configured', () => {
+        renderWithProviders(<ClassName value={FQCN} />);
+        expect(screen.queryByLabelText('Open in Editor')).not.toBeInTheDocument();
+    });
+});

--- a/libs/frontend/packages/panel/src/Application/Component/ClassName.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/ClassName.tsx
@@ -1,0 +1,92 @@
+import {useGetClassQuery} from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
+import {type EditorConfig} from '@app-dev-panel/sdk/Helper/editorUrl';
+import {useEditorUrl} from '@app-dev-panel/sdk/Helper/useEditorUrl';
+import {Code, FolderOpen} from '@mui/icons-material';
+import {IconButton, Tooltip, Typography} from '@mui/material';
+import {type ReactNode} from 'react';
+import {useSelector} from 'react-redux';
+import {Link as RouterLink} from 'react-router';
+
+type ClassNameProps = {value: string; methodName?: string; children?: ReactNode; sx?: Record<string, unknown>};
+
+const isFqcn = (value: string): boolean => value.includes('\\');
+
+const isEditorEnabled = (config: EditorConfig | undefined): boolean =>
+    !!config && (config.editor !== 'none' || !!config.customUrlTemplate);
+
+/**
+ * Renders a PHP class name with two action buttons:
+ * - Open in File Explorer (internal `/inspector/files?class=...`)
+ * - Open in Editor (e.g. `phpstorm://`, `vscode://`, resolved via user settings)
+ *
+ * The source file path is resolved lazily via the inspector API when an
+ * editor is configured, so the editor URL can jump to the class (and the
+ * method start line when `methodName` is provided).
+ *
+ * Buttons are suppressed when `value` is not a fully-qualified name
+ * (no backslash) — short/unknown identifiers render as plain text.
+ */
+export const ClassName = ({value, methodName, children, sx}: ClassNameProps) => {
+    const getEditorUrl = useEditorUrl();
+    const editorConfig = useSelector(
+        (state: {application: {editorConfig?: EditorConfig}}) => state.application.editorConfig,
+    );
+    const fqcn = isFqcn(value);
+    const editorEnabled = isEditorEnabled(editorConfig);
+
+    const {data} = useGetClassQuery({className: value, methodName: methodName ?? ''}, {skip: !fqcn || !editorEnabled});
+
+    // getClass returns a single file-content object when a class is resolved,
+    // despite the builder's declared `InspectorFile[]` return type.
+    const resolved = !Array.isArray(data) ? (data as {path?: string; startLine?: number} | undefined) : undefined;
+    const editorUrl = resolved?.path ? getEditorUrl(resolved.path, resolved.startLine) : null;
+
+    const params = new URLSearchParams({class: value});
+    if (methodName) params.set('method', methodName);
+    const explorerHref = `/inspector/files?${params.toString()}`;
+
+    const label = children ?? (
+        <Typography
+            component="span"
+            sx={(theme) => ({fontFamily: theme.adp.fontFamilyMono, fontSize: 'inherit', color: 'inherit'})}
+        >
+            {value}
+        </Typography>
+    );
+
+    if (!fqcn) {
+        return <span style={{display: 'inline-flex', alignItems: 'center', minWidth: 0, ...sx}}>{label}</span>;
+    }
+
+    return (
+        <span style={{display: 'inline-flex', alignItems: 'center', gap: 2, minWidth: 0, ...sx}}>
+            {label}
+            <Tooltip title="Open in File Explorer">
+                <IconButton
+                    size="small"
+                    component={RouterLink}
+                    to={explorerHref}
+                    aria-label="Open in File Explorer"
+                    onClick={(e) => e.stopPropagation()}
+                    sx={{p: 0.25, ml: 0.25}}
+                >
+                    <FolderOpen sx={{fontSize: 14}} />
+                </IconButton>
+            </Tooltip>
+            {editorUrl && (
+                <Tooltip title="Open in Editor">
+                    <IconButton
+                        size="small"
+                        component="a"
+                        href={editorUrl}
+                        aria-label="Open in Editor"
+                        onClick={(e) => e.stopPropagation()}
+                        sx={{p: 0.25}}
+                    >
+                        <Code sx={{fontSize: 14}} />
+                    </IconButton>
+                </Tooltip>
+            )}
+        </span>
+    );
+};

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/AssetBundlePanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/AssetBundlePanel.tsx
@@ -1,3 +1,4 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRenderer';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
@@ -131,7 +132,9 @@ export const AssetBundlePanel = ({data}: AssetBundlePanelProps) => {
                 return (
                     <Box key={key}>
                         <BundleRow expanded={expanded} onClick={() => setExpandedKey(expanded ? null : key)}>
-                            <ClassCell>{shortClassName(bundle.class)}</ClassCell>
+                            <ClassCell>
+                                <ClassName value={bundle.class}>{shortClassName(bundle.class)}</ClassName>
+                            </ClassCell>
                             {bundle.css.length > 0 && (
                                 <Chip
                                     label={`${bundle.css.length} CSS`}
@@ -178,7 +181,7 @@ export const AssetBundlePanel = ({data}: AssetBundlePanelProps) => {
                             <DetailBox>
                                 <Box sx={{mb: 1.5}}>
                                     <FieldLabel>Full Class Name</FieldLabel>
-                                    <Typography
+                                    <Box
                                         sx={(theme) => ({
                                             fontFamily: theme.adp.fontFamilyMono,
                                             fontSize: '12px',
@@ -186,8 +189,8 @@ export const AssetBundlePanel = ({data}: AssetBundlePanelProps) => {
                                             wordBreak: 'break-all',
                                         })}
                                     >
-                                        {bundle.class}
-                                    </Typography>
+                                        <ClassName value={bundle.class} />
+                                    </Box>
                                 </Box>
                                 {bundle.sourcePath && (
                                     <Box sx={{mb: 1.5}}>

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/CommandPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/CommandPanel.tsx
@@ -1,3 +1,4 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRenderer';
 import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
 import {Box, Chip, Collapse, Icon, Tab, Tabs, Typography, type Theme} from '@mui/material';
@@ -280,7 +281,13 @@ const EventCard = ({eventClass, eventData}: {eventClass: string; eventData: Comm
                 }}
             >
                 <Icon sx={{fontSize: 16, color: 'text.disabled'}}>{expanded ? 'expand_less' : 'expand_more'}</Icon>
-                <Typography sx={{fontWeight: 600, fontSize: '13px', flex: 1}}>{shortName}</Typography>
+                <Box sx={{fontWeight: 600, fontSize: '13px', flex: 1, display: 'flex', alignItems: 'center'}}>
+                    <ClassName value={eventClass}>
+                        <Typography component="span" sx={{fontWeight: 600, fontSize: '13px'}}>
+                            {shortName}
+                        </Typography>
+                    </ClassName>
+                </Box>
                 {exitCode != null && (
                     <Chip
                         label={exitCode === 0 ? 'OK' : `exit ${exitCode}`}

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/DeprecationPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/DeprecationPanel.tsx
@@ -1,3 +1,4 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
@@ -233,9 +234,13 @@ export const DeprecationPanel = ({data}: DeprecationPanelProps) => {
                                         {entry.trace.map((frame, i) => (
                                             <TraceRow key={i}>
                                                 {frame.file && `${frame.file}:${frame.line} `}
-                                                {frame.class
-                                                    ? `${frame.class}::${frame.function}()`
-                                                    : `${frame.function}()`}
+                                                {frame.class ? (
+                                                    <ClassName value={frame.class} methodName={frame.function}>
+                                                        {`${frame.class}::${frame.function}()`}
+                                                    </ClassName>
+                                                ) : (
+                                                    `${frame.function}()`
+                                                )}
                                             </TraceRow>
                                         ))}
                                     </Box>

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EventPanel.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EventPanel.test.tsx
@@ -78,7 +78,8 @@ describe('EventPanel', () => {
         renderWithProviders(<EventPanel events={[makeEvent({name: 'App\\Event\\Click'})]} />, {preloadedState});
         const elements = screen.getAllByText('Click');
         await user.click(elements[0]);
-        expect(screen.getByLabelText('Open File')).toBeInTheDocument();
+        // Expanded detail exposes the ClassName widget for the event class
+        expect(screen.getByLabelText('Open in File Explorer')).toBeInTheDocument();
         // Full class name may appear in both detail and tooltip
         expect(screen.getAllByText('App\\Event\\Click').length).toBeGreaterThanOrEqual(1);
     });

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EventPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/EventPanel.tsx
@@ -1,11 +1,10 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRenderer';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
-import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
 import {parseFilename} from '@app-dev-panel/sdk/Helper/filePathParser';
 import {formatMicrotime} from '@app-dev-panel/sdk/Helper/formatDate';
-import {Description} from '@mui/icons-material';
 import {Box, Chip, Collapse, Icon, IconButton, Tooltip, Typography} from '@mui/material';
 import {styled, useTheme} from '@mui/material/styles';
 import {useCallback, useDeferredValue, useMemo, useState} from 'react';
@@ -238,28 +237,16 @@ export const EventPanel = ({events}: EventTimelineProps) => {
                         <Collapse in={expanded}>
                             <DetailBox>
                                 <Box sx={{display: 'flex', alignItems: 'center', gap: 0.5, mb: 1}}>
-                                    <Typography
-                                        variant="caption"
+                                    <Box
                                         sx={(theme) => ({
                                             fontFamily: theme.adp.fontFamilyMono,
+                                            fontSize: theme.typography.caption.fontSize,
                                             color: 'text.secondary',
                                             flex: 1,
                                         })}
                                     >
-                                        {event.name}
-                                    </Typography>
-                                    <FileLink className={event.name}>
-                                        <Tooltip title="Open File">
-                                            <IconButton
-                                                size="small"
-                                                component="span"
-                                                aria-label="Open File"
-                                                sx={{p: 0.5}}
-                                            >
-                                                <Description sx={{fontSize: 16}} />
-                                            </IconButton>
-                                        </Tooltip>
-                                    </FileLink>
+                                        <ClassName value={event.name} />
+                                    </Box>
                                 </Box>
 
                                 {event.event && <JsonRenderer value={event.event} depth={3} />}

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/ExceptionPanel.test.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/ExceptionPanel.test.tsx
@@ -68,9 +68,12 @@ describe('ExceptionPanel', () => {
     });
 
     it('always shows exception detail (no expand needed)', () => {
-        renderWithProviders(<ExceptionPanel exceptions={[makeException()]} />);
-        // Detail is always visible — chips should be immediately present
-        expect(screen.getByLabelText('Open Exception Class')).toBeInTheDocument();
+        renderWithProviders(
+            <ExceptionPanel exceptions={[makeException({class: 'App\\Exception\\RuntimeException'})]} />,
+        );
+        // Detail is always visible — exception class is rendered via ClassName in the row header
+        // (its file-explorer button appears only for FQCNs), source-location button is in the detail body
+        expect(screen.getAllByLabelText('Open in File Explorer').length).toBeGreaterThanOrEqual(1);
         expect(screen.getByLabelText('Open Source Location')).toBeInTheDocument();
     });
 

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/ExceptionPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/ExceptionPanel.tsx
@@ -1,3 +1,4 @@
+import {ClassName as ClassNameLink} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {InspectorFileContent, useLazyGetFilesQuery} from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
 import {CodeHighlight} from '@app-dev-panel/sdk/Component/CodeHighlight';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
@@ -7,8 +8,8 @@ import {StackTrace} from '@app-dev-panel/sdk/Component/StackTrace';
 import {monoFontFamily} from '@app-dev-panel/sdk/Component/Theme/DefaultTheme';
 import {parseFilename, parseFilePath} from '@app-dev-panel/sdk/Helper/filePathParser';
 import {usePathMapper} from '@app-dev-panel/sdk/Helper/usePathMapper';
-import {BugReport, FmdGood} from '@mui/icons-material';
-import {Box, Chip, Collapse, Icon, IconButton, Tooltip, Typography} from '@mui/material';
+import {FmdGood} from '@mui/icons-material';
+import {Box, Chip, Collapse, Icon, IconButton, type Theme, Tooltip, Typography} from '@mui/material';
 import {alpha, styled, useTheme} from '@mui/material/styles';
 import {useEffect, useState} from 'react';
 
@@ -52,13 +53,13 @@ const IndexBadge = styled(Box)(({theme}) => ({
     marginTop: 2,
 }));
 
-const ClassName = styled(Typography)(({theme}) => ({
+const classNameSx = (theme: Theme) => ({
     fontFamily: theme.adp.fontFamilyMono,
     fontSize: '13px',
     fontWeight: 600,
     color: theme.palette.error.main,
     wordBreak: 'break-word',
-}));
+});
 
 const Message = styled(Typography)(({theme}) => ({
     fontSize: '13px',
@@ -117,13 +118,6 @@ const ExceptionDetail = ({exception}: {exception: ExceptionData}) => {
             <Typography sx={{fontSize: '13px', mb: 2, color: 'text.primary'}}>{exception.message}</Typography>
 
             <Box sx={{display: 'flex', gap: 0.5, mb: 2}}>
-                <FileLink className={parseFilePath(exception.class)}>
-                    <Tooltip title="Open Exception Class">
-                        <IconButton size="small" component="span" aria-label="Open Exception Class" sx={{p: 0.5}}>
-                            <BugReport sx={{fontSize: 16}} />
-                        </IconButton>
-                    </Tooltip>
-                </FileLink>
                 <FileLink path={localFile} line={+exception.line}>
                     <Tooltip title="Open Source Location">
                         <IconButton size="small" component="span" aria-label="Open Source Location" sx={{p: 0.5}}>
@@ -203,7 +197,9 @@ export const ExceptionPanel = ({exceptions}: ExceptionPanelProps) => {
                         <ExceptionRow expanded={expanded} onClick={() => setExpandedIndex(expanded ? null : index)}>
                             <IndexBadge>{index + 1}</IndexBadge>
                             <Box sx={{flex: 1, minWidth: 0}}>
-                                <ClassName>{exception.class}</ClassName>
+                                <Box sx={classNameSx}>
+                                    <ClassNameLink value={exception.class} />
+                                </Box>
                                 <Message>{exception.message}</Message>
                             </Box>
                             <FileLink path={pathMapper.toLocal(exception.file)} line={+exception.line}>

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/MiddlewarePanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/MiddlewarePanel.tsx
@@ -1,3 +1,4 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRenderer';
 import {useDebugEntry} from '@app-dev-panel/sdk/API/Debug/Context';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
@@ -122,9 +123,11 @@ export const MiddlewarePanel = (props: MiddlewarePanelProps) => {
                                 }}
                             />
                             <NameCell>
-                                <Tooltip title={row.name}>
-                                    <span>{shortName}</span>
-                                </Tooltip>
+                                <ClassName value={row.name}>
+                                    <Tooltip title={row.name}>
+                                        <span>{shortName}</span>
+                                    </Tooltip>
+                                </ClassName>
                             </NameCell>
                             {row.memory > 0 && (
                                 <Typography sx={{fontSize: '11px', color: 'text.disabled', flexShrink: 0}}>
@@ -137,17 +140,17 @@ export const MiddlewarePanel = (props: MiddlewarePanelProps) => {
                         </MiddlewareRow>
                         <Collapse in={expanded}>
                             <DetailBox>
-                                <Typography
-                                    variant="caption"
+                                <Box
                                     sx={(theme) => ({
                                         fontFamily: theme.adp.fontFamilyMono,
+                                        fontSize: theme.typography.caption.fontSize,
                                         color: 'text.secondary',
                                         display: 'block',
                                         mb: 1,
                                     })}
                                 >
-                                    {row.name}
-                                </Typography>
+                                    <ClassName value={row.name} />
+                                </Box>
 
                                 {objectId && debugEntry && (
                                     <Box sx={{mb: 1}}>

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/QueuePanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/QueuePanel.tsx
@@ -1,3 +1,4 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRenderer';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
@@ -162,7 +163,9 @@ const MessageItem = ({message, expanded, onToggle}: {message: Message; expanded:
     return (
         <Box>
             <ItemRow expanded={expanded} onClick={onToggle}>
-                <MessageClassCell>{shortClassName(message.messageClass)}</MessageClassCell>
+                <MessageClassCell>
+                    <ClassName value={message.messageClass}>{shortClassName(message.messageClass)}</ClassName>
+                </MessageClassCell>
                 <Chip
                     label={message.bus}
                     size="small"
@@ -246,7 +249,7 @@ const MessageItem = ({message, expanded, onToggle}: {message: Message; expanded:
                         <Typography sx={{fontSize: '11px', fontWeight: 600, color: 'text.disabled', mb: 0.5}}>
                             Full Class Name
                         </Typography>
-                        <Typography
+                        <Box
                             sx={(theme) => ({
                                 fontFamily: theme.adp.fontFamilyMono,
                                 fontSize: '12px',
@@ -254,8 +257,8 @@ const MessageItem = ({message, expanded, onToggle}: {message: Message; expanded:
                                 wordBreak: 'break-all',
                             })}
                         >
-                            {message.messageClass}
-                        </Typography>
+                            <ClassName value={message.messageClass} />
+                        </Box>
                         {message.message != null && (
                             <Box sx={{mt: 1.5}}>
                                 <Typography sx={{fontSize: '11px', fontWeight: 600, color: 'text.disabled', mb: 0.5}}>

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/RouterPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/RouterPanel.tsx
@@ -1,6 +1,6 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRenderer';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
-import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
 import {monoFontFamily} from '@app-dev-panel/sdk/Component/Theme/DefaultTheme';
@@ -181,19 +181,14 @@ export const RouterPanel = ({data}: RouterPanelProps) => {
                             <FieldLabel>Action</FieldLabel>
                             <FieldValue sx={{fontFamily: monoFontFamily}}>
                                 {typeof currentRoute.action === 'string' ? (
-                                    <FileLink className={currentRoute.action}>
+                                    <ClassName value={currentRoute.action}>
                                         <Typography
                                             component="span"
-                                            sx={{
-                                                fontFamily: monoFontFamily,
-                                                fontSize: '12px',
-                                                color: 'primary.main',
-                                                '&:hover': {textDecoration: 'underline'},
-                                            }}
+                                            sx={{fontFamily: monoFontFamily, fontSize: '12px', color: 'primary.main'}}
                                         >
                                             {currentRoute.action}
                                         </Typography>
-                                    </FileLink>
+                                    </ClassName>
                                 ) : (
                                     <JsonRenderer value={currentRoute.action} />
                                 )}

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/ServicesPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/ServicesPanel.tsx
@@ -1,3 +1,4 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRenderer';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
@@ -88,7 +89,11 @@ const SummaryView = ({summaryRows}: {summaryRows: Record<string, SummaryItemType
                 return (
                     <Box key={index}>
                         <ServiceRow expanded={expanded} onClick={() => setExpandedIndex(expanded ? null : index)}>
-                            <MethodCell>{concatClassMethod(row.class, row.method)}</MethodCell>
+                            <MethodCell>
+                                <ClassName value={row.class} methodName={row.method}>
+                                    {concatClassMethod(row.class, row.method)}
+                                </ClassName>
+                            </MethodCell>
                             <Chip
                                 label={`${row.count} call${row.count !== 1 ? 's' : ''}`}
                                 size="small"
@@ -179,7 +184,11 @@ const AllView = ({rows}: {rows: AllRow[]}) => {
                 return (
                     <Box key={index}>
                         <ServiceRow expanded={expanded} onClick={() => setExpandedIndex(expanded ? null : index)}>
-                            <MethodCell>{concatClassMethod(row.class, row.method)}</MethodCell>
+                            <MethodCell>
+                                <ClassName value={row.class} methodName={row.method}>
+                                    {concatClassMethod(row.class, row.method)}
+                                </ClassName>
+                            </MethodCell>
                             <Chip
                                 label={isError ? 'ERROR' : 'OK'}
                                 size="small"

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/TimelineDetailCard.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/TimelineDetailCard.tsx
@@ -1,6 +1,6 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRenderer';
 import {type TimelineItem} from '@app-dev-panel/panel/Module/Debug/Component/Panel/timelineTypes';
-import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
 import {MessageCopyButton} from '@app-dev-panel/sdk/Component/MessageCopyButton';
 import {SqlHighlight} from '@app-dev-panel/sdk/Component/SqlHighlight';
 import {isClassString} from '@app-dev-panel/sdk/Helper/classMatcher';
@@ -65,20 +65,14 @@ export const TimelineDetailCard = ({
                 <MetaLabel sx={{color: 'text.disabled'}}>{formatMicrotime(row[0])}</MetaLabel>
                 <MetaLabel sx={{color: 'text.disabled'}}>Offset: {offsetLabel}</MetaLabel>
                 {row[1] != null && <MetaLabel sx={{color: 'text.disabled'}}>Ref: {String(row[1])}</MetaLabel>}
-                <FileLink className={collectorClass}>
+                <ClassName value={collectorClass}>
                     <Typography
                         component="span"
-                        sx={(t) => ({
-                            fontFamily: t.adp.fontFamilyMono,
-                            fontSize: '11px',
-                            color: 'primary.main',
-                            cursor: 'pointer',
-                            '&:hover': {textDecoration: 'underline'},
-                        })}
+                        sx={(t) => ({fontFamily: t.adp.fontFamilyMono, fontSize: '11px', color: 'primary.main'})}
                     >
                         {collectorClass.split('\\').pop() ?? collectorClass}
                     </Typography>
-                </FileLink>
+                </ClassName>
             </Header>
 
             {showDetail && (

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/UnifiedLogPanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/UnifiedLogPanel.tsx
@@ -1,3 +1,4 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRenderer';
 import {VarDumpValue} from '@app-dev-panel/panel/Module/Debug/Component/VarDumpValue';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
@@ -658,9 +659,16 @@ export const UnifiedLogPanel = ({logs, deprecations, dumps}: UnifiedLogPanelProp
                                                 {dep.trace.map((frame, i) => (
                                                     <TraceRow key={i}>
                                                         {frame.file && `${frame.file}:${frame.line} `}
-                                                        {frame.class
-                                                            ? `${frame.class}::${frame.function}()`
-                                                            : `${frame.function}()`}
+                                                        {frame.class ? (
+                                                            <ClassName
+                                                                value={frame.class}
+                                                                methodName={frame.function}
+                                                            >
+                                                                {`${frame.class}::${frame.function}()`}
+                                                            </ClassName>
+                                                        ) : (
+                                                            `${frame.function}()`
+                                                        )}
                                                     </TraceRow>
                                                 ))}
                                             </Box>

--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Timeline/TimelineContentWrapper.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Timeline/TimelineContentWrapper.tsx
@@ -1,3 +1,4 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {useDebugEntry} from '@app-dev-panel/sdk/API/Debug/Context';
 import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
 import {parseObjectId} from '@app-dev-panel/sdk/Helper/objectString';
@@ -22,9 +23,11 @@ export const TimelineContentWrapper = React.memo((props: PropsWithChildren<Timel
     return (
         <TimelineContent sx={{py: '12px', px: 2, display: 'flex', flexDirection: 'column'}}>
             <Box sx={{wordBreak: 'break-word'}}>
-                <Tooltip title={name}>
-                    <Typography component="span">{shortName}</Typography>
-                </Tooltip>
+                <ClassName value={name}>
+                    <Tooltip title={name}>
+                        <Typography component="span">{shortName}</Typography>
+                    </Tooltip>
+                </ClassName>
                 {debugEntry && (
                     <Tooltip title="Examine an object">
                         <IconButton

--- a/libs/frontend/packages/panel/src/Module/Debug/Pages/ObjectPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Pages/ObjectPage.tsx
@@ -1,3 +1,4 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {JsonRenderer} from '@app-dev-panel/panel/Module/Debug/Component/JsonRenderer';
 import {useGetObjectQuery} from '@app-dev-panel/sdk/API/Debug/Debug';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
@@ -38,8 +39,12 @@ export const ObjectPage = () => {
 
     return (
         <Box>
-            <Typography variant="h6" my={1}>
-                {data.class}#{objectId}
+            <Typography variant="h6" my={1} component="div">
+                <ClassName value={data.class}>
+                    <span>
+                        {data.class}#{objectId}
+                    </span>
+                </ClassName>
             </Typography>
             <JsonRenderer value={data.value} />
         </Box>

--- a/libs/frontend/packages/panel/src/Module/Debug/Pages/ObjectPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Pages/ObjectPage.tsx
@@ -39,7 +39,7 @@ export const ObjectPage = () => {
 
     return (
         <Box>
-            <Typography variant="h6" my={1} component="div">
+            <Typography variant="h6" my={1}>
                 <ClassName value={data.class}>
                     <span>
                         {data.class}#{objectId}

--- a/libs/frontend/packages/panel/src/Module/Inspector/API/Inspector.ts
+++ b/libs/frontend/packages/panel/src/Module/Inspector/API/Inspector.ts
@@ -489,6 +489,7 @@ export const {
     useGetClassesQuery,
     useLazyGetObjectQuery,
     useLazyGetFilesQuery,
+    useGetClassQuery,
     useLazyGetClassQuery,
     useGetCommandsQuery,
     useLazyGetCommandsQuery,

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/AuthorizationPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/AuthorizationPage.tsx
@@ -1,3 +1,4 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {
     AuthorizationGuard,
     AuthorizationVoter,
@@ -8,10 +9,8 @@ import {JsonRenderer} from '@app-dev-panel/sdk/Component/JsonRenderer';
 import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
 import {QueryErrorState} from '@app-dev-panel/sdk/Component/QueryErrorState';
 import {SectionTitle} from '@app-dev-panel/sdk/Component/SectionTitle';
-import {FolderOpen} from '@mui/icons-material';
-import {Box, Chip, IconButton, LinearProgress, Tooltip, Typography} from '@mui/material';
+import {Box, Chip, LinearProgress, Typography} from '@mui/material';
 import {styled} from '@mui/material/styles';
-import {Link as RouterLink} from 'react-router';
 
 const TableContainer = styled(Box)(({theme}) => ({
     border: `1px solid ${theme.palette.divider}`,
@@ -40,10 +39,8 @@ const TableHeader = styled(TableRow)(({theme}) => ({
 
 const MonoText = styled(Typography)(({theme}) => ({fontFamily: theme.adp.fontFamilyMono, fontSize: '12px'}));
 
-const isFqcn = (value: string): boolean => value.includes('\\');
-
-const ClassName = ({value, bold = false, muted = false}: {value: string; bold?: boolean; muted?: boolean}) => (
-    <Box sx={{display: 'inline-flex', alignItems: 'center', gap: 0.25, minWidth: 0}}>
+const ClassNameText = ({value, bold = false, muted = false}: {value: string; bold?: boolean; muted?: boolean}) => (
+    <ClassName value={value}>
         <Typography
             component="span"
             sx={(theme) => ({
@@ -55,21 +52,7 @@ const ClassName = ({value, bold = false, muted = false}: {value: string; bold?: 
         >
             {value}
         </Typography>
-        {isFqcn(value) && (
-            <Tooltip title="Open in File Explorer">
-                <IconButton
-                    size="small"
-                    component={RouterLink}
-                    to={`/inspector/files?class=${encodeURIComponent(value)}`}
-                    aria-label="Open in File Explorer"
-                    onClick={(e) => e.stopPropagation()}
-                    sx={{p: 0.25}}
-                >
-                    <FolderOpen sx={{fontSize: 14}} />
-                </IconButton>
-            </Tooltip>
-        )}
-    </Box>
+    </ClassName>
 );
 
 const HierarchyRow = styled(Box)(({theme}) => ({
@@ -91,10 +74,10 @@ const GuardsTable = ({guards}: {guards: AuthorizationGuard[]}) => (
         {guards.map((guard) => (
             <TableRow key={guard.name}>
                 <Box sx={{flex: 1}}>
-                    <ClassName value={guard.name} bold />
+                    <ClassNameText value={guard.name} bold />
                 </Box>
                 <Box sx={{flex: 1}}>
-                    <ClassName value={guard.provider} muted />
+                    <ClassNameText value={guard.provider} muted />
                 </Box>
                 <Box sx={{flex: 2}}>
                     {Object.entries(guard.config).map(([key, value]) => (
@@ -167,7 +150,7 @@ const VotersTable = ({voters}: {voters: AuthorizationVoter[]}) => (
         {voters.map((voter, index) => (
             <TableRow key={index}>
                 <Box sx={{flex: 2}}>
-                    <ClassName value={voter.name} bold />
+                    <ClassNameText value={voter.name} bold />
                 </Box>
                 <Box sx={{flex: 1}}>
                     <Chip

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/EventsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/EventsPage.tsx
@@ -1,3 +1,4 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {
     ClosureDescriptor,
     EventEntry,
@@ -162,11 +163,11 @@ const ListenerItem = React.memo(({listener}: {listener: EventListener}) => {
     if (parsed) {
         return (
             <ListenerRow>
-                <FileLink className={parsed.className} methodName={parsed.methodName} sx={{flex: 1, minWidth: 0}}>
+                <ClassName value={parsed.className} methodName={parsed.methodName} sx={{flex: 1, minWidth: 0}}>
                     <Typography component="span" sx={monoLinkSx}>
                         {serializeCallable(listener)}
                     </Typography>
-                </FileLink>
+                </ClassName>
             </ListenerRow>
         );
     }
@@ -174,11 +175,11 @@ const ListenerItem = React.memo(({listener}: {listener: EventListener}) => {
     if (typeof listener === 'string' && isClassName(listener)) {
         return (
             <ListenerRow>
-                <FileLink className={listener} sx={{flex: 1, minWidth: 0}}>
+                <ClassName value={listener} sx={{flex: 1, minWidth: 0}}>
                     <Typography component="span" sx={monoLinkSx}>
                         {listener}
                     </Typography>
-                </FileLink>
+                </ClassName>
             </ListenerRow>
         );
     }

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/RoutesPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/RoutesPage.tsx
@@ -1,6 +1,6 @@
+import {ClassName} from '@app-dev-panel/panel/Application/Component/ClassName';
 import {useGetRoutesQuery, useLazyGetCheckRouteQuery} from '@app-dev-panel/panel/Module/Inspector/API/Inspector';
 import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
-import {FileLink} from '@app-dev-panel/sdk/Component/FileLink';
 import {FilterChip} from '@app-dev-panel/sdk/Component/FilterChip';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
@@ -186,7 +186,7 @@ const MiddlewareItem = ({mw}: {mw: any}) => {
     const parsed = parseCallable(mw);
     if (parsed) {
         return (
-            <FileLink className={parsed.className} methodName={parsed.methodName}>
+            <ClassName value={parsed.className} methodName={parsed.methodName}>
                 <Typography
                     component="span"
                     sx={(theme) => ({
@@ -194,19 +194,17 @@ const MiddlewareItem = ({mw}: {mw: any}) => {
                         fontFamily: theme.adp.fontFamilyMono,
                         fontSize: '12px',
                         color: 'primary.main',
-                        textDecoration: 'none',
                         py: 0.25,
-                        '&:hover': {textDecoration: 'underline'},
                     })}
                 >
                     {concatClassMethod(parsed.className, parsed.methodName)}
                 </Typography>
-            </FileLink>
+            </ClassName>
         );
     }
     if (typeof mw === 'string' && isClassName(mw)) {
         return (
-            <FileLink className={mw}>
+            <ClassName value={mw}>
                 <Typography
                     component="span"
                     sx={(theme) => ({
@@ -214,14 +212,12 @@ const MiddlewareItem = ({mw}: {mw: any}) => {
                         fontFamily: theme.adp.fontFamilyMono,
                         fontSize: '12px',
                         color: 'primary.main',
-                        textDecoration: 'none',
                         py: 0.25,
-                        '&:hover': {textDecoration: 'underline'},
                     })}
                 >
                     {mw}
                 </Typography>
-            </FileLink>
+            </ClassName>
         );
     }
     return (
@@ -253,7 +249,7 @@ const RouteDetail = ({route}: {route: RouteType}) => {
                         Action
                     </Typography>
                     <Box sx={{mt: 0.5, display: 'flex', alignItems: 'center', gap: 0.5}}>
-                        <FileLink className={action.className} methodName={action.methodName}>
+                        <ClassName value={action.className} methodName={action.methodName}>
                             <Typography
                                 component="span"
                                 sx={(theme) => ({
@@ -261,13 +257,11 @@ const RouteDetail = ({route}: {route: RouteType}) => {
                                     fontSize: '12px',
                                     wordBreak: 'break-all',
                                     color: 'primary.main',
-                                    textDecoration: 'none',
-                                    '&:hover': {textDecoration: 'underline'},
                                 })}
                             >
                                 {actionFull}
                             </Typography>
-                        </FileLink>
+                        </ClassName>
                         <Tooltip title="Copy">
                             <IconButton
                                 size="small"
@@ -370,20 +364,18 @@ const RouteChecker = () => {
                                 const parsed = parseCallable(checkRouteQueryInfo.data.action);
                                 if (parsed) {
                                     return (
-                                        <FileLink className={parsed.className} methodName={parsed.methodName}>
+                                        <ClassName value={parsed.className} methodName={parsed.methodName}>
                                             <Typography
                                                 component="span"
                                                 sx={(theme) => ({
                                                     fontFamily: theme.adp.fontFamilyMono,
                                                     fontSize: '13px',
                                                     color: 'primary.main',
-                                                    textDecoration: 'none',
-                                                    '&:hover': {textDecoration: 'underline'},
                                                 })}
                                             >
                                                 {parsed.className + '::' + parsed.methodName}
                                             </Typography>
-                                        </FileLink>
+                                        </ClassName>
                                     );
                                 }
                                 return serializeCallable(checkRouteQueryInfo.data.action);
@@ -549,17 +541,14 @@ export const RoutesPage = () => {
                                     />
                                     <PatternCell>{route.pattern}</PatternCell>
                                     {actionShort && route.action && (
-                                        <FileLink
-                                            className={route.action.className}
-                                            methodName={route.action.methodName}
-                                        >
+                                        <ClassName value={route.action.className} methodName={route.action.methodName}>
                                             <ActionInlineLink as="span">{actionShort}</ActionInlineLink>
-                                        </FileLink>
+                                        </ClassName>
                                     )}
-                                    {firstClassMwShort && (
-                                        <FileLink className={firstClassMw}>
+                                    {firstClassMwShort && typeof firstClassMw === 'string' && (
+                                        <ClassName value={firstClassMw}>
                                             <ActionInlineLink as="span">{firstClassMwShort}</ActionInlineLink>
-                                        </FileLink>
+                                        </ClassName>
                                     )}
                                     {route.name && <NameCell>{route.name}</NameCell>}
                                     {hasDetails && (

--- a/libs/frontend/packages/sdk/src/Component/FileLink.test.tsx
+++ b/libs/frontend/packages/sdk/src/Component/FileLink.test.tsx
@@ -4,8 +4,8 @@ import {renderWithProviders} from '../test-utils';
 import {FileLink} from './FileLink';
 
 describe('FileLink', () => {
-    it('returns null when neither path nor className provided', () => {
-        const {container} = renderWithProviders(<FileLink />);
+    it('returns null when path is empty', () => {
+        const {container} = renderWithProviders(<FileLink path="" />);
         expect(container.innerHTML).toBe('');
     });
 
@@ -20,28 +20,6 @@ describe('FileLink', () => {
         renderWithProviders(<FileLink path="/src/app.php">app.php</FileLink>);
         const link = screen.getByText('app.php');
         expect(link.closest('a')).toHaveAttribute('href', '/inspector/files?path=/src/app.php');
-    });
-
-    it('renders explorer link for className', () => {
-        renderWithProviders(<FileLink className={'App\\Controller\\HomeController'}>HomeController</FileLink>);
-        const link = screen.getByText('HomeController');
-        const href = link.closest('a')?.getAttribute('href') ?? '';
-        expect(href).toMatch(/^\/inspector\/files\?class=/);
-        expect(href).toContain('class=App');
-        expect(href).toContain('Controller');
-    });
-
-    it('renders explorer link for className with methodName', () => {
-        renderWithProviders(
-            <FileLink className={'App\\Controller'} methodName="index">
-                Controller::index
-            </FileLink>,
-        );
-        const link = screen.getByText('Controller::index');
-        const href = link.closest('a')?.getAttribute('href') ?? '';
-        expect(href).toContain('/inspector/files?');
-        expect(href).toContain('method=index');
-        expect(href).toContain('class=App');
     });
 
     it('does not render editor button when editor is none (default)', () => {
@@ -102,16 +80,6 @@ describe('FileLink', () => {
         );
         const editButton = screen.getByLabelText('Open in Editor');
         expect(editButton).toHaveAttribute('href', 'vscode://file/%2Fsrc%2Fapp.php:5');
-    });
-
-    it('does not render editor button for className-only link (no path)', () => {
-        renderWithProviders(<FileLink className="App\\Controller">Controller</FileLink>, {
-            preloadedState: {
-                application: {baseUrl: '', editorConfig: {editor: 'phpstorm', customUrlTemplate: '', pathMapping: {}}},
-            },
-        });
-        // No path means no editor URL can be generated
-        expect(screen.queryByLabelText('Open in Editor')).not.toBeInTheDocument();
     });
 
     it('renders without children (editor-only mode)', () => {

--- a/libs/frontend/packages/sdk/src/Component/FileLink.tsx
+++ b/libs/frontend/packages/sdk/src/Component/FileLink.tsx
@@ -7,14 +7,10 @@ import {Link as RouterLink} from 'react-router';
 
 type FileLinkProps = {
     /** File path, optionally with :line suffix (e.g. "/app/src/Foo.php:42") */
-    path?: string;
-    /** Class name for class-based resolution */
-    className?: string;
-    /** Method name (used with className) */
-    methodName?: string;
+    path: string;
     /** Explicit line number (overrides line parsed from path) */
     line?: number;
-    /** Content to render as the link text. If not provided, uses path or className. */
+    /** Content to render as the link text. If not provided, no text is rendered. */
     children?: ReactNode;
     /** Custom sx for the wrapper */
     sx?: Record<string, unknown>;
@@ -26,31 +22,27 @@ function extractLineFromPath(path: string): number | undefined {
 }
 
 /**
- * Renders a link to the internal File Explorer with an optional "Open in Editor" button.
- * The editor button appears only when an editor is configured in settings.
+ * Renders a link to the internal File Explorer for a given file path, with an
+ * optional "Open in Editor" button. The editor button appears only when an
+ * editor is configured in settings.
+ *
+ * For PHP class names (FQCN) use `ClassName` instead — it resolves the source
+ * location via the inspector API and adds a dedicated File Explorer button.
  *
  * Uses React Router Link directly (not MUI Link) to ensure SPA navigation
  * even when rendered inside components that override the MUI theme (e.g. JsonViewer).
  */
-export const FileLink = ({path, className, methodName, line, children, sx}: FileLinkProps) => {
+export const FileLink = ({path, line, children, sx}: FileLinkProps) => {
     const getEditorUrl = useEditorUrl();
 
-    // Build the internal file explorer href
-    let explorerHref: string;
-    if (className) {
-        const params = new URLSearchParams({class: className});
-        if (methodName) params.set('method', methodName);
-        explorerHref = `/inspector/files?${params.toString()}`;
-    } else if (path) {
-        explorerHref = `/inspector/files?path=${parseFilePathWithLineAnchor(path)}`;
-    } else {
+    if (!path) {
         return null;
     }
 
-    // Build editor URL
-    const cleanPath = path ? parseFilePath(path) : undefined;
-    const resolvedLine = line ?? (path ? extractLineFromPath(path) : undefined);
-    const editorUrl = cleanPath ? getEditorUrl(cleanPath, resolvedLine) : null;
+    const explorerHref = `/inspector/files?path=${parseFilePathWithLineAnchor(path)}`;
+    const cleanPath = parseFilePath(path);
+    const resolvedLine = line ?? extractLineFromPath(path);
+    const editorUrl = getEditorUrl(cleanPath, resolvedLine);
 
     return (
         <span style={{display: 'inline-flex', alignItems: 'center', gap: 2, ...sx}}>


### PR DESCRIPTION
## Summary

Introduces a new `ClassName` component to centralize PHP class name rendering across the application. This component provides consistent UI/UX for displaying fully-qualified class names (FQCNs) with integrated File Explorer and IDE editor links, while gracefully handling short/unknown identifiers as plain text.

## Key Changes

- **New Component**: `ClassName.tsx` in `panel/Application/Component/`
  - Renders PHP class names with two action buttons: "Open in File Explorer" and "Open in Editor"
  - Resolves source file paths lazily via the inspector API when an editor is configured
  - Supports optional `methodName` parameter to include method information in both explorer and editor URLs
  - Suppresses buttons for non-FQCN values (identifiers without backslash), rendering as plain inline text
  - Accepts custom children for label override and custom `sx` styling

- **Refactored FileLink**: Simplified to handle file *paths* only
  - Removed `className` and `methodName` props (now exclusive to `ClassName`)
  - Made `path` parameter required (was optional)
  - Removed class-based resolution logic
  - Updated documentation to clarify it's for file paths, not class names

- **Updated all class name usages** across debug and inspector modules:
  - `RoutesPage.tsx`: Middleware and route action rendering
  - `AuthorizationPage.tsx`: Guard and voter class names
  - `EventPanel.tsx`, `ExceptionPanel.tsx`, `MiddlewarePanel.tsx`: Event/exception class rendering
  - `TimelineDetailCard.tsx`, `UnifiedLogPanel.tsx`, `RouterPanel.tsx`: Collector and callable class names
  - `ServicesPanel.tsx`, `AssetBundlePanel.tsx`, `DeprecationPanel.tsx`, `QueuePanel.tsx`, `CommandPanel.tsx`: Service and message class rendering
  - `EventsPage.tsx`, `ObjectPage.tsx`: Event listener and object class rendering
  - `TimelineContentWrapper.tsx`: Timeline item class names

- **Documentation**: Updated `CLAUDE.md` with rendering rules for class names vs. file paths

## Implementation Details

- The component uses `useGetClassQuery` hook to resolve class file paths only when needed (FQCN + editor enabled)
- Editor URL generation is deferred until the class is resolved, enabling IDE jump-to-line functionality
- Non-FQCN values render safely without attempting resolution, making the component suitable for both short and fully-qualified identifiers
- Maintains consistent styling with monospace font and proper inline-flex layout for button alignment

https://claude.ai/code/session_01ANnytEo25taAhvV1e8yWu7