### PR TITLE
Enhance logger stats display with log level breakdown

### DIFF
--- a/libs/frontend/packages/panel/src/Module/Debug/Component/DebugEntryList.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/DebugEntryList.tsx
@@ -5,6 +5,13 @@ import {getEntrySearchText, isDebugEntryAboutConsole, isDebugEntryAboutWeb} from
 import {formatBytes} from '@app-dev-panel/sdk/Helper/formatBytes';
 import {formatDate, formatTime} from '@app-dev-panel/sdk/Helper/formatDate';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';
+import {
+    LOG_LEVEL_GROUP_ORDER,
+    LOG_LEVEL_GROUPS,
+    LogLevel,
+    LogLevelGroup,
+    sumLevels,
+} from '@app-dev-panel/sdk/Types/LogLevel';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import {
     Alert,
@@ -78,6 +85,38 @@ const StatCell = styled(Box)(({theme}) => ({
 }));
 
 const StatLabel = styled(Typography)(({theme}) => ({fontFamily: theme.adp.fontFamilyMono, fontSize: '10px'}));
+
+const LOG_GROUP_COLOR: Record<LogLevelGroup, string> = {
+    errors: 'error.main',
+    warnings: 'warning.main',
+    info: 'text.disabled',
+};
+
+type LogSummary = {total?: number; byLevel?: Partial<Record<LogLevel, number>>};
+
+const LogStat = ({logger}: {logger?: LogSummary}) => {
+    const total = logger?.total ?? 0;
+    if (total === 0) return null;
+    const byLevel = logger?.byLevel;
+    const segments = LOG_LEVEL_GROUP_ORDER.map((group) => ({
+        group,
+        count: byLevel ? sumLevels(byLevel, LOG_LEVEL_GROUPS[group]) : group === 'info' ? total : 0,
+    })).filter(({count}) => count > 0);
+    const visible = segments.length > 0 ? segments : [{group: 'info' as LogLevelGroup, count: total}];
+    return (
+        <StatCell>
+            <Icon sx={{fontSize: 13, color: 'text.disabled'}}>description</Icon>
+            {visible.map(({group, count}, i) => (
+                <React.Fragment key={group}>
+                    {i > 0 && <StatLabel sx={{color: 'text.disabled'}}>/</StatLabel>}
+                    <StatLabel sx={{color: LOG_GROUP_COLOR[group], fontWeight: group === 'errors' ? 700 : 400}}>
+                        {count}
+                    </StatLabel>
+                </React.Fragment>
+            ))}
+        </StatCell>
+    );
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -199,12 +238,7 @@ export const DebugEntryList = () => {
                             <MetaLabel sx={{color: 'primary.main'}}>{(duration * 1000).toFixed(0)}ms</MetaLabel>
                         )}
                         {memory != null && <MetaLabel sx={{color: 'success.main'}}>{formatBytes(memory)}</MetaLabel>}
-                        {entry.logger?.total != null && entry.logger.total > 0 && (
-                            <StatCell>
-                                <Icon sx={{fontSize: 13, color: 'text.disabled'}}>description</Icon>
-                                <StatLabel sx={{color: 'text.disabled'}}>{entry.logger.total}</StatLabel>
-                            </StatCell>
-                        )}
+                        <LogStat logger={entry.logger} />
                         {entry.db?.queries?.total != null && entry.db.queries.total > 0 && (
                             <StatCell>
                                 <Icon
@@ -279,12 +313,7 @@ export const DebugEntryList = () => {
                             <MetaLabel sx={{color: 'primary.main'}}>{(duration * 1000).toFixed(0)}ms</MetaLabel>
                         )}
                         {memory != null && <MetaLabel sx={{color: 'success.main'}}>{formatBytes(memory)}</MetaLabel>}
-                        {entry.logger?.total != null && entry.logger.total > 0 && (
-                            <StatCell>
-                                <Icon sx={{fontSize: 13, color: 'text.disabled'}}>description</Icon>
-                                <StatLabel sx={{color: 'text.disabled'}}>{entry.logger.total}</StatLabel>
-                            </StatCell>
-                        )}
+                        <LogStat logger={entry.logger} />
                         {hasN1Indicator(entry) && (
                             <Tooltip title="Duplicate operations detected (N+1)">
                                 <Chip


### PR DESCRIPTION
## Summary
Refactored the logger statistics display in the debug entry list to show a breakdown of log entries by severity level (errors, warnings, info) instead of just displaying the total count.

## Key Changes
- Added imports for log level types and utilities (`LOG_LEVEL_GROUP_ORDER`, `LOG_LEVEL_GROUPS`, `LogLevel`, `LogLevelGroup`, `sumLevels`)
- Created `LogSummary` type to represent logger statistics with optional total and breakdown by level
- Introduced `LogStat` component that:
  - Renders a visual breakdown of log entries grouped by severity level
  - Displays counts for errors, warnings, and info logs separated by forward slashes
  - Uses color coding: red for errors, orange for warnings, gray for info
  - Applies bold font weight to error counts for emphasis
  - Falls back to showing total count when level breakdown is unavailable
  - Returns null when there are no logs to display
- Added `LOG_GROUP_COLOR` mapping for consistent color styling across log level groups
- Replaced two instances of inline logger stat rendering with the new `LogStat` component (in both list and grid views)

## Implementation Details
- The component intelligently filters out log level groups with zero counts to avoid cluttering the UI
- When detailed level information is unavailable, it defaults to displaying the total as an info-level stat
- The color scheme aligns with Material-UI theme conventions (error.main, warning.main, text.disabled)

https://claude.ai/code/session_01AW8bQvhtmUvT88xJg5NJ6o