### PR TITLE
Format EmptyState icon styling to single line

### DIFF
--- a/libs/frontend/packages/sdk/src/Component/EmptyState.tsx
+++ b/libs/frontend/packages/sdk/src/Component/EmptyState.tsx
@@ -74,11 +74,7 @@ export const EmptyState = ({
                             // `&&` doubles the wrapper class specificity so we override
                             // the default 1.5rem font-size that MUI SvgIcon applies via
                             // its own MuiSvgIcon-fontSize* class.
-                            '&& > *': {
-                                fontSize: resolvedIconSize,
-                                width: resolvedIconSize,
-                                height: resolvedIconSize,
-                            },
+                            '&& > *': {fontSize: resolvedIconSize, width: resolvedIconSize, height: resolvedIconSize},
                         }}
                     >
                         {icon}


### PR DESCRIPTION
## Summary
Reformatted the CSS-in-JS styling object for the EmptyState component's icon wrapper to use a single-line format instead of multi-line.

## Key Changes
- Condensed the `'&& > *'` style object from 5 lines to 1 line in the EmptyState component
- No functional changes to the styling logic or behavior

## Implementation Details
The change is purely a code formatting/style adjustment. The three CSS properties (`fontSize`, `width`, and `height`) remain identical in their values and application - only the object literal formatting has been modified from expanded to compact form.

https://claude.ai/code/session_01Xjn8zppe4f1542hs1nvTgf