### PR TITLE
Fix Live Demo link behavior in hero section

### DIFF
--- a/website/index.md
+++ b/website/index.md
@@ -15,7 +15,7 @@ hero:
     - theme: alt
       text: Live Demo
       link: /demo/
-      rel: external
+      target: _self
     - theme: alt
       text: View on GitHub
       link: https://github.com/app-dev-panel/app-dev-panel

--- a/website/ru/index.md
+++ b/website/ru/index.md
@@ -15,7 +15,7 @@ hero:
     - theme: alt
       text: Live Demo
       link: /demo/
-      rel: external
+      target: _self
     - theme: alt
       text: GitHub
       link: https://github.com/app-dev-panel/app-dev-panel


### PR DESCRIPTION
## Summary
Updated the Live Demo button configuration in the hero section to use the correct link behavior attribute.

## Changes
- Changed `rel: external` to `target: _self` for the Live Demo button in both English and Russian homepage versions
- This ensures the Live Demo link (`/demo/`) opens in the same window/tab instead of being marked as an external link

## Details
The `rel: external` attribute was replaced with `target: _self`, which is the appropriate way to specify that a link should open in the current browsing context. This is particularly important for internal demo links that should not be treated as external resources.

Both language versions (English and Russian) were updated consistently to maintain parity across the site.

https://claude.ai/code/session_01XgT6Emt51D9DmGREMk2A8z