### PR TITLE
Track view render timing with before/after event handlers

### DIFF
--- a/libs/Adapter/Yii3/config/events-web.php
+++ b/libs/Adapter/Yii3/config/events-web.php
@@ -13,6 +13,7 @@ use AppDevPanel\Kernel\StartupContext;
 use Yiisoft\ErrorHandler\Event\ApplicationError;
 use Yiisoft\Profiler\ProfilerInterface;
 use Yiisoft\View\Event\WebView\AfterRender;
+use Yiisoft\View\Event\WebView\BeforeRender;
 use Yiisoft\Yii\Http\Event\AfterEmit;
 use Yiisoft\Yii\Http\Event\AfterRequest;
 use Yiisoft\Yii\Http\Event\ApplicationShutdown;
@@ -61,7 +62,10 @@ return [
             $event->getThrowable(),
         ),
     ],
+    BeforeRender::class => [
+        [ViewEventListener::class, 'beforeRender'],
+    ],
     AfterRender::class => [
-        [ViewEventListener::class, 'collect'],
+        [ViewEventListener::class, 'afterRender'],
     ],
 ];

--- a/libs/Adapter/Yii3/src/Collector/View/ViewEventListener.php
+++ b/libs/Adapter/Yii3/src/Collector/View/ViewEventListener.php
@@ -6,19 +6,37 @@ namespace AppDevPanel\Adapter\Yii3\Collector\View;
 
 use AppDevPanel\Kernel\Collector\TemplateCollector;
 use Yiisoft\View\Event\WebView\AfterRender;
+use Yiisoft\View\Event\WebView\BeforeRender;
 
 /**
  * Listens to Yii view render events and feeds normalized data
  * to the framework-agnostic Kernel TemplateCollector.
+ *
+ * BeforeRender opens an entry on the collector's nesting stack and records a
+ * microtime snapshot; AfterRender pops it and reports the elapsed render time
+ * along with the produced output and parameters. Because yiisoft/view renders
+ * are strictly nested, a plain LIFO stack of start times is sufficient.
  */
 final class ViewEventListener
 {
+    /** @var float[] */
+    private array $startStack = [];
+
     public function __construct(
         private readonly TemplateCollector $collector,
     ) {}
 
-    public function collect(AfterRender $event): void
+    public function beforeRender(BeforeRender $event): void
     {
-        $this->collector->collectRender($event->getFile(), $event->getResult(), $event->getParameters());
+        $this->collector->beginRender($event->getFile());
+        $this->startStack[] = microtime(true);
+    }
+
+    public function afterRender(AfterRender $event): void
+    {
+        $start = array_pop($this->startStack);
+        $renderTime = $start !== null ? microtime(true) - $start : 0.0;
+
+        $this->collector->endRender($event->getResult(), $event->getParameters(), $renderTime);
     }
 }

--- a/libs/Adapter/Yii3/tests/Unit/Collector/View/ViewEventListenerTest.php
+++ b/libs/Adapter/Yii3/tests/Unit/Collector/View/ViewEventListenerTest.php
@@ -9,28 +9,27 @@ use AppDevPanel\Kernel\Collector\TemplateCollector;
 use AppDevPanel\Kernel\Collector\TimelineCollector;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\View\Event\WebView\AfterRender;
+use Yiisoft\View\Event\WebView\BeforeRender;
 use Yiisoft\View\WebView;
 
 final class ViewEventListenerTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        if (!class_exists(AfterRender::class, true)) {
-            $this->markTestSkipped('yiisoft/view is not installed.');
-        }
-    }
-
-    public function testCollectDelegatesRenderDataToTemplateCollector(): void
+    private function buildListener(): array
     {
         $timeline = new TimelineCollector();
         $timeline->startup();
         $collector = new TemplateCollector($timeline);
         $collector->startup();
-        $listener = new ViewEventListener($collector);
+        return [new ViewEventListener($collector), $collector, $timeline];
+    }
 
-        $event = new AfterRender(new WebView(), '/views/index.php', ['title' => 'Test'], '<h1>Hello</h1>');
+    public function testBeforeAfterRenderCollectsTemplateData(): void
+    {
+        [$listener, $collector] = $this->buildListener();
+        $view = new WebView();
 
-        $listener->collect($event);
+        $listener->beforeRender(new BeforeRender($view, '/views/index.php', ['title' => 'Test']));
+        $listener->afterRender(new AfterRender($view, '/views/index.php', ['title' => 'Test'], '<h1>Hello</h1>'));
 
         $collected = $collector->getCollected();
         $this->assertCount(1, $collected['renders']);
@@ -39,55 +38,81 @@ final class ViewEventListenerTest extends TestCase
         $this->assertSame(['title' => 'Test'], $collected['renders'][0]['parameters']);
     }
 
-    public function testCollectMultipleRenderEvents(): void
+    public function testRenderTimeIsMeasured(): void
     {
-        $timeline = new TimelineCollector();
-        $timeline->startup();
-        $collector = new TemplateCollector($timeline);
-        $collector->startup();
-        $listener = new ViewEventListener($collector);
+        [$listener, $collector] = $this->buildListener();
+        $view = new WebView();
 
-        $event1 = new AfterRender(new WebView(), '/views/layout.php', [], '<html></html>');
-        $event2 = new AfterRender(new WebView(), '/views/partial.php', ['key' => 'value'], '<div>Partial</div>');
+        $listener->beforeRender(new BeforeRender($view, '/views/slow.php', []));
+        usleep(2000);
+        $listener->afterRender(new AfterRender($view, '/views/slow.php', [], 'out'));
 
-        $listener->collect($event1);
-        $listener->collect($event2);
+        $collected = $collector->getCollected();
+        $this->assertGreaterThan(0.0, $collected['renders'][0]['renderTime']);
+        $this->assertGreaterThan(0.0, $collected['totalTime']);
+        $this->assertSame(1, $collected['renderCount']);
+    }
+
+    public function testMultipleSequentialRenders(): void
+    {
+        [$listener, $collector] = $this->buildListener();
+        $view = new WebView();
+
+        $listener->beforeRender(new BeforeRender($view, '/views/layout.php', []));
+        $listener->afterRender(new AfterRender($view, '/views/layout.php', [], '<html></html>'));
+
+        $listener->beforeRender(new BeforeRender($view, '/views/partial.php', ['key' => 'value']));
+        $listener->afterRender(new AfterRender($view, '/views/partial.php', ['key' => 'value'], '<div>Partial</div>'));
 
         $collected = $collector->getCollected();
         $this->assertCount(2, $collected['renders']);
         $this->assertSame('/views/layout.php', $collected['renders'][0]['template']);
         $this->assertSame('/views/partial.php', $collected['renders'][1]['template']);
+        $this->assertSame(0, $collected['renders'][0]['depth']);
+        $this->assertSame(0, $collected['renders'][1]['depth']);
     }
 
-    public function testCollectUpdatesTimeline(): void
+    public function testNestedRendersTrackDepthAndOrdering(): void
     {
-        $timeline = new TimelineCollector();
-        $timeline->startup();
-        $collector = new TemplateCollector($timeline);
-        $collector->startup();
-        $listener = new ViewEventListener($collector);
+        [$listener, $collector] = $this->buildListener();
+        $view = new WebView();
 
-        $event = new AfterRender(new WebView(), '/views/test.php', [], '');
+        // Outer layout starts rendering, then includes a partial, then finishes.
+        $listener->beforeRender(new BeforeRender($view, '/views/layout.php', []));
+        $listener->beforeRender(new BeforeRender($view, '/views/partial.php', []));
+        $listener->afterRender(new AfterRender($view, '/views/partial.php', [], '<div>Partial</div>'));
+        $listener->afterRender(new AfterRender($view, '/views/layout.php', [], '<html><div>Partial</div></html>'));
 
-        $listener->collect($event);
+        $collected = $collector->getCollected();
+        $this->assertCount(2, $collected['renders']);
+        // Parent-first ordering from beginRender.
+        $this->assertSame('/views/layout.php', $collected['renders'][0]['template']);
+        $this->assertSame(0, $collected['renders'][0]['depth']);
+        $this->assertSame('/views/partial.php', $collected['renders'][1]['template']);
+        $this->assertSame(1, $collected['renders'][1]['depth']);
+    }
+
+    public function testRenderUpdatesTimeline(): void
+    {
+        [$listener, $collector, $timeline] = $this->buildListener();
+        $view = new WebView();
+
+        $listener->beforeRender(new BeforeRender($view, '/views/test.php', []));
+        $listener->afterRender(new AfterRender($view, '/views/test.php', [], ''));
 
         $this->assertCount(1, $timeline->getCollected());
     }
 
-    public function testCollectUpdatesSummary(): void
+    public function testSummaryReflectsRenders(): void
     {
-        $timeline = new TimelineCollector();
-        $timeline->startup();
-        $collector = new TemplateCollector($timeline);
-        $collector->startup();
-        $listener = new ViewEventListener($collector);
+        [$listener, $collector] = $this->buildListener();
+        $view = new WebView();
 
-        $event = new AfterRender(new WebView(), '/views/test.php', [], 'output');
-
-        $listener->collect($event);
+        $listener->beforeRender(new BeforeRender($view, '/views/test.php', []));
+        $listener->afterRender(new AfterRender($view, '/views/test.php', [], 'output'));
 
         $summary = $collector->getSummary();
         $this->assertSame(1, $summary['template']['renderCount']);
-        $this->assertSame(0.0, $summary['template']['totalTime']);
+        $this->assertGreaterThanOrEqual(0.0, $summary['template']['totalTime']);
     }
 }


### PR DESCRIPTION
## Summary
Refactored the view event listener to track render timing by listening to both `BeforeRender` and `AfterRender` events, enabling measurement of individual render durations and support for nested render tracking.

## Key Changes
- **Split event handling**: Replaced single `collect()` method with separate `beforeRender()` and `afterRender()` handlers
- **Timing measurement**: Implemented a stack-based approach to track microtime snapshots at render start, calculating elapsed time on completion
- **Nested render support**: Added depth tracking for nested renders through the collector's `beginRender()` and `endRender()` methods
- **Event registration**: Updated event configuration to register both `BeforeRender` and `AfterRender` event listeners
- **Test coverage**: Completely rewrote test suite to cover:
  - Basic render data collection
  - Render time measurement accuracy
  - Sequential renders
  - Nested render depth and ordering
  - Timeline updates
  - Summary statistics

## Implementation Details
- Uses a simple LIFO stack (`$startStack`) to handle nested renders, since yiisoft/view renders are strictly nested
- Delegates nesting logic to `TemplateCollector` via `beginRender()` and `endRender()` methods
- Render time is calculated as the difference between `microtime(true)` snapshots taken at before/after events
- All test setup logic consolidated into `buildListener()` helper method to reduce duplication

https://claude.ai/code/session_01KmsfwqqSi5ty4bYKrZAFZM