### PR TITLE
Fix SQL query text overflow in debug panel

### DIFF
--- a/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/DatabasePanel.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Component/Panel/DatabasePanel.tsx
@@ -246,7 +246,16 @@ const DuplicateQueryGroup = ({
                         mt: '2px',
                     }}
                 />
-                <Box sx={{flex: 1, wordBreak: 'break-word', lineHeight: 1.6, color: 'text.primary'}}>
+                <Box
+                    sx={{
+                        flex: 1,
+                        minWidth: 0,
+                        overflow: 'hidden',
+                        wordBreak: 'break-word',
+                        lineHeight: 1.6,
+                        color: 'text.primary',
+                    }}
+                >
                     <SqlHighlight sql={sqlPreview} inline />
                 </Box>
                 <Chip
@@ -436,7 +445,7 @@ const QueryRowWithExplain = ({
                         mt: '2px',
                     }}
                 />
-                <Box sx={{flex: 1, wordBreak: 'break-word', lineHeight: 1.6}}>
+                <Box sx={{flex: 1, minWidth: 0, overflow: 'hidden', wordBreak: 'break-word', lineHeight: 1.6}}>
                     <SqlHighlight sql={query.sql} inline />
                 </Box>
                 {query.rowsNumber != null && (


### PR DESCRIPTION
## Summary
Fixed text overflow issues in the Database Debug Panel by adding proper flex container constraints to SQL query display boxes.

## Key Changes
- Added `minWidth: 0` and `overflow: 'hidden'` to Box components containing SQL queries in `DuplicateQueryGroup` and `QueryRowWithExplain` components
- These CSS properties ensure that flex items properly constrain their content and prevent text from overflowing the container bounds
- Reformatted the first Box styling for better readability by expanding the inline sx prop to multiple lines

## Implementation Details
The changes address a common flexbox issue where flex items don't properly shrink below their content size. By adding:
- `minWidth: 0`: Allows the flex item to shrink below its content width
- `overflow: 'hidden'`: Clips content that exceeds the container bounds

This ensures SQL query text respects the flex layout and wraps/truncates appropriately instead of breaking the layout.

https://claude.ai/code/session_01EjvntXsXDiTEmn7Lb6kSaK