### PR TITLE
Fix debug panel collector refetch and support HTTP methods in test fixtures

### DIFF
--- a/libs/frontend/packages/panel/src/Module/Debug/Pages/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Module/Debug/Pages/Layout.tsx
@@ -296,8 +296,9 @@ const Layout = () => {
     const dispatch = useDispatch();
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
+    const collectorParam = searchParams.get('collector') || '';
     const {data: entriesList} = useGetDebugQuery();
-    const [selectedCollector, setSelectedCollector] = useState<string>(() => searchParams.get('collector') || '');
+    const [selectedCollector, setSelectedCollector] = useState<string>(() => collectorParam);
     const [collectorData, setCollectorData] = useState<any>(undefined);
     const [entryMissingError, setEntryMissingError] = useState<CollectorError | null>(null);
     const [collectorInfo, collectorQueryInfo] = useLazyGetCollectorInfoQuery();
@@ -307,9 +308,12 @@ const Layout = () => {
         setCollectorData(null);
     }, []);
 
+    // Depend on collectorParam (the only URL input this effect cares about) rather than the
+    // whole searchParams object. Otherwise unrelated params like `requestTab` — which the
+    // request panel toggles on every tab switch — would produce a new searchParams reference,
+    // re-run this effect, and trigger a spurious collectorInfo refetch + LinearProgress flash.
     useEffect(() => {
-        const collector = searchParams.get('collector') || '';
-        if (collector.trim() === '') {
+        if (collectorParam.trim() === '') {
             clearCollectorAndData();
             setEntryMissingError(null);
             return;
@@ -318,8 +322,8 @@ const Layout = () => {
             return;
         }
         // Resolve virtual EntryCollector to the real collector based on entry type
-        let resolvedCollector = collector;
-        if (collector === CollectorsMap.EntryCollector) {
+        let resolvedCollector = collectorParam;
+        if (collectorParam === CollectorsMap.EntryCollector) {
             if (isDebugEntryAboutWeb(debugEntry)) {
                 resolvedCollector = CollectorsMap.RequestCollector;
             } else if (isDebugEntryAboutConsole(debugEntry)) {
@@ -333,8 +337,11 @@ const Layout = () => {
         // The lazy trigger returns a promise that always resolves with {error, data, isError};
         // rejection is not possible, so there is no need for a .catch branch. The cancelled
         // flag prevents an in-flight fetch from overwriting state after a newer one started.
+        // `preferCacheValue: true` avoids re-hitting the network when this effect does fire
+        // (e.g. navigating back to the same collector) — collector data for a given debug
+        // entry is immutable, so the cached value is always correct.
         let cancelled = false;
-        collectorInfo({id: debugEntry.id, collector: resolvedCollector}).then(({error, data, isError}) => {
+        collectorInfo({id: debugEntry.id, collector: resolvedCollector}, true).then(({error, data, isError}) => {
             if (cancelled) return;
             if (isError) {
                 // 404 means the entry (or at least this collector for it) has been
@@ -357,7 +364,7 @@ const Layout = () => {
         return () => {
             cancelled = true;
         };
-    }, [searchParams, debugEntry, collectorInfo, clearCollectorAndData]);
+    }, [collectorParam, debugEntry, collectorInfo, clearCollectorAndData]);
 
     const latestEntry = useMemo(() => {
         if (!entriesList || entriesList.length === 0) return undefined;

--- a/playground/laravel-app/routes/web.php
+++ b/playground/laravel-app/routes/web.php
@@ -64,7 +64,7 @@ Route::prefix('test/fixtures')->group(function (): void {
     Route::get('/timeline', TimelineAction::class);
     Route::get('/exception', ExceptionAction::class);
     Route::get('/exception-chained', ExceptionChainedAction::class);
-    Route::get('/request-info', RequestInfoAction::class);
+    Route::match(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], '/request-info', RequestInfoAction::class);
     Route::get('/multi', MultiAction::class);
     Route::get('/cache', CacheAction::class);
     Route::get('/cache-heavy', CacheHeavyAction::class);

--- a/playground/symfony-app/src/Controller/TestFixtures/RequestInfoAction.php
+++ b/playground/symfony-app/src/Controller/TestFixtures/RequestInfoAction.php
@@ -7,7 +7,11 @@ namespace App\Controller\TestFixtures;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route('/test/fixtures/request-info', name: 'test_request_info', methods: ['GET'])]
+#[Route(
+    '/test/fixtures/request-info',
+    name: 'test_request_info',
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+)]
 final class RequestInfoAction
 {
     public function __invoke(): JsonResponse

--- a/playground/yii2-basic-app/config/web.php
+++ b/playground/yii2-basic-app/config/web.php
@@ -47,7 +47,7 @@ return [
                 'GET /test/fixtures/events' => 'test-fixtures/events',
                 'GET /test/fixtures/dump' => 'test-fixtures/dump',
                 'GET /test/fixtures/timeline' => 'test-fixtures/timeline',
-                'GET /test/fixtures/request-info' => 'test-fixtures/request-info',
+                'GET,POST,PUT,PATCH,DELETE,OPTIONS /test/fixtures/request-info' => 'test-fixtures/request-info',
                 'GET /test/fixtures/exception' => 'test-fixtures/exception',
                 'GET /test/fixtures/exception-chained' => 'test-fixtures/exception-chained',
                 'GET /test/fixtures/multi' => 'test-fixtures/multi',

--- a/playground/yii3-app/config/common/routes.php
+++ b/playground/yii3-app/config/common/routes.php
@@ -39,7 +39,9 @@ return [
             Route::get('/events')->action(Web\TestFixtures\EventsAction::class)->name('test-events'),
             Route::get('/dump')->action(Web\TestFixtures\DumpAction::class)->name('test-dump'),
             Route::get('/timeline')->action(Web\TestFixtures\TimelineAction::class)->name('test-timeline'),
-            Route::get('/request-info')->action(Web\TestFixtures\RequestInfoAction::class)->name('test-request-info'),
+            Route::methods(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], '/request-info')
+                ->action(Web\TestFixtures\RequestInfoAction::class)
+                ->name('test-request-info'),
             Route::get('/exception')->action(Web\TestFixtures\ExceptionAction::class)->name('test-exception'),
             Route::get('/exception-chained')->action(Web\TestFixtures\ExceptionChainedAction::class)->name(
                 'test-exception-chained',


### PR DESCRIPTION
## Summary
This PR addresses two issues: (1) unnecessary refetches in the debug panel when unrelated URL parameters change, and (2) test fixture endpoints that only accept GET requests when they should support multiple HTTP methods.

## Key Changes

### Debug Panel Optimization
- **Extract `collectorParam` from `searchParams`**: Created a stable reference to the collector URL parameter to prevent unnecessary effect re-runs when other URL parameters (like `requestTab`) change.
- **Update effect dependency**: Changed the `useEffect` dependency from the entire `searchParams` object to just `collectorParam`, eliminating spurious refetches when unrelated parameters toggle.
- **Enable response caching**: Added `preferCacheValue: true` to the `collectorInfo` query call, leveraging cached collector data since it's immutable per debug entry. This prevents redundant network requests when navigating back to previously viewed collectors.
- **Improve code clarity**: Added detailed comments explaining the optimization rationale and caching behavior.

### Test Fixture HTTP Methods
Updated all playground app test fixture endpoints (`/test/fixtures/request-info`) to accept multiple HTTP methods instead of just GET:
- **Symfony**: Modified route attribute to accept GET, POST, PUT, PATCH, DELETE, OPTIONS
- **Yii3**: Updated route definition to support the same HTTP methods
- **Laravel**: Changed from `Route::get()` to `Route::match()` with multiple methods
- **Yii2**: Updated URL rule pattern to include all HTTP methods

These changes enable the request-info fixture to be used for testing various HTTP request types, improving test coverage for request handling.

https://claude.ai/code/session_01RcsthEsXNax83Xj7YHkNS1