### PR TITLE
Reorder action buttons and improve route action rendering

### DIFF
--- a/libs/frontend/packages/panel/src/Application/Component/ClassName.test.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/ClassName.test.tsx
@@ -1,7 +1,11 @@
 import {renderWithProviders} from '@app-dev-panel/sdk/test-utils';
 import {screen} from '@testing-library/react';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 import {ClassName} from './ClassName';
+
+vi.mock('@app-dev-panel/panel/Module/Inspector/API/Inspector', () => ({
+    useGetClassQuery: vi.fn(() => ({data: {path: '/app/src/Message/ProcessPayment.php', startLine: 10}})),
+}));
 
 const FQCN = 'App\\Message\\ProcessPayment';
 
@@ -37,5 +41,14 @@ describe('ClassName', () => {
     it('does not render Open in Editor button when editor is not configured', () => {
         renderWithProviders(<ClassName value={FQCN} />);
         expect(screen.queryByLabelText('Open in Editor')).not.toBeInTheDocument();
+    });
+
+    it('renders Open in Editor button before Open in File Explorer button', () => {
+        renderWithProviders(<ClassName value={FQCN} />, {
+            preloadedState: {application: {editorConfig: {editor: 'phpstorm'}}},
+        });
+        const editor = screen.getByLabelText('Open in Editor');
+        const explorer = screen.getByLabelText('Open in File Explorer');
+        expect(editor.compareDocumentPosition(explorer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
 });

--- a/libs/frontend/packages/panel/src/Application/Component/ClassName.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/ClassName.tsx
@@ -61,18 +61,6 @@ export const ClassName = ({value, methodName, children, sx}: ClassNameProps) => 
     return (
         <span style={{display: 'inline-flex', alignItems: 'center', gap: 2, minWidth: 0, ...sx}}>
             {label}
-            <Tooltip title="Open in File Explorer">
-                <IconButton
-                    size="small"
-                    component={RouterLink}
-                    to={explorerHref}
-                    aria-label="Open in File Explorer"
-                    onClick={(e) => e.stopPropagation()}
-                    sx={{p: 0.25, ml: 0.25}}
-                >
-                    <FolderOpen sx={{fontSize: 14}} />
-                </IconButton>
-            </Tooltip>
             {editorUrl && (
                 <Tooltip title="Open in Editor">
                     <IconButton
@@ -81,12 +69,24 @@ export const ClassName = ({value, methodName, children, sx}: ClassNameProps) => 
                         href={editorUrl}
                         aria-label="Open in Editor"
                         onClick={(e) => e.stopPropagation()}
-                        sx={{p: 0.25}}
+                        sx={{p: 0.25, ml: 0.25}}
                     >
                         <Code sx={{fontSize: 14}} />
                     </IconButton>
                 </Tooltip>
             )}
+            <Tooltip title="Open in File Explorer">
+                <IconButton
+                    size="small"
+                    component={RouterLink}
+                    to={explorerHref}
+                    aria-label="Open in File Explorer"
+                    onClick={(e) => e.stopPropagation()}
+                    sx={{p: 0.25, ml: editorUrl ? 0 : 0.25}}
+                >
+                    <FolderOpen sx={{fontSize: 14}} />
+                </IconButton>
+            </Tooltip>
         </span>
     );
 };

--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/RoutesPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/RoutesPage.tsx
@@ -361,7 +361,8 @@ const RouteChecker = () => {
                     {checkRouteQueryInfo.data.result ? (
                         <AlertTitle>
                             {(() => {
-                                const parsed = parseCallable(checkRouteQueryInfo.data.action);
+                                const action = checkRouteQueryInfo.data.action;
+                                const parsed = parseCallable(action);
                                 if (parsed) {
                                     return (
                                         <ClassName value={parsed.className} methodName={parsed.methodName}>
@@ -373,12 +374,28 @@ const RouteChecker = () => {
                                                     color: 'primary.main',
                                                 })}
                                             >
-                                                {parsed.className + '::' + parsed.methodName}
+                                                {concatClassMethod(parsed.className, parsed.methodName)}
                                             </Typography>
                                         </ClassName>
                                     );
                                 }
-                                return serializeCallable(checkRouteQueryInfo.data.action);
+                                if (typeof action === 'string' && isClassName(action)) {
+                                    return (
+                                        <ClassName value={action}>
+                                            <Typography
+                                                component="span"
+                                                sx={(theme) => ({
+                                                    fontFamily: theme.adp.fontFamilyMono,
+                                                    fontSize: '13px',
+                                                    color: 'primary.main',
+                                                })}
+                                            >
+                                                {action}
+                                            </Typography>
+                                        </ClassName>
+                                    );
+                                }
+                                return serializeCallable(action);
                             })()}
                         </AlertTitle>
                     ) : (


### PR DESCRIPTION
## Summary
This PR reorders the action buttons in the ClassName component to display the "Open in Editor" button before the "Open in File Explorer" button, and enhances the route action rendering logic to better handle class name-only actions.

## Key Changes

- **Button Reordering**: Moved the "Open in File Explorer" button after the "Open in Editor" button in the ClassName component for improved UX consistency
  - Adjusted margin logic so the left margin is applied to the Editor button when present, and to the Explorer button only when the Editor button is absent
  
- **Enhanced Route Action Rendering**: Improved the RouteChecker component to better handle different action types
  - Extracted the action variable for cleaner code and reusability
  - Added support for rendering class name-only actions (when action is a string and is a valid class name) with proper styling and ClassName wrapper
  - Replaced string concatenation with `concatClassMethod()` utility function for consistency
  
- **Test Coverage**: Added a new test case to verify the button rendering order when an editor is configured

## Implementation Details

The button reordering uses conditional margin styling (`ml: editorUrl ? 0 : 0.25`) to ensure proper spacing regardless of which buttons are rendered. The route action rendering now handles three cases: callable actions (method calls), class name-only actions, and fallback serialization.

https://claude.ai/code/session_018bUvtfiHh9N7zt9ocQsiyr