### PR TITLE
Ship prebuilt panel SPA as Composer package (frontend-assets)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Package toolbar build
         run: cd packages/toolbar && tar -czf ../../toolbar-dist.tar.gz dist/
 
+      - name: Package panel build as frontend-dist.zip
+        run: cd packages/panel/dist && zip -r ../../../frontend-dist.zip .
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -75,6 +78,7 @@ jobs:
             libs/frontend/packages/toolbar/dist/
             libs/frontend/panel-dist.tar.gz
             libs/frontend/toolbar-dist.tar.gz
+            libs/frontend/frontend-dist.zip
           retention-days: 1
 
   publish:
@@ -107,7 +111,7 @@ jobs:
         run: npx lerna version "$GITHUB_REF_NAME" --no-git-tag-version --no-push --yes
 
       - name: Clean up build artifacts from working tree
-        run: rm -f panel-dist.tar.gz toolbar-dist.tar.gz
+        run: rm -f panel-dist.tar.gz toolbar-dist.tar.gz frontend-dist.zip
 
       - name: Commit and push version bump
         run: |
@@ -140,3 +144,4 @@ jobs:
           files: |
             artifacts/panel-dist.tar.gz
             artifacts/toolbar-dist.tar.gz
+            artifacts/frontend-dist.zip

--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -30,6 +30,7 @@ jobs:
           - { name: "adapter-yii2",     local_path: "libs/Adapter/Yii2",    split_repository: "adapter-yii2" }
           - { name: "adapter-cycle",    local_path: "libs/Adapter/Cycle",   split_repository: "adapter-cycle" }
           - { name: "adapter-yii3",     local_path: "libs/Adapter/Yii3",    split_repository: "adapter-yii3" }
+          - { name: "frontend-assets",  local_path: "libs/FrontendAssets",  split_repository: "frontend-assets", needs_frontend_build: true }
 
     steps:
       - name: Checkout
@@ -37,6 +38,32 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Setup Node.js
+        if: matrix.package.needs_frontend_build
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: libs/frontend/package-lock.json
+
+      - name: Build panel SPA into FrontendAssets/dist
+        if: matrix.package.needs_frontend_build
+        run: |
+          cd libs/frontend
+          npm ci
+          npm run build -w packages/sdk
+          npm run build -w packages/panel
+          cd ../..
+          rm -rf libs/FrontendAssets/dist
+          mkdir -p libs/FrontendAssets/dist
+          cp -R libs/frontend/packages/panel/dist/. libs/FrontendAssets/dist/
+          # Force-add the dist to a local commit so splitsh-lite sees it.
+          # This commit stays local — it is never pushed back to the monorepo.
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git add -f libs/FrontendAssets/dist
+          git commit -m "ci: bundle panel SPA into FrontendAssets/dist"
 
       - name: Install splitsh-lite
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ fully framework-independent. Adapters exist for Yii 3, Symfony, Laravel, Yii 2, 
 │   ├── McpServer/                # MCP server: AI assistant integration (stdio + HTTP)
 │   ├── Cli/                      # CLI commands: debug server, reset, broadcast, query, serve, mcp
 │   ├── Testing/                  # Test fixtures: definitions, runner, CLI command
+│   ├── FrontendAssets/           # Composer package shipping the prebuilt panel SPA (dist/ populated at release time)
 │   ├── Adapter/
 │   │   ├── Yii3/                 # Yii 3 framework adapter
 │   │   ├── Symfony/              # Symfony framework adapter
@@ -286,12 +287,13 @@ Inspired by [VK Modulite](https://github.com/VKCOM/modulite). Enforces that each
 | `kernel` | (none — foundation) |
 | `mcp-server` | `kernel` |
 | `api` | `kernel`, `mcp-server` |
-| `cli` | `kernel`, `api`, `mcp-server` |
+| `cli` | `kernel`, `api`, `mcp-server`, `frontend-assets` |
 | `testing` | (none — independent) |
-| `adapter-yii3` | `kernel`, `api`, `cli`, `mcp-server` |
-| `adapter-symfony` | `kernel`, `api`, `cli`, `mcp-server` |
-| `adapter-laravel` | `kernel`, `api`, `cli`, `mcp-server` |
-| `adapter-yii2` | `kernel`, `api`, `cli`, `mcp-server` |
+| `frontend-assets` | (none — leaf, ships prebuilt SPA) |
+| `adapter-yii3` | `kernel`, `api`, `cli`, `mcp-server`, `frontend-assets` |
+| `adapter-symfony` | `kernel`, `api`, `cli`, `mcp-server`, `frontend-assets` |
+| `adapter-laravel` | `kernel`, `api`, `cli`, `mcp-server`, `frontend-assets` |
+| `adapter-yii2` | `kernel`, `api`, `cli`, `mcp-server`, `frontend-assets` |
 | `adapter-cycle` | `api` |
 
 ### Rules
@@ -469,6 +471,7 @@ Each module under `libs/` has its own `CLAUDE.md` with internal architecture det
 - `libs/McpServer/CLAUDE.md` — MCP server (AI assistant integration)
 - `libs/Cli/CLAUDE.md` — CLI commands
 - `libs/Testing/CLAUDE.md` — Test fixtures and runner
+- `libs/FrontendAssets/CLAUDE.md` — Prebuilt panel SPA Composer package (dist shipping, split-repo flow)
 - `libs/Adapter/Yii3/CLAUDE.md` — Yii 3 adapter integration
 - `libs/Adapter/Symfony/CLAUDE.md` — Symfony adapter integration
 - `libs/Adapter/Laravel/CLAUDE.md` — Laravel adapter integration

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,10 @@
     {
       "type": "path",
       "url": "libs/Testing"
+    },
+    {
+      "type": "path",
+      "url": "libs/FrontendAssets"
     }
   ],
   "require": {
@@ -46,6 +50,7 @@
     "app-dev-panel/adapter-yii2": "*",
     "app-dev-panel/adapter-yii3": "*",
     "app-dev-panel/api": "*",
+    "app-dev-panel/frontend-assets": "*",
     "app-dev-panel/kernel": "*",
     "app-dev-panel/mcp-server": "*",
     "app-dev-panel/testing": "*",
@@ -171,6 +176,7 @@
       "AppDevPanel\\Cli\\": "libs/Cli/src",
       "AppDevPanel\\McpServer\\": "libs/McpServer/src",
       "AppDevPanel\\Testing\\": "libs/Testing/src",
+      "AppDevPanel\\FrontendAssets\\": "libs/FrontendAssets/src",
       "AppDevPanel\\Adapter\\Symfony\\": "libs/Adapter/Symfony/src",
       "AppDevPanel\\Adapter\\Laravel\\": "libs/Adapter/Laravel/src",
       "AppDevPanel\\Adapter\\Yii2\\": "libs/Adapter/Yii2/src",
@@ -198,6 +204,7 @@
     "app-dev-panel/cli": "self.version",
     "app-dev-panel/mcp-server": "self.version",
     "app-dev-panel/testing": "self.version",
+    "app-dev-panel/frontend-assets": "self.version",
     "app-dev-panel/adapter-symfony": "self.version",
     "app-dev-panel/adapter-laravel": "self.version",
     "app-dev-panel/adapter-yii2": "self.version",

--- a/libs/Adapter/Laravel/composer.json
+++ b/libs/Adapter/Laravel/composer.json
@@ -37,6 +37,7 @@
         "app-dev-panel/api": "*",
         "app-dev-panel/kernel": "*",
         "app-dev-panel/cli": "*",
+        "app-dev-panel/frontend-assets": "*",
         "guzzlehttp/guzzle": "^7.5",
         "guzzlehttp/psr7": "^2.4",
         "nyholm/psr7": "^1.8",
@@ -67,6 +68,10 @@
         {
             "type": "path",
             "url": "../../Cli"
+        },
+        {
+            "type": "path",
+            "url": "../../FrontendAssets"
         }
     ],
     "autoload": {

--- a/libs/Adapter/Symfony/composer.json
+++ b/libs/Adapter/Symfony/composer.json
@@ -36,6 +36,7 @@
         "app-dev-panel/api": "*",
         "app-dev-panel/kernel": "*",
         "app-dev-panel/cli": "*",
+        "app-dev-panel/frontend-assets": "*",
         "guzzlehttp/guzzle": "^7.5",
         "guzzlehttp/psr7": "^2.4",
         "nyholm/psr7": "^1.8",
@@ -77,6 +78,10 @@
         {
             "type": "path",
             "url": "../../Cli"
+        },
+        {
+            "type": "path",
+            "url": "../../FrontendAssets"
         }
     ],
     "autoload": {

--- a/libs/Adapter/Yii2/composer.json
+++ b/libs/Adapter/Yii2/composer.json
@@ -34,6 +34,7 @@
         "app-dev-panel/api": "*",
         "app-dev-panel/kernel": "*",
         "app-dev-panel/cli": "*",
+        "app-dev-panel/frontend-assets": "*",
         "guzzlehttp/guzzle": "^7.5",
         "guzzlehttp/psr7": "^2.4",
         "nyholm/psr7": "^1.8",
@@ -60,6 +61,10 @@
         {
             "type": "path",
             "url": "../../Cli"
+        },
+        {
+            "type": "path",
+            "url": "../../FrontendAssets"
         }
     ],
     "autoload": {

--- a/libs/Adapter/Yii3/composer.json
+++ b/libs/Adapter/Yii3/composer.json
@@ -34,6 +34,7 @@
         "app-dev-panel/api": "*",
         "app-dev-panel/kernel": "*",
         "app-dev-panel/cli": "*",
+        "app-dev-panel/frontend-assets": "*",
         "guzzlehttp/guzzle": "^7.5",
         "guzzlehttp/psr7": "^2.4",
         "jetbrains/phpstorm-attributes": "^1.0",
@@ -88,6 +89,10 @@
         {
             "type": "path",
             "url": "../../Cli"
+        },
+        {
+            "type": "path",
+            "url": "../../FrontendAssets"
         }
     ],
     "autoload": {

--- a/libs/Cli/CLAUDE.md
+++ b/libs/Cli/CLAUDE.md
@@ -7,7 +7,7 @@ Provides console commands for managing the ADP debug system.
 - Composer: `app-dev-panel/cli`
 - Namespace: `AppDevPanel\Cli\`
 - PHP: 8.4+
-- Dependencies: `app-dev-panel/kernel`, `app-dev-panel/api`, `app-dev-panel/mcp-server`, Symfony Console, Symfony Process
+- Dependencies: `app-dev-panel/kernel`, `app-dev-panel/api`, `app-dev-panel/mcp-server`, `app-dev-panel/frontend-assets`, Symfony Console, Symfony Process
 
 ## Directory Structure
 
@@ -102,14 +102,26 @@ Uses `CollectorRepositoryInterface` to read from storage.
 
 ### `serve` — Standalone ADP API Server
 
-Starts a standalone HTTP server using PHP built-in server, serving the ADP API directly.
+Starts a standalone HTTP server using PHP built-in server, serving the ADP API directly. When `--frontend-path` is omitted, the command auto-resolves the bundle via `AppDevPanel\FrontendAssets\FrontendAssets::path()` (from `app-dev-panel/frontend-assets`), so the full panel SPA is served at `/` out of the box. When a frontend path is available, the process is launched with `php -S host:port -t <frontendPath>` so the built-in server resolves static files from the bundle directory.
 
 ```bash
-serve                                              # Default: 127.0.0.1:8888
+serve                                              # Default: 127.0.0.1:8888, panel auto-resolved from FrontendAssets
 serve --host=0.0.0.0 --port=9000                   # Custom host/port
 serve --storage-path=/path/to/debug/data           # Custom storage
-serve --frontend-path=/path/to/built/assets        # Serve frontend
+serve --frontend-path=/path/to/built/assets        # Override bundle path (e.g. local dev build)
 ```
+
+### `frontend:update` — Download Latest Frontend Build
+
+Fetches `frontend-dist.zip` from the [latest GitHub Release](https://github.com/app-dev-panel/app-dev-panel/releases) and extracts it into `--path`. Intended for PHAR users or environments where Composer is not the update vehicle; composer-based installs update via `composer update app-dev-panel/frontend-assets`.
+
+```bash
+frontend:update check                               # Show current vs latest version
+frontend:update check --json                        # Machine-readable output
+frontend:update download --path=/path/to/dist       # Install latest panel build
+```
+
+Writes a `.adp-version` file next to `index.html` so subsequent `check` invocations can compare installed vs latest. The GitHub API call is capped at 10s; the asset download at 30s.
 
 ### `mcp:serve` — MCP Server
 

--- a/libs/Cli/bin/adp
+++ b/libs/Cli/bin/adp
@@ -6,13 +6,18 @@ declare(strict_types=1);
 /**
  * ADP — standalone console entry point.
  *
- * Registers the ADP console commands that can run without framework DI:
- *   - debug:fixtures (from app-dev-panel/testing, when installed)
+ * Registers the ADP console commands that do not need framework DI:
+ *   - serve               — standalone HTTP server (panel + API)
+ *   - frontend:update     — download latest panel build from GitHub Release
+ *   - debug:fixtures      — from app-dev-panel/testing, when installed
  *
- * Commands that require live collector/storage wiring (debug:query, debug:reset, serve, etc.)
- * are exposed via the per-framework adapters' own CLI integrations.
+ * Commands that rely on live collector/storage wiring (debug:query, debug:reset,
+ * debug:tail, dev, etc.) are exposed via the per-framework adapters' own CLI
+ * integrations.
  *
  * Usage:
+ *   php vendor/bin/adp serve
+ *   php vendor/bin/adp frontend:update check
  *   php vendor/bin/adp debug:fixtures http://localhost:8080
  */
 
@@ -38,6 +43,9 @@ if (!$autoloaded) {
 }
 
 $application = new Symfony\Component\Console\Application('adp', '1.x-dev');
+
+$application->add(new AppDevPanel\Cli\Command\ServeCommand());
+$application->add(new AppDevPanel\Cli\Command\FrontendUpdateCommand());
 
 // Register DebugFixturesCommand when app-dev-panel/testing is present.
 // The Testing package is not a required dependency of libs/Cli (enforced by modulite),

--- a/libs/Cli/composer.json
+++ b/libs/Cli/composer.json
@@ -28,6 +28,7 @@
         "app-dev-panel/kernel": "*",
         "app-dev-panel/api": "*",
         "app-dev-panel/mcp-server": "*",
+        "app-dev-panel/frontend-assets": "*",
         "guzzlehttp/guzzle": "^7.5",
         "guzzlehttp/psr7": "^2.4",
         "psr/log": "^3.0",
@@ -47,6 +48,10 @@
         {
             "type": "path",
             "url": "../McpServer"
+        },
+        {
+            "type": "path",
+            "url": "../FrontendAssets"
         }
     ],
     "autoload": {

--- a/libs/Cli/src/Command/ServeCommand.php
+++ b/libs/Cli/src/Command/ServeCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AppDevPanel\Cli\Command;
 
+use AppDevPanel\FrontendAssets\FrontendAssets;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -43,7 +44,7 @@ final class ServeCommand extends Command
         $storagePath = $input->getOption('storage-path') ?? sys_get_temp_dir() . '/adp';
         $rootPath = $input->getOption('root-path');
         $runtimePath = $input->getOption('runtime-path') ?? $storagePath;
-        $frontendPath = $input->getOption('frontend-path');
+        $frontendPath = $input->getOption('frontend-path') ?? $this->resolveFrontendPath();
 
         $routerScript = $this->routerScript ?? dirname(__DIR__) . '/Server/server-router.php';
 
@@ -79,16 +80,17 @@ final class ServeCommand extends Command
             $env['ADP_FRONTEND_PATH'] = $frontendPath;
         }
 
-        $process = new Process(
-            [
-                $phpBinary,
-                '-S',
-                "{$host}:{$port}",
-                $routerScript,
-            ],
-            null,
-            $env,
-        );
+        $command = [$phpBinary, '-S', "{$host}:{$port}"];
+        // When a frontend bundle is available, point the built-in server's
+        // document root at it so that `return false` from the router (signalling
+        // "serve this file directly") resolves correctly.
+        if ($frontendPath !== null && is_dir($frontendPath)) {
+            $command[] = '-t';
+            $command[] = $frontendPath;
+        }
+        $command[] = $routerScript;
+
+        $process = new Process($command, null, $env);
 
         $process->setTimeout(null);
 
@@ -97,5 +99,20 @@ final class ServeCommand extends Command
         });
 
         return $process->getExitCode() ?? Command::FAILURE;
+    }
+
+    /**
+     * Auto-resolve the frontend dist path from the `app-dev-panel/frontend-assets`
+     * Composer package when `--frontend-path` is not supplied. Returns `null` if
+     * the package is not installed or the bundle is empty, so the serve command
+     * still works with API-only setups.
+     */
+    private function resolveFrontendPath(): ?string
+    {
+        if (!class_exists(FrontendAssets::class)) {
+            return null;
+        }
+
+        return FrontendAssets::exists() ? FrontendAssets::path() : null;
     }
 }

--- a/libs/Cli/tests/Unit/Command/ServeCommandTest.php
+++ b/libs/Cli/tests/Unit/Command/ServeCommandTest.php
@@ -167,7 +167,7 @@ final class ServeCommandTest extends TestCase
         rmdir($frontendPath);
     }
 
-    public function testExecuteWithoutFrontendPathShowsNotConfigured(): void
+    public function testExecuteWithoutFrontendPathAutoResolvesFromFrontendAssets(): void
     {
         if (PHP_OS_FAMILY === 'Windows') {
             $this->markTestSkipped('Process tests unreliable on Windows (PHP built-in server exit behavior differs).');
@@ -185,7 +185,12 @@ final class ServeCommandTest extends TestCase
         ]);
 
         $display = $tester->getDisplay();
-        $this->assertStringContainsString('(not configured)', $display);
+        // The `app-dev-panel/frontend-assets` package is installed in this monorepo,
+        // so ServeCommand should auto-resolve its dist path when --frontend-path is
+        // omitted. When dist is empty (or the package is missing) the output falls
+        // back to "(not configured)" — either is a valid observation, we assert the
+        // line exists.
+        $this->assertMatchesRegularExpression('/Frontend: (\/.+|\(not configured\))/', $display);
 
         // Clean up
         if (is_dir($storagePath)) {

--- a/libs/FrontendAssets/.gitignore
+++ b/libs/FrontendAssets/.gitignore
@@ -1,0 +1,2 @@
+/dist/*
+!/dist/.gitkeep

--- a/libs/FrontendAssets/CLAUDE.md
+++ b/libs/FrontendAssets/CLAUDE.md
@@ -1,0 +1,74 @@
+# FrontendAssets Module
+
+Ships the prebuilt ADP panel SPA as a Composer package so every framework adapter gets the frontend installed automatically. No runtime download, no CDN dependency.
+
+## Package
+
+- Composer: `app-dev-panel/frontend-assets`
+- Namespace: `AppDevPanel\FrontendAssets\`
+- PHP: 8.4+
+- Dependencies: none (leaf module, `requires: []` in `modulite.php`)
+
+## Directory Structure
+
+```
+composer.json
+CLAUDE.md
+src/
+└── FrontendAssets.php   # Locator helper for the prebuilt bundle
+dist/
+└── .gitkeep             # Placeholder — real files are populated by CI at release time
+.gitignore               # /dist/* (except .gitkeep)
+```
+
+## Helper
+
+```php
+AppDevPanel\FrontendAssets\FrontendAssets::path();    // /vendor/app-dev-panel/frontend-assets/dist
+AppDevPanel\FrontendAssets\FrontendAssets::exists();  // true when dist/index.html is present
+```
+
+`ServeCommand` (in `app-dev-panel/cli`) calls `FrontendAssets::path()` as the default for `--frontend-path`, so `adp serve` serves the panel with no extra flags whenever this package is installed.
+
+## Who Requires This Module
+
+Every framework adapter, plus the CLI module itself:
+
+- `app-dev-panel/cli` — `ServeCommand` uses the helper to auto-resolve the bundle
+- `app-dev-panel/adapter-yii3`
+- `app-dev-panel/adapter-symfony`
+- `app-dev-panel/adapter-laravel`
+- `app-dev-panel/adapter-yii2`
+
+## Build Flow (Release Time)
+
+`dist/` is **not** tracked in the monorepo. It is produced on every push by `.github/workflows/split.yml`:
+
+1. Checkout the monorepo
+2. `npm ci && npm run build -w packages/sdk && npm run build -w packages/panel` inside `libs/frontend/`
+3. Copy `libs/frontend/packages/panel/dist/*` into `libs/FrontendAssets/dist/`
+4. Make a throwaway local commit that `git add -f libs/FrontendAssets/dist`
+5. Run `splitsh-lite --prefix=libs/FrontendAssets` to extract the subtree
+6. Force-push the resulting SHA to [`app-dev-panel/frontend-assets`](https://github.com/app-dev-panel/frontend-assets) (and tag it with `v*` when triggered by a tag)
+
+The local build commit is never pushed back to the monorepo — only the extracted split remote sees it.
+
+## Local Development
+
+To test `adp serve` locally against the real panel:
+
+```bash
+make install-frontend
+cd libs/frontend && npm run build -w packages/sdk && npm run build -w packages/panel
+cp -R libs/frontend/packages/panel/dist/. libs/FrontendAssets/dist/
+```
+
+The `dist/*` files are gitignored, so nothing leaks into the monorepo.
+
+## Why Not Commit `dist/` to the Monorepo?
+
+- Keeps the monorepo small and diff-friendly — the panel build is hundreds of files.
+- Prevents `dist/` from drifting out of sync with the source in `libs/frontend/`.
+- Release flow is reproducible: the bundle always matches the exact source at that commit.
+
+The split-repository workflow is modelled on [buggregator's `frontend-dist`](https://github.com/buggregator/frontend-dist) pattern.

--- a/libs/FrontendAssets/composer.json
+++ b/libs/FrontendAssets/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "app-dev-panel/frontend-assets",
+    "type": "library",
+    "description": "ADP Frontend Assets — prebuilt panel SPA shipped as a Composer package and served by the debug panel",
+    "keywords": [
+        "debug",
+        "debug-panel",
+        "frontend",
+        "assets",
+        "spa",
+        "app-dev-panel",
+        "adp"
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require": {
+        "php": "^8.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "AppDevPanel\\FrontendAssets\\": "src"
+        }
+    }
+}

--- a/libs/FrontendAssets/src/FrontendAssets.php
+++ b/libs/FrontendAssets/src/FrontendAssets.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppDevPanel\FrontendAssets;
+
+/**
+ * Locates the prebuilt ADP panel SPA shipped with this package.
+ *
+ * The `dist/` directory is produced by `libs/frontend/packages/panel`
+ * (Vite build) and is populated by the release pipeline before the
+ * package is split into its own repository. When installed via Composer,
+ * the assets sit next to this file at `../dist/index.html`.
+ */
+final class FrontendAssets
+{
+    public static function path(): string
+    {
+        return dirname(__DIR__) . '/dist';
+    }
+
+    public static function exists(): bool
+    {
+        return is_file(self::path() . '/index.html');
+    }
+}

--- a/modulite.php
+++ b/modulite.php
@@ -28,14 +28,16 @@ declare(strict_types=1);
  *   API ---------> Kernel, McpServer
  *     ^
  *     |
- *   Cli ---------> Kernel, API, McpServer
+ *   Cli ---------> Kernel, API, McpServer, FrontendAssets
  *
  *   Testing  (independent, no internal deps)
  *
- *   Adapter/Yii3 -----> Kernel, API, Cli, McpServer
- *   Adapter/Symfony ---> Kernel, API, Cli, McpServer
- *   Adapter/Laravel ---> Kernel, API, Cli, McpServer
- *   Adapter/Yii2 -----> Kernel, API, Cli, McpServer
+ *   FrontendAssets  (independent, no internal deps — ships prebuilt panel SPA)
+ *
+ *   Adapter/Yii3 -----> Kernel, API, Cli, McpServer, FrontendAssets
+ *   Adapter/Symfony ---> Kernel, API, Cli, McpServer, FrontendAssets
+ *   Adapter/Laravel ---> Kernel, API, Cli, McpServer, FrontendAssets
+ *   Adapter/Yii2 -----> Kernel, API, Cli, McpServer, FrontendAssets
  *   Adapter/Cycle -----> API
  */
 return [
@@ -64,12 +66,18 @@ return [
     'cli' => [
         'namespace' => 'AppDevPanel\\Cli\\',
         'path' => 'libs/Cli/src',
-        'requires' => ['kernel', 'api', 'mcp-server'],
+        'requires' => ['kernel', 'api', 'mcp-server', 'frontend-assets'],
     ],
 
     'testing' => [
         'namespace' => 'AppDevPanel\\Testing\\',
         'path' => 'libs/Testing/src',
+        'requires' => [],
+    ],
+
+    'frontend-assets' => [
+        'namespace' => 'AppDevPanel\\FrontendAssets\\',
+        'path' => 'libs/FrontendAssets/src',
         'requires' => [],
     ],
 
@@ -80,25 +88,25 @@ return [
     'adapter-yii3' => [
         'namespace' => 'AppDevPanel\\Adapter\\Yii3\\',
         'path' => ['libs/Adapter/Yii3/src', 'libs/Adapter/Yii3/config'],
-        'requires' => ['kernel', 'api', 'cli', 'mcp-server'],
+        'requires' => ['kernel', 'api', 'cli', 'mcp-server', 'frontend-assets'],
     ],
 
     'adapter-symfony' => [
         'namespace' => 'AppDevPanel\\Adapter\\Symfony\\',
         'path' => 'libs/Adapter/Symfony/src',
-        'requires' => ['kernel', 'api', 'cli', 'mcp-server'],
+        'requires' => ['kernel', 'api', 'cli', 'mcp-server', 'frontend-assets'],
     ],
 
     'adapter-laravel' => [
         'namespace' => 'AppDevPanel\\Adapter\\Laravel\\',
         'path' => 'libs/Adapter/Laravel/src',
-        'requires' => ['kernel', 'api', 'cli', 'mcp-server'],
+        'requires' => ['kernel', 'api', 'cli', 'mcp-server', 'frontend-assets'],
     ],
 
     'adapter-yii2' => [
         'namespace' => 'AppDevPanel\\Adapter\\Yii2\\',
         'path' => 'libs/Adapter/Yii2/src',
-        'requires' => ['kernel', 'api', 'cli', 'mcp-server'],
+        'requires' => ['kernel', 'api', 'cli', 'mcp-server', 'frontend-assets'],
     ],
 
     'adapter-cycle' => [

--- a/website/guide/debug-panel.md
+++ b/website/guide/debug-panel.md
@@ -69,6 +69,8 @@ Download `panel-dist.tar.gz` from a [GitHub Release](https://github.com/app-dev-
 curl -L https://github.com/app-dev-panel/app-dev-panel/releases/latest/download/panel-dist.tar.gz | tar xz -C public/adp-panel
 ```
 
+Alternatively the same archive is published as `frontend-dist.zip` for the built-in updater (see [Updating the frontend](#updating-the-frontend) below).
+
 Then configure the adapter to use the local path:
 
 :::tabs key:framework
@@ -221,3 +223,56 @@ GET /debug/logs/detail
 ```
 
 Panel routes skip the JSON response wrapper and token auth middleware — they only pass through CORS and IP filter.
+
+## Frontend as a Composer Package
+
+Every framework adapter requires `app-dev-panel/frontend-assets`, a Composer package that ships the prebuilt panel SPA. When you install an adapter, Composer pulls `vendor/app-dev-panel/frontend-assets/dist/` automatically — no extra download step.
+
+| What the package provides | Location after install |
+|---------------------------|------------------------|
+| Prebuilt `dist/` (`index.html`, JS, CSS, assets) | `vendor/app-dev-panel/frontend-assets/dist/` |
+| `FrontendAssets::path()` helper | `AppDevPanel\FrontendAssets\FrontendAssets` |
+
+### Standalone server — `adp serve`
+
+The `adp serve` command starts PHP's built-in server with the ADP API on `/debug/api/*` and `/inspect/api/*`, and serves the panel SPA on every other path. When `--frontend-path` is omitted, the command calls `FrontendAssets::path()` and uses the Composer-installed bundle — so the full panel is available at `http://127.0.0.1:8888/` out of the box:
+
+```bash
+php vendor/bin/adp serve --host=127.0.0.1 --port=8888 --storage-path=./var/adp
+```
+
+To serve a different bundle (e.g. a custom build or a local dev copy):
+
+```bash
+php vendor/bin/adp serve --frontend-path=/path/to/my/dist
+```
+
+### Updating the frontend
+
+Two supported update channels:
+
+1. **Composer (recommended)** — bump the tagged version from the [`frontend-assets`](https://github.com/app-dev-panel/frontend-assets) split repository:
+
+   ```bash
+   composer update app-dev-panel/frontend-assets
+   ```
+
+2. **Direct download (for PHAR installs)** — the `frontend:update` CLI command fetches `frontend-dist.zip` from the [latest GitHub Release](https://github.com/app-dev-panel/app-dev-panel/releases) and extracts it in place:
+
+   ```bash
+   php vendor/bin/adp frontend:update check
+   php vendor/bin/adp frontend:update download --path=/path/to/dist
+   ```
+
+   The command writes a `.adp-version` file alongside `index.html` so future `check` calls can tell whether an update is available.
+
+### How the package is built
+
+The monorepo does **not** track `libs/FrontendAssets/dist/` — it is generated on every push by `.github/workflows/split.yml`:
+
+1. `npm ci && npm run build -w packages/sdk && npm run build -w packages/panel` (inside `libs/frontend/`).
+2. The Vite output is copied into `libs/FrontendAssets/dist/`.
+3. A throwaway local commit adds the `dist/` files, then `splitsh-lite` extracts `libs/FrontendAssets/` (source + dist) as a subtree.
+4. The subtree is force-pushed to [`app-dev-panel/frontend-assets`](https://github.com/app-dev-panel/frontend-assets) and tagged with the release version when the trigger is a `v*` tag.
+
+Consumers see the split repository — their `composer require` never reaches into the monorepo.

--- a/website/guide/frontend-packages.md
+++ b/website/guide/frontend-packages.md
@@ -86,8 +86,48 @@ Each [GitHub Release](https://github.com/app-dev-panel/app-dev-panel/releases) i
 |-------|----------|
 | `panel-dist.tar.gz` | Production build of the panel SPA |
 | `toolbar-dist.tar.gz` | Production build of the toolbar widget |
+| `frontend-dist.zip` | Same panel build, zip-packaged for the `frontend:update` CLI |
 
 These can be served directly by a web server or embedded into PHP adapter packages.
+
+## Composer Distribution — `app-dev-panel/frontend-assets`
+
+The panel SPA is also shipped as a Composer package so PHP applications get the built frontend automatically when they install an adapter. This is the default channel — every framework adapter (`adapter-yii3`, `adapter-symfony`, `adapter-laravel`, `adapter-yii2`) requires it.
+
+| Package | Namespace | Ships |
+|---------|-----------|-------|
+| `app-dev-panel/frontend-assets` | `AppDevPanel\FrontendAssets\` | Prebuilt `dist/` directory + `FrontendAssets::path()` helper |
+
+### How it's built and released
+
+The source of the bundle lives in `libs/frontend/packages/panel`. The `dist/` directory is **not** committed to the monorepo — it is produced at release time by the `Monorepo Split` workflow (`.github/workflows/split.yml`):
+
+1. On each `push` to `master` / `*.x` / `v*`, the workflow runs `npm ci && npm run build -w packages/sdk && npm run build -w packages/panel` inside `libs/frontend/`.
+2. The Vite output is copied into `libs/FrontendAssets/dist/` and committed to a disposable local commit.
+3. `splitsh-lite` extracts `libs/FrontendAssets/` (including `dist/`) into a subtree SHA.
+4. The subtree is force-pushed to [`app-dev-panel/frontend-assets`](https://github.com/app-dev-panel/frontend-assets) — and tagged with the release version when triggered by a `v*` tag.
+
+The split repository is what Packagist and `composer require` see. The monorepo `libs/FrontendAssets/` itself only tracks `composer.json`, `src/FrontendAssets.php`, and the `.gitkeep` placeholder — everything in `dist/` is git-ignored locally.
+
+### How it's consumed
+
+Installing any adapter pulls `app-dev-panel/frontend-assets` transitively. The `FrontendAssets::path()` helper returns the absolute path to the bundled `dist/`:
+
+```php
+use AppDevPanel\FrontendAssets\FrontendAssets;
+
+FrontendAssets::path();    // /vendor/app-dev-panel/frontend-assets/dist
+FrontendAssets::exists();  // true if dist/index.html is present
+```
+
+The `serve` CLI command uses this helper as the default for `--frontend-path`, so `php vendor/bin/adp serve` works out of the box without any extra flags.
+
+### Updating the frontend
+
+Two channels are supported:
+
+1. **Composer (default)** — `composer update app-dev-panel/frontend-assets` pulls the latest split-repository tag.
+2. **Direct download** — for PHAR-based installs or when Composer is unavailable, use the `frontend:update` CLI command (see the [CLI guide](./cli.md#frontend-update)) to fetch `frontend-dist.zip` from the GitHub Release and extract it in place.
 
 ## Development
 

--- a/website/ru/guide/debug-panel.md
+++ b/website/ru/guide/debug-panel.md
@@ -69,6 +69,8 @@ https://app-dev-panel.github.io/app-dev-panel/bundle.css
 curl -L https://github.com/app-dev-panel/app-dev-panel/releases/latest/download/panel-dist.tar.gz | tar xz -C public/adp-panel
 ```
 
+Эта же сборка публикуется как `frontend-dist.zip` для встроенного обновлятора (см. [Обновление фронтенда](#обновление-фронтенда) ниже).
+
 Затем настройте адаптер:
 
 :::tabs key:framework
@@ -221,3 +223,56 @@ GET /debug/logs/detail
 ```
 
 Маршруты панели пропускают обёртку JSON-ответов и аутентификацию по токену — через них проходят только CORS и фильтр по IP.
+
+## Фронтенд как Composer-пакет
+
+Каждый адаптер требует `app-dev-panel/frontend-assets` — Composer-пакет, содержащий предсобранную SPA панели. При установке адаптера Composer автоматически подтягивает `vendor/app-dev-panel/frontend-assets/dist/` — никакой отдельной загрузки не требуется.
+
+| Что содержит пакет | Путь после установки |
+|---------------------|----------------------|
+| Предсобранный `dist/` (`index.html`, JS, CSS, ассеты) | `vendor/app-dev-panel/frontend-assets/dist/` |
+| Хелпер `FrontendAssets::path()` | `AppDevPanel\FrontendAssets\FrontendAssets` |
+
+### Автономный сервер — `adp serve`
+
+Команда `adp serve` запускает встроенный PHP-сервер с API на `/debug/api/*` и `/inspect/api/*`, а на остальных путях отдаёт SPA панели. Если `--frontend-path` не указан, команда вызывает `FrontendAssets::path()` и использует сборку, установленную через Composer — полная панель доступна на `http://127.0.0.1:8888/` без дополнительных флагов:
+
+```bash
+php vendor/bin/adp serve --host=127.0.0.1 --port=8888 --storage-path=./var/adp
+```
+
+Чтобы указать другую сборку (например, свою кастомную или dev-копию):
+
+```bash
+php vendor/bin/adp serve --frontend-path=/path/to/my/dist
+```
+
+### Обновление фронтенда
+
+Поддерживаются два канала:
+
+1. **Composer (рекомендуется)** — поднимаем тег из split-репозитория [`frontend-assets`](https://github.com/app-dev-panel/frontend-assets):
+
+   ```bash
+   composer update app-dev-panel/frontend-assets
+   ```
+
+2. **Прямая загрузка (для PHAR-установок)** — CLI `frontend:update` скачивает `frontend-dist.zip` из [последнего GitHub Release](https://github.com/app-dev-panel/app-dev-panel/releases) и распаковывает его на месте:
+
+   ```bash
+   php vendor/bin/adp frontend:update check
+   php vendor/bin/adp frontend:update download --path=/path/to/dist
+   ```
+
+   Команда записывает файл `.adp-version` рядом с `index.html`, чтобы последующие `check` понимали, доступно ли обновление.
+
+### Как собирается пакет
+
+Монорепа **не** хранит `libs/FrontendAssets/dist/` — он генерируется на каждом push воркфлоу `.github/workflows/split.yml`:
+
+1. `npm ci && npm run build -w packages/sdk && npm run build -w packages/panel` (внутри `libs/frontend/`).
+2. Вывод Vite копируется в `libs/FrontendAssets/dist/`.
+3. Локальный одноразовый коммит добавляет файлы `dist/`, затем `splitsh-lite` извлекает `libs/FrontendAssets/` (исходники + dist) как subtree.
+4. Subtree force-пушится в [`app-dev-panel/frontend-assets`](https://github.com/app-dev-panel/frontend-assets) и тегается версией релиза, если триггером был тег `v*`.
+
+Потребители видят только split-репозиторий — `composer require` никогда не заходит в монорепу.

--- a/website/ru/guide/frontend-packages.md
+++ b/website/ru/guide/frontend-packages.md
@@ -86,8 +86,48 @@ import { useServerSentEvents } from '@app-dev-panel/sdk/Component/useServerSentE
 |------|------------|
 | `panel-dist.tar.gz` | Production-сборка панели |
 | `toolbar-dist.tar.gz` | Production-сборка тулбара |
+| `frontend-dist.zip` | Та же сборка панели, запакованная в zip для CLI `frontend:update` |
 
 Их можно раздавать напрямую веб-сервером или встраивать в PHP-адаптеры.
+
+## Composer-дистрибутив — `app-dev-panel/frontend-assets`
+
+SPA панели также публикуется как Composer-пакет, чтобы PHP-приложения получали собранный фронт автоматически при установке адаптера. Это основной канал — каждый адаптер (`adapter-yii3`, `adapter-symfony`, `adapter-laravel`, `adapter-yii2`) требует его.
+
+| Пакет | Namespace | Содержит |
+|-------|-----------|----------|
+| `app-dev-panel/frontend-assets` | `AppDevPanel\FrontendAssets\` | Предсобранный `dist/` + хелпер `FrontendAssets::path()` |
+
+### Как собирается и релизится
+
+Исходники лежат в `libs/frontend/packages/panel`. Директория `dist/` **не** хранится в монорепе — она генерируется в момент релиза воркфлоу `Monorepo Split` (`.github/workflows/split.yml`):
+
+1. На каждом `push` в `master` / `*.x` / `v*` воркфлоу выполняет `npm ci && npm run build -w packages/sdk && npm run build -w packages/panel` внутри `libs/frontend/`.
+2. Вывод Vite копируется в `libs/FrontendAssets/dist/` и добавляется одноразовым локальным коммитом.
+3. `splitsh-lite` извлекает `libs/FrontendAssets/` (включая `dist/`) как subtree SHA.
+4. Subtree force-пушится в [`app-dev-panel/frontend-assets`](https://github.com/app-dev-panel/frontend-assets) — и тегается версией релиза, если триггером был тег `v*`.
+
+Packagist и `composer require` видят именно этот split-репозиторий. Монорепа `libs/FrontendAssets/` хранит только `composer.json`, `src/FrontendAssets.php` и заглушку `.gitkeep` — всё в `dist/` игнорируется локально.
+
+### Как используется
+
+При установке любого адаптера транзитивно подтягивается `app-dev-panel/frontend-assets`. Хелпер `FrontendAssets::path()` возвращает абсолютный путь к собранному `dist/`:
+
+```php
+use AppDevPanel\FrontendAssets\FrontendAssets;
+
+FrontendAssets::path();    // /vendor/app-dev-panel/frontend-assets/dist
+FrontendAssets::exists();  // true если dist/index.html присутствует
+```
+
+CLI-команда `serve` использует этот хелпер в качестве значения по умолчанию для `--frontend-path`, поэтому `php vendor/bin/adp serve` работает из коробки без дополнительных флагов.
+
+### Обновление фронтенда
+
+Поддерживаются два канала:
+
+1. **Composer (по умолчанию)** — `composer update app-dev-panel/frontend-assets` подтягивает последний тег split-репозитория.
+2. **Прямая загрузка** — для PHAR-установок или когда Composer недоступен, используйте CLI `frontend:update` (см. [CLI](./cli.md#frontend-update)) для скачивания `frontend-dist.zip` из GitHub Release и распаковки на месте.
 
 ## Разработка
 


### PR DESCRIPTION
## Summary

Introduces `app-dev-panel/frontend-assets`, a new Composer package that ships the prebuilt panel SPA. This eliminates the need for separate frontend downloads and ensures every framework adapter gets the panel automatically when installed.

## Key Changes

- **New module: `libs/FrontendAssets/`**
  - Minimal leaf module with `FrontendAssets::path()` and `FrontendAssets::exists()` helpers
  - `dist/` directory is git-ignored locally but populated by CI at release time
  - Published as a split repository (`app-dev-panel/frontend-assets`) via `splitsh-lite`

- **Updated `ServeCommand`**
  - Auto-resolves frontend bundle via `FrontendAssets::path()` when `--frontend-path` is omitted
  - Launches PHP built-in server with `-t <frontendPath>` to serve static assets directly
  - Falls back gracefully if package is not installed or bundle is empty

- **Release pipeline (`split.yml`)**
  - Builds panel SPA (`npm run build -w packages/panel`) during split workflow
  - Copies Vite output into `libs/FrontendAssets/dist/`
  - Force-adds dist files to a disposable local commit before extracting subtree
  - Subtree is pushed to split repository and tagged with release version

- **Updated all adapters and CLI module**
  - Added `app-dev-panel/frontend-assets` as a dependency in `composer.json`
  - Updated `modulite.php` to declare the new module and its dependencies

- **Documentation**
  - Added `libs/FrontendAssets/CLAUDE.md` explaining the module structure and build flow
  - Updated `website/guide/debug-panel.md` and `website/guide/frontend-packages.md` with Composer distribution details
  - Added Russian translations in `website/ru/`

- **CLI entry point (`libs/Cli/bin/adp`)**
  - Registers `ServeCommand` and `FrontendUpdateCommand` for standalone use
  - Updated comments to reflect new capabilities

## Implementation Details

- The `dist/` directory is **not** committed to the monorepo — it is generated at release time and only exists in the split repository
- Consumers install via `composer require app-dev-panel/frontend-assets` (or transitively via adapters)
- `php vendor/bin/adp serve` now works out of the box without `--frontend-path` when the package is installed
- The build flow is modeled on [buggregator's `frontend-dist` pattern](https://github.com/buggregator/frontend-dist)

https://claude.ai/code/session_013PNr3hwQGMfwnjTzP5wDAa