### PR TITLE
Improve mobile responsiveness across sidebar and entry components

### DIFF
--- a/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
+++ b/libs/frontend/packages/panel/src/Application/Component/Layout.tsx
@@ -681,9 +681,10 @@ export const Layout = React.memo(({children}: React.PropsWithChildren) => {
                         open={ui.mobileMenuOpen}
                         onClose={handleMenuClose}
                         ModalProps={{keepMounted: true}}
-                        sx={{'& .MuiDrawer-paper': {width: 240, pt: 1}}}
+                        sx={{'& .MuiDrawer-paper': {width: 'min(82vw, 320px)', borderRight: 'none'}}}
                     >
                         <UnifiedSidebar
+                            variant="plain"
                             sections={sidebarSections}
                             activePath={location.pathname}
                             activeChildKey={activeChildKey}

--- a/libs/frontend/packages/sdk/src/Component/Layout/EntrySelector.tsx
+++ b/libs/frontend/packages/sdk/src/Component/Layout/EntrySelector.tsx
@@ -12,7 +12,7 @@ import {formatBytes} from '@app-dev-panel/sdk/Helper/formatBytes';
 import {formatDate} from '@app-dev-panel/sdk/Helper/formatDate';
 import {fuzzyMatch, type FuzzyMatch} from '@app-dev-panel/sdk/Helper/fuzzyMatch';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';
-import {Box, Chip, Icon, Popover, type Theme, Typography} from '@mui/material';
+import {Box, Chip, Icon, Popover, type Theme, Typography, useMediaQuery} from '@mui/material';
 import {styled, useTheme} from '@mui/material/styles';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
@@ -112,6 +112,7 @@ const EntryRow = styled(Box, {shouldForwardProp: (p) => p !== 'active' && p !== 
     fontSize: '13px',
     backgroundColor: highlighted ? theme.palette.action.selected : active ? theme.palette.primary.light : 'transparent',
     '&:hover': {backgroundColor: theme.palette.action.hover},
+    [theme.breakpoints.down('sm')]: {gap: theme.spacing(0.75), padding: theme.spacing(1, 1.25)},
 }));
 
 const MethodLabel = styled('span')({fontWeight: 600, fontSize: '11px', minWidth: 40});
@@ -131,6 +132,7 @@ const TimeLabel = styled('span')(({theme}) => ({
     color: theme.palette.text.disabled,
     flexShrink: 0,
     whiteSpace: 'nowrap',
+    [theme.breakpoints.down('sm')]: {display: 'none'},
 }));
 
 const statusColor = (status: number, theme: Theme): string => {
@@ -296,6 +298,7 @@ export const EntrySelector = ({
     onAllClick,
 }: EntrySelectorProps) => {
     const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const [filter, setFilter] = useState('');
     const inputRef = useRef<HTMLInputElement>(null);
     const listRef = useRef<HTMLDivElement>(null);
@@ -428,25 +431,42 @@ export const EntrySelector = ({
     return (
         <Popover
             open={open}
-            anchorEl={anchorEl}
+            anchorEl={isMobile ? undefined : anchorEl}
+            anchorReference={isMobile ? 'anchorPosition' : 'anchorEl'}
+            anchorPosition={isMobile ? {top: 48, left: 0} : undefined}
             onClose={handleClose}
             anchorOrigin={{vertical: 'bottom', horizontal: 'left'}}
             transformOrigin={{vertical: 'top', horizontal: 'left'}}
+            marginThreshold={isMobile ? 0 : 16}
             slotProps={{
                 paper: {
-                    sx: {
-                        width: anchorEl ? anchorEl.offsetWidth : 520,
-                        minWidth: 420,
-                        maxHeight: 440,
-                        mt: 0.5,
-                        borderRadius: 1.5,
-                        border: 1,
-                        borderColor: 'divider',
-                        boxShadow: '0 8px 32px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.08)',
-                        backdropFilter: 'blur(12px)',
-                        backgroundColor: (t) =>
-                            t.palette.mode === 'dark' ? 'rgba(30, 41, 59, 0.92)' : 'rgba(255, 255, 255, 0.92)',
-                    },
+                    sx: isMobile
+                        ? {
+                              width: '100vw',
+                              maxWidth: '100vw',
+                              maxHeight: 'calc(100vh - 48px)',
+                              borderRadius: 0,
+                              borderTop: 1,
+                              borderColor: 'divider',
+                              borderBottom: 1,
+                              boxShadow: '0 8px 24px rgba(0,0,0,0.18)',
+                              backdropFilter: 'blur(12px)',
+                              backgroundColor: (t) =>
+                                  t.palette.mode === 'dark' ? 'rgba(30, 41, 59, 0.96)' : 'rgba(255, 255, 255, 0.96)',
+                          }
+                        : {
+                              width: anchorEl ? anchorEl.offsetWidth : 520,
+                              minWidth: 420,
+                              maxHeight: 440,
+                              mt: 0.5,
+                              borderRadius: 1.5,
+                              border: 1,
+                              borderColor: 'divider',
+                              boxShadow: '0 8px 32px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.08)',
+                              backdropFilter: 'blur(12px)',
+                              backgroundColor: (t) =>
+                                  t.palette.mode === 'dark' ? 'rgba(30, 41, 59, 0.92)' : 'rgba(255, 255, 255, 0.92)',
+                          },
                 },
             }}
         >
@@ -498,7 +518,7 @@ export const EntrySelector = ({
                 filterState={filterState}
                 onChange={setFilterState}
             />
-            <Box ref={listRef} sx={{overflowY: 'auto', maxHeight: 360}}>
+            <Box ref={listRef} sx={{overflowY: 'auto', maxHeight: isMobile ? 'calc(100vh - 140px)' : 360}}>
                 {matched.length === 0 && <EmptyState icon="search_off" title={`No entries match "${filter}"`} />}
                 {matched.map(({entry, indices}, idx) => {
                     const active = entry.id === currentEntryId;

--- a/libs/frontend/packages/sdk/src/Component/Layout/RequestPill.tsx
+++ b/libs/frontend/packages/sdk/src/Component/Layout/RequestPill.tsx
@@ -23,6 +23,10 @@ const PillRoot = styled('button')(({theme}) => ({
     fontFamily: theme.typography.fontFamily,
     color: theme.palette.text.primary,
     width: '100%',
+    minWidth: 0,
+    overflow: 'hidden',
+    isolation: 'isolate',
+    [theme.breakpoints.down('sm')]: {gap: theme.spacing(0.75), padding: theme.spacing(0.5, 1.25)},
     '&:hover': {borderColor: theme.palette.primary.main},
 }));
 
@@ -52,7 +56,13 @@ const methodColor = (method: string, theme: Theme): string => {
     }
 };
 
-const Separator = styled('span')(({theme}) => ({color: theme.palette.divider, flexShrink: 0}));
+const Divider = styled('span')(({theme}) => ({
+    width: 1,
+    alignSelf: 'stretch',
+    margin: theme.spacing(0.5, 0),
+    backgroundColor: theme.palette.divider,
+    flexShrink: 0,
+}));
 
 const MethodLabel = styled('span')({fontWeight: 600, fontSize: '11px', flexShrink: 0, whiteSpace: 'nowrap'});
 
@@ -65,6 +75,7 @@ const PathLabel = styled('span')(({theme}) => ({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     textAlign: 'left',
+    [theme.breakpoints.down('sm')]: {display: 'none'},
 }));
 
 const StatusLabel = styled('span')({fontWeight: 500, fontSize: '12px', flexShrink: 0, whiteSpace: 'nowrap'});
@@ -76,6 +87,13 @@ const DurationLabel = styled('span')(({theme}) => ({
     whiteSpace: 'nowrap',
 }));
 
+const ChevronIcon = styled(Icon)(({theme}) => ({
+    fontSize: 16,
+    color: theme.palette.text.disabled,
+    flexShrink: 0,
+    marginLeft: 'auto',
+}));
+
 export const RequestPill = React.memo(({method, path, status, duration, onClick}: RequestPillProps) => {
     const theme = useTheme();
     const isCli = method.toUpperCase() === 'CLI';
@@ -85,11 +103,11 @@ export const RequestPill = React.memo(({method, path, status, duration, onClick}
             {isCli && <Icon sx={{fontSize: 14, color: 'info.main', flexShrink: 0}}>terminal</Icon>}
             <MethodLabel sx={{color: methodColor(method, theme)}}>{method}</MethodLabel>
             <PathLabel>{path}</PathLabel>
-            <Separator>&mdash;</Separator>
+            <Divider />
             <StatusLabel sx={{color: statusColor(status, isCli, theme)}}>{statusLabel}</StatusLabel>
-            <Separator>&mdash;</Separator>
+            <Divider />
             <DurationLabel>{duration}</DurationLabel>
-            <Icon sx={{fontSize: 16, color: 'text.disabled'}}>expand_more</Icon>
+            <ChevronIcon>expand_more</ChevronIcon>
         </PillRoot>
     );
 });

--- a/libs/frontend/packages/sdk/src/Component/Layout/UnifiedSidebar.tsx
+++ b/libs/frontend/packages/sdk/src/Component/Layout/UnifiedSidebar.tsx
@@ -20,28 +20,37 @@ type NavChild = {
 
 type NavSection = {key: string; icon: string; label: string; href: string; children?: NavChild[]};
 
+type UnifiedSidebarVariant = 'card' | 'plain';
+
 type UnifiedSidebarProps = {
     sections: NavSection[];
     activePath: string;
     activeChildKey?: string;
     onNavigate: (href: string) => void;
     onChildClick?: (sectionKey: string, childKey: string) => void;
+    /**
+     * `card` (default) — bordered Paper with rounded corners; for the desktop sidebar slot.
+     * `plain` — flat, full-width, no border, no radius; for use inside a mobile Drawer where
+     * the Drawer itself already provides the surface.
+     */
+    variant?: UnifiedSidebarVariant;
 };
 
 // ---------------------------------------------------------------------------
 // Styled components
 // ---------------------------------------------------------------------------
 
-const SidebarRoot = styled(Paper)(({theme}) => ({
-    width: componentTokens.sidebar.width,
-    borderRadius: componentTokens.sidebar.borderRadius,
+const SidebarRoot = styled(Paper, {shouldForwardProp: (p) => p !== 'plain'})<{plain?: boolean}>(({theme, plain}) => ({
+    width: plain ? '100%' : componentTokens.sidebar.width,
+    borderRadius: plain ? 0 : componentTokens.sidebar.borderRadius,
     display: 'flex',
     flexDirection: 'column',
-    padding: theme.spacing(1.5, 1),
+    padding: plain ? theme.spacing(1, 0.75) : theme.spacing(1.5, 1),
     gap: theme.spacing(0.25),
     flexShrink: 0,
-    height: 'min-content',
+    height: plain ? '100%' : 'min-content',
     overflowY: 'auto',
+    ...(plain && {border: 'none', boxShadow: 'none', backgroundColor: 'transparent'}),
 }));
 
 const ChildList = styled('div')(({theme}) => ({
@@ -201,7 +210,7 @@ const SidebarSection = React.memo(
 // ---------------------------------------------------------------------------
 
 export const UnifiedSidebar = React.memo(
-    ({sections, activePath, activeChildKey, onNavigate, onChildClick}: UnifiedSidebarProps) => {
+    ({sections, activePath, activeChildKey, onNavigate, onChildClick, variant = 'card'}: UnifiedSidebarProps) => {
         const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
         const prevPathRef = useRef(activePath);
 
@@ -240,8 +249,10 @@ export const UnifiedSidebar = React.memo(
             [sections, activePath],
         );
 
+        const plain = variant === 'plain';
+
         return (
-            <SidebarRoot variant="outlined">
+            <SidebarRoot variant={plain ? 'elevation' : 'outlined'} elevation={0} plain={plain}>
                 {sections.map((section, idx) => {
                     const isSectionMatch =
                         section.href === '/' ? activePath === '/' : activePath.startsWith(section.href);


### PR DESCRIPTION
## Summary
This PR enhances mobile responsiveness across multiple layout components by adding responsive styling, adjusting popover behavior for small screens, and introducing a new `variant` prop to the UnifiedSidebar component for flexible styling contexts.

## Key Changes

**EntrySelector.tsx**
- Added `useMediaQuery` hook to detect mobile breakpoints
- Implemented responsive styling for `EntryRow` (reduced gap and padding on mobile)
- Hidden `TimeLabel` on small screens via `display: 'none'`
- Modified Popover behavior for mobile:
  - Uses `anchorPosition` instead of `anchorEl` on mobile
  - Full viewport width (`100vw`) on mobile vs. fixed width on desktop
  - Adjusted max-height to `calc(100vh - 48px)` on mobile
  - Increased backdrop filter opacity and adjusted shadows for mobile
  - Set `marginThreshold` to 0 on mobile to allow edge-to-edge display
- Responsive list height: `calc(100vh - 140px)` on mobile vs. `360px` on desktop

**RequestPill.tsx**
- Added `minWidth: 0`, `overflow: 'hidden'`, and `isolation: 'isolate'` to `PillRoot` for proper text truncation
- Responsive padding and gap on small screens
- Replaced text separators (`&mdash;`) with styled `Divider` component (vertical line)
- Created new `ChevronIcon` styled component with proper spacing and styling
- Hidden `PathLabel` on small screens

**UnifiedSidebar.tsx**
- Added `variant` prop (`'card' | 'plain'`) to support different styling contexts
- `'card'` variant: bordered Paper with rounded corners (desktop sidebar)
- `'plain'` variant: flat, full-width, no border/radius (for mobile Drawer)
- Updated `SidebarRoot` styling to conditionally apply borders, shadows, and dimensions based on variant
- Adjusted padding based on variant

**Layout.tsx**
- Updated mobile Drawer width to `min(82vw, 320px)` for responsive sizing
- Removed right border from Drawer paper
- Applied `variant="plain"` to UnifiedSidebar within mobile Drawer

## Implementation Details
- Mobile detection uses Material-UI's `useMediaQuery` with theme breakpoints
- Responsive styling maintains visual hierarchy while optimizing for small screens
- Popover positioning uses absolute positioning on mobile to avoid viewport constraints
- Component variants provide flexibility for reusing components in different contexts

https://claude.ai/code/session_01APuktfAEhzeszeYLTiqNDJ