### PR TITLE
Add empty state UI for translations page when no translations exist

### DIFF
--- a/libs/frontend/packages/panel/src/Module/Inspector/Pages/TranslationsPage.tsx
+++ b/libs/frontend/packages/panel/src/Module/Inspector/Pages/TranslationsPage.tsx
@@ -3,17 +3,20 @@ import {
     TranslationUpdaterContext,
     TranslationUpdaterContextProvider,
 } from '@app-dev-panel/panel/Module/Inspector/Context/TranslationUpdaterContext';
+import {DuckIcon} from '@app-dev-panel/sdk/Component/DuckIcon';
+import {EmptyState} from '@app-dev-panel/sdk/Component/EmptyState';
 import {FilterInput} from '@app-dev-panel/sdk/Component/FilterInput';
 import {FullScreenCircularProgress} from '@app-dev-panel/sdk/Component/FullScreenCircularProgress';
 import {DataTable} from '@app-dev-panel/sdk/Component/Grid';
 import {JsonRenderer} from '@app-dev-panel/sdk/Component/JsonRenderer';
 import {PageHeader} from '@app-dev-panel/sdk/Component/PageHeader';
-import {QueryErrorState} from '@app-dev-panel/sdk/Component/QueryErrorState';
 import {PageToolbar} from '@app-dev-panel/sdk/Component/PageToolbar';
+import {QueryErrorState} from '@app-dev-panel/sdk/Component/QueryErrorState';
 import {searchVariants} from '@app-dev-panel/sdk/Helper/layoutTranslit';
 import {regexpQuote} from '@app-dev-panel/sdk/Helper/regexpQuote';
+import {Typography} from '@mui/material';
 import {GridColDef, GridRenderCellParams, GridValidRowModel} from '@mui/x-data-grid';
-import {useCallback, useContext, useMemo} from 'react';
+import {memo, useCallback, useContext, useMemo} from 'react';
 import {useSearchParams} from 'react-router';
 
 const TempComponent = (params: GridRenderCellParams) => {
@@ -28,6 +31,21 @@ const TempComponent = (params: GridRenderCellParams) => {
         />
     );
 };
+const NoTranslations = memo(() => (
+    <EmptyState
+        icon={<DuckIcon />}
+        iconSize={150}
+        title="No translations yet"
+        description={
+            <Typography variant="inherit">
+                Translation messages registered through your application&apos;s i18n configuration will appear here.
+                Edit values inline once your app provides them.
+            </Typography>
+        }
+        fillHeight
+    />
+));
+
 const columns: GridColDef[] = [
     {
         field: '0',
@@ -87,6 +105,10 @@ export const TranslationsPage = () => {
                 />
             </>
         );
+    }
+
+    if (rows.length === 0) {
+        return <NoTranslations />;
     }
 
     return (


### PR DESCRIPTION
## Summary
Added an empty state component to the Translations page that displays when no translations are available, improving the user experience by providing helpful guidance.

## Key Changes
- Created a new `NoTranslations` memoized component that displays an empty state with a duck icon, title, and descriptive message
- Added conditional rendering to show the empty state when the translations list is empty (`rows.length === 0`)
- Imported required UI components: `DuckIcon`, `EmptyState`, and `Typography` from Material-UI
- Reorganized imports for consistency (alphabetical ordering of some imports)
- Added `memo` to React imports for component memoization

## Implementation Details
- The `NoTranslations` component uses the `EmptyState` component with:
  - A duck icon (150px size) as the visual indicator
  - Title: "No translations yet"
  - Descriptive text explaining that translations will appear once registered through the app's i18n configuration
  - `fillHeight` prop to ensure proper layout spacing
- The empty state check is placed after the loading and error states, ensuring proper state precedence

https://claude.ai/code/session_017LAFRHsnsJD9MF9zE1cRKH