### PR TITLE
Fix git tag version parsing in npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -115,7 +115,7 @@ jobs:
           path: libs/frontend/
 
       - name: Set package versions from git tag
-        run: npx lerna version "$GITHUB_REF_NAME" --no-git-tag-version --no-push --yes
+        run: npx lerna version "${GITHUB_REF_NAME#v}" --no-git-tag-version --no-push --yes
 
       - name: Clean up build artifacts from working tree
         run: rm -f panel-dist.tar.gz toolbar-dist.tar.gz frontend-dist.zip


### PR DESCRIPTION
## Summary
Updated the npm publish workflow to properly strip the 'v' prefix from git tags before passing the version to lerna.

## Key Changes
- Modified the `Set package versions from git tag` step to use bash parameter expansion `${GITHUB_REF_NAME#v}` instead of directly using `$GITHUB_REF_NAME`
- This ensures that git tags in the format `v1.2.3` are converted to `1.2.3` before being passed to lerna, which expects semantic version strings without the 'v' prefix

## Implementation Details
The change uses bash's parameter expansion syntax `${variable#pattern}` to remove the leading 'v' character from the git tag reference name. This is a common convention where git tags are prefixed with 'v' (e.g., `v1.0.0`), but npm package versions should not include this prefix.

https://claude.ai/code/session_01RynMKzMBiei4VbVm38rYQw